### PR TITLE
fix(serve): use configured OAuth provider in dashboard login (swamp-club#1893)

### DIFF
--- a/packages/dashboard/src/client/SwampProvider.tsx
+++ b/packages/dashboard/src/client/SwampProvider.tsx
@@ -36,6 +36,7 @@ interface SwampContextValue {
   connected: boolean;
   token: string | null;
   authMode: AuthInfo["mode"] | null;
+  verificationBaseUri: string | null;
   login: (token: string) => void;
   logout: () => void;
   request: <T = Record<string, unknown>>(
@@ -59,6 +60,9 @@ export function SwampProvider({ children }: { children: ReactNode }) {
     () => sessionStorage.getItem(TOKEN_KEY),
   );
   const [authMode, setAuthMode] = useState<AuthInfo["mode"] | null>(null);
+  const [verificationBaseUri, setVerificationBaseUri] = useState<string | null>(
+    null,
+  );
   const socketRef = useRef<WebSocket | null>(null);
   const pendingRef = useRef<
     Map<
@@ -73,7 +77,10 @@ export function SwampProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     fetch("/auth/info")
       .then((r) => r.json())
-      .then((info: AuthInfo) => setAuthMode(info.mode))
+      .then((info: AuthInfo) => {
+        setAuthMode(info.mode);
+        setVerificationBaseUri(info.verificationBaseUri ?? null);
+      })
       .catch(() => setAuthMode("none"));
   }, []);
 
@@ -184,7 +191,15 @@ export function SwampProvider({ children }: { children: ReactNode }) {
 
   return (
     <SwampContext.Provider
-      value={{ connected, token, authMode, login, logout, request }}
+      value={{
+        connected,
+        token,
+        authMode,
+        verificationBaseUri,
+        login,
+        logout,
+        request,
+      }}
     >
       {children}
     </SwampContext.Provider>

--- a/packages/dashboard/src/views/Login.tsx
+++ b/packages/dashboard/src/views/Login.tsx
@@ -21,11 +21,25 @@ import { useCallback, useEffect, useState } from "react";
 import { useSwamp } from "../client/SwampProvider";
 import { Logo } from "../components/Logo";
 
+function providerHost(verificationBaseUri: string | null): string {
+  if (!verificationBaseUri) return "swamp-club.com";
+  try {
+    return new URL(verificationBaseUri).hostname;
+  } catch {
+    return "swamp-club.com";
+  }
+}
+
 export function Login() {
-  const { authMode, login } = useSwamp();
+  const { authMode, verificationBaseUri, login } = useSwamp();
 
   if (authMode === "oauth") {
-    return <OAuthLogin onToken={login} />;
+    return (
+      <OAuthLogin
+        onToken={login}
+        providerHost={providerHost(verificationBaseUri)}
+      />
+    );
   }
 
   return <TokenLogin onToken={login} />;
@@ -112,7 +126,12 @@ interface DeviceGrant {
 
 type OAuthState = "idle" | "starting" | "waiting" | "error";
 
-function OAuthLogin({ onToken }: { onToken: (t: string) => void }) {
+function OAuthLogin(
+  { onToken, providerHost }: {
+    onToken: (t: string) => void;
+    providerHost: string;
+  },
+) {
   const [state, setState] = useState<OAuthState>("idle");
   const [grant, setGrant] = useState<DeviceGrant | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -174,8 +193,8 @@ function OAuthLogin({ onToken }: { onToken: (t: string) => void }) {
             <>
               <h2>Sign in to your dashboard</h2>
               <p>
-                You'll be redirected to swamp-club.com to authenticate with your
-                account.
+                You'll be redirected to {providerHost}{" "}
+                to authenticate with your account.
               </p>
               <button
                 type="button"
@@ -193,7 +212,7 @@ function OAuthLogin({ onToken }: { onToken: (t: string) => void }) {
                   cursor: "pointer",
                 }}
               >
-                Login with swamp-club
+                Login with {providerHost}
               </button>
             </>
           )}
@@ -212,8 +231,8 @@ function OAuthLogin({ onToken }: { onToken: (t: string) => void }) {
             <>
               <h2>Complete login in your browser</h2>
               <p>
-                A new tab has opened at swamp-club.com. Enter the code below to
-                confirm it's you.
+                A new tab has opened at{" "}
+                {providerHost}. Enter the code below to confirm it's you.
               </p>
               <div className="login-code-block">
                 <div className="login-code-label">Confirmation code</div>
@@ -230,7 +249,7 @@ function OAuthLogin({ onToken }: { onToken: (t: string) => void }) {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Open swamp-club.com manually
+                  Open {providerHost} manually
                 </a>
               </p>
             </>


### PR DESCRIPTION
## Summary

- Thread `verificationBaseUri` from the `/auth/info` response through `SwampProvider`'s React context so the dashboard login screen displays the actual OAuth provider hostname instead of hardcoded "swamp-club.com"
- Replace four hardcoded strings in `Login.tsx` (lines 177, 196, 215, 233) with the dynamic provider hostname, falling back to "swamp-club.com" when absent
- Fix the failure mode where users with a custom `--oauth-provider` were directed to swamp-club.com to enter a device code minted by a different IdP

## Test plan

- [x] `deno check` passes (dashboard Vite/JSX errors are pre-existing)
- [x] `deno fmt` clean
- [x] `deno lint` clean
- [x] Full test suite passes
- [x] Compile + binary smoke check passes
- [x] Code review: VERDICT pass, 0 findings
- [ ] Manual verification: run `swamp serve --auth-mode oauth --oauth-provider <custom-url> --dashboard` and confirm login screen shows the custom hostname

Closes swamp-club#1893

🤖 Generated with [Claude Code](https://claude.com/claude-code)