### PR TITLE
feat(repo): add Amp Code as a built-in tool (swamp-club#1856)

### DIFF
--- a/design/audit-doctor.md
+++ b/design/audit-doctor.md
@@ -96,8 +96,8 @@ prefix is the only identifier available for all four tools.
 - Without `--tool`, reads `.swamp.yaml`'s `tool` field.
 - If both are absent, throws `NoToolConfiguredError` — a usage error,
   not a check fail, exits non-zero from the CLI.
-- `codex` and `none` short-circuit to a single skip result (those tools
-  don't emit audit hooks).
+- `amp`, `codex`, and `none` short-circuit to a single skip result (those
+  tools don't emit audit hooks).
 
 ## Platform
 

--- a/design/global-skills.md
+++ b/design/global-skills.md
@@ -23,6 +23,7 @@ it reads at runtime:
 
 | Tool     | Global skills path                       | Reads `~/.agents/skills/`? |
 | -------- | ---------------------------------------- | -------------------------- |
+| amp      | reads from `~/.agents/skills/` directly  | Yes                        |
 | claude   | `~/.claude/skills/`                      | No                         |
 | cursor   | reads from `~/.agents/skills/` directly  | Yes                        |
 | opencode | reads from `~/.agents/skills/` directly  | Yes                        |
@@ -30,7 +31,7 @@ it reads at runtime:
 | copilot  | reads from `~/.agents/skills/` directly  | Yes                        |
 | kiro     | `~/.kiro/skills/`                        | No                         |
 
-Tools that read from `~/.agents/skills/` natively (Cursor, OpenCode, Codex,
+Tools that read from `~/.agents/skills/` natively (Amp, Cursor, OpenCode, Codex,
 Copilot) share a single copy. Claude Code and Kiro require their own copies at
 their vendor-specific global paths.
 
@@ -41,6 +42,7 @@ built-in tool:
 
 ```typescript
 const GLOBAL_SKILL_DIRS: Record<string, string> = {
+  amp: ".agents/skills",
   claude: ".claude/skills",
   cursor: ".agents/skills",
   opencode: ".agents/skills",
@@ -108,7 +110,7 @@ Today these commands copy skills into the repo. Under the new model:
 
 1. Detect enrolled tools (same as today)
 2. Write skills to each tool's **global** directory (deduplicated — write to
-   `~/.agents/skills/` once even if codex + copilot + opencode are all enrolled)
+   `~/.agents/skills/` once even if amp + codex + copilot + opencode are all enrolled)
 3. Write instructions files to the **repo** (CLAUDE.md, AGENTS.md,
    `.cursor/rules/swamp.mdc`, `.kiro/steering/swamp-rules.md`) — these stay
    per-repo because they reference repo-specific context (model names,

--- a/design/repo.md
+++ b/design/repo.md
@@ -18,8 +18,8 @@ agent should attempt to use swamp for most tasks.
 
 ## Multi-tool Repos
 
-A swamp repo can be enrolled for multiple AI agent tools at once (Claude
-Code, Cursor, OpenCode, Codex, Copilot, Kiro). The marker file stores the
+A swamp repo can be enrolled for multiple AI agent tools at once (Amp,
+Claude Code, Cursor, OpenCode, Codex, Copilot, Kiro). The marker file stores the
 full enrolled list as `tools: AiTool[]`. Each tool's scaffolding (skills
 directory, instructions file, settings/hooks) is written independently
 since the paths don't conflict.

--- a/src/cli/ai_tool_parser.ts
+++ b/src/cli/ai_tool_parser.ts
@@ -22,6 +22,7 @@ import type { AiTool } from "../infrastructure/persistence/repo_marker_repositor
 
 /** The canonical list of valid AI tool names. */
 export const VALID_AI_TOOLS: readonly AiTool[] = [
+  "amp",
   "claude",
   "cursor",
   "kiro",

--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -46,7 +46,16 @@ type AnyOptions = any;
 
 class ToolNameType extends StringType {
   override complete(): string[] {
-    return ["claude", "cursor", "opencode", "codex", "copilot", "kiro", "none"];
+    return [
+      "amp",
+      "claude",
+      "cursor",
+      "opencode",
+      "codex",
+      "copilot",
+      "kiro",
+      "none",
+    ];
   }
 
   override parse(type: ArgumentValue): string {
@@ -120,7 +129,7 @@ const TOOL_FLAG_DESCRIPTION =
   "AI coding tool to configure for. Repeat to enroll multiple tools " +
   "(e.g. `--tool claude --tool kiro`). Duplicates are collapsed. " +
   "Use `--tool none` (alone) to skip tool scaffolding. Defaults to " +
-  "`claude` when omitted. Built-in: claude, cursor, opencode, codex, " +
+  "`claude` when omitted. Built-in: amp, claude, cursor, opencode, codex, " +
   "copilot, kiro, none. Custom tools defined via `swamp agent setup` " +
   "are also accepted.";
 

--- a/src/domain/audit/doctor/checks/binary_on_path_test.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path_test.ts
@@ -78,6 +78,7 @@ Deno.test("binaryOnPath: appliesTo returns true for all five audit tools, false 
   assertEquals(check.appliesTo("kiro"), true);
   assertEquals(check.appliesTo("opencode"), true);
   assertEquals(check.appliesTo("copilot"), true);
+  assertEquals(check.appliesTo("amp"), false);
   assertEquals(check.appliesTo("codex"), false);
   assertEquals(check.appliesTo("none"), false);
 });

--- a/src/domain/audit/doctor/checks/recording_smoke_test.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke_test.ts
@@ -129,6 +129,7 @@ Deno.test("recordingSmokeTest: appliesTo returns true only for audit-hook tools"
   assertEquals(recordingSmokeTestCheck.appliesTo("claude"), true);
   assertEquals(recordingSmokeTestCheck.appliesTo("kiro"), true);
   assertEquals(recordingSmokeTestCheck.appliesTo("copilot"), true);
+  assertEquals(recordingSmokeTestCheck.appliesTo("amp"), false);
   assertEquals(recordingSmokeTestCheck.appliesTo("codex"), false);
   assertEquals(recordingSmokeTestCheck.appliesTo("none"), false);
 });

--- a/src/domain/audit/doctor/doctor_service.ts
+++ b/src/domain/audit/doctor/doctor_service.ts
@@ -105,7 +105,7 @@ function buildDefaultChecks(deps: AuditDoctorDeps): readonly PreflightCheck[] {
 /**
  * Runs preflight checks against the audit integration for the given tool.
  *
- * For tools without audit hooks (codex, none), emits a single
+ * For tools without audit hooks (amp, codex, none), emits a single
  * skip result and returns a `warn` report.
  */
 export async function* auditDoctor(
@@ -116,7 +116,8 @@ export async function* auditDoctor(
   // Tools without audit hook integration: short-circuit cleanly.
   // Custom tools (non-built-in) also skip — they have no audit hooks.
   if (
-    !isBuiltInTool(tool) || tool === "codex" || tool === "none"
+    !isBuiltInTool(tool) || tool === "amp" || tool === "codex" ||
+    tool === "none"
   ) {
     const skipResult: CheckResult = {
       name: "recording-smoke-test",

--- a/src/domain/audit/doctor/doctor_service_test.ts
+++ b/src/domain/audit/doctor/doctor_service_test.ts
@@ -149,7 +149,7 @@ Deno.test(
 Deno.test(
   "auditDoctor: short-circuits to a single skip for tools without audit hooks",
   async () => {
-    for (const tool of ["codex", "none"] as const) {
+    for (const tool of ["amp", "codex", "none"] as const) {
       const events = await collect(auditDoctor(makeDeps(tool)));
       assertEquals(events.length, 2);
       assertEquals(events[0].kind, "check-completed");

--- a/src/domain/audit/doctor/synthetic_payloads.ts
+++ b/src/domain/audit/doctor/synthetic_payloads.ts
@@ -135,6 +135,7 @@ export function syntheticPayloadFor(
       };
       return { stdin: JSON.stringify(raw), env: {}, expectedCommand };
     }
+    case "amp":
     case "codex":
     case "none":
     default:

--- a/src/domain/audit/doctor/synthetic_payloads_test.ts
+++ b/src/domain/audit/doctor/synthetic_payloads_test.ts
@@ -79,6 +79,7 @@ Deno.test("syntheticPayloadFor: sets USER_PROMPT env var for kiro only", () => {
 });
 
 Deno.test("syntheticPayloadFor: returns null for tools without audit hooks", () => {
+  assertEquals(syntheticPayloadFor("amp", "nonce"), null);
   assertEquals(syntheticPayloadFor("codex", "nonce"), null);
   assertEquals(syntheticPayloadFor("none", "nonce"), null);
 });

--- a/src/domain/repo/ai_tool.ts
+++ b/src/domain/repo/ai_tool.ts
@@ -28,6 +28,7 @@
  * compatibility but is never written.
  */
 export type AiTool =
+  | "amp"
   | "claude"
   | "cursor"
   | "opencode"

--- a/src/domain/repo/custom_tool.ts
+++ b/src/domain/repo/custom_tool.ts
@@ -43,6 +43,7 @@ export interface ToolConfig {
 }
 
 export const BUILT_IN_TOOL_NAMES: readonly string[] = [
+  "amp",
   "claude",
   "cursor",
   "opencode",
@@ -95,6 +96,15 @@ export function assertPathContained(
 
 export function builtInToolConfig(tool: AiTool): ToolConfig {
   switch (tool) {
+    case "amp":
+      return {
+        name: "amp",
+        isBuiltIn: true,
+        skillsDir: ".agents/skills",
+        instructionsFile: "AGENTS.md",
+        instructionsMode: "shared",
+        skillReferenceStyle: "name",
+      };
     case "claude":
       return {
         name: "claude",

--- a/src/domain/repo/custom_tool_test.ts
+++ b/src/domain/repo/custom_tool_test.ts
@@ -32,6 +32,7 @@ import {
 import { UserError } from "../errors.ts";
 
 Deno.test("isBuiltInTool: recognizes built-in tools", () => {
+  assertEquals(isBuiltInTool("amp"), true);
   assertEquals(isBuiltInTool("claude"), true);
   assertEquals(isBuiltInTool("cursor"), true);
   assertEquals(isBuiltInTool("opencode"), true);
@@ -131,8 +132,18 @@ Deno.test("builtInToolConfig: kiro config", () => {
   assertEquals(config.skillReferenceStyle, "name");
 });
 
-Deno.test("builtInToolConfig: opencode/codex/copilot share AGENTS.md", () => {
-  for (const tool of ["opencode", "codex", "copilot"] as const) {
+Deno.test("builtInToolConfig: amp config", () => {
+  const config = builtInToolConfig("amp");
+  assertEquals(config.name, "amp");
+  assertEquals(config.isBuiltIn, true);
+  assertEquals(config.skillsDir, ".agents/skills");
+  assertEquals(config.instructionsFile, "AGENTS.md");
+  assertEquals(config.instructionsMode, "shared");
+  assertEquals(config.skillReferenceStyle, "name");
+});
+
+Deno.test("builtInToolConfig: amp/opencode/codex/copilot share AGENTS.md", () => {
+  for (const tool of ["amp", "opencode", "codex", "copilot"] as const) {
     const config = builtInToolConfig(tool);
     assertEquals(config.instructionsFile, "AGENTS.md");
     assertEquals(config.instructionsMode, "shared");

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -798,6 +798,14 @@ export class RepoService {
           if (changed) changedFiles.push(".github/hooks/swamp-audit.json");
           break;
         }
+        case "amp": {
+          const changed = alreadyExists
+            ? await this.updateAmpSettings(repoPath)
+            : await this.createAmpSettingsIfNotExists(repoPath);
+          settingsChanged = changed;
+          if (changed) changedFiles.push(".amp/settings.json");
+          break;
+        }
         case "codex":
         case "none":
           break;
@@ -1599,6 +1607,83 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
       },
       hooks: mergedHooks,
     };
+    await atomicWriteTextFile(
+      settingsPath,
+      JSON.stringify(newSettings, null, 2) + "\n",
+    );
+    return true;
+  }
+
+  private generateAmpSettingsContent(): string {
+    const settings = {
+      "amp.commands": {
+        allowlist: ["swamp *"],
+        strict: true,
+      },
+    };
+    return JSON.stringify(settings, null, 2) + "\n";
+  }
+
+  private createAmpSettingsIfNotExists(
+    repoPath: RepoPath,
+  ): Promise<boolean> {
+    const settingsPath = join(repoPath.value, ".amp", "settings.json");
+    return this.createFileIfNotExists(
+      settingsPath,
+      this.generateAmpSettingsContent(),
+    );
+  }
+
+  private async updateAmpSettings(repoPath: RepoPath): Promise<boolean> {
+    const ampDir = join(repoPath.value, ".amp");
+    const settingsPath = join(ampDir, "settings.json");
+
+    await ensureDir(ampDir);
+
+    let existingSettings: Record<string, unknown> = {};
+    let settingsExisted = false;
+
+    try {
+      const content = await Deno.readTextFile(settingsPath);
+      existingSettings = JSON.parse(content);
+      settingsExisted = true;
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    const ourSettings = JSON.parse(this.generateAmpSettingsContent());
+    const existingCommands =
+      (existingSettings as Record<string, Record<string, unknown>>)
+        ?.["amp.commands"] as
+          | { allowlist?: string[]; strict?: boolean }
+          | undefined;
+
+    const mergedAllowlist = [
+      ...new Set([
+        ...(existingCommands?.allowlist ?? []),
+        ...ourSettings["amp.commands"].allowlist,
+      ]),
+    ];
+
+    const hasChanges =
+      mergedAllowlist.length !== (existingCommands?.allowlist?.length ?? 0) ||
+      existingCommands?.strict !== true;
+
+    if (!hasChanges && settingsExisted) {
+      return false;
+    }
+
+    const newSettings = {
+      ...existingSettings,
+      "amp.commands": {
+        ...existingCommands,
+        allowlist: mergedAllowlist,
+        strict: true,
+      },
+    };
+
     await atomicWriteTextFile(
       settingsPath,
       JSON.stringify(newSettings, null, 2) + "\n",

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -2965,3 +2965,44 @@ Deno.test("RepoService.upgrade: custom tool with relative skillsDir gets skills 
     assertEquals(stat.isFile, true);
   });
 });
+
+Deno.test("RepoService.init with tool amp creates .amp/settings.json", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    const result = await service.init(repoPath, { tools: ["amp"] });
+
+    assertEquals(result.tools, ["amp"]);
+    assertEquals(result.settingsCreated, true);
+
+    const content = await Deno.readTextFile(
+      join(tempDir, ".amp", "settings.json"),
+    );
+    const settings = JSON.parse(content);
+    assertEquals(settings["amp.commands"].allowlist, ["swamp *"]);
+    assertEquals(settings["amp.commands"].strict, true);
+  });
+});
+
+Deno.test("RepoService.upgrade with tool amp preserves existing .amp/settings.json entries", async () => {
+  await withTempDir(async (tempDir) => {
+    const service = new RepoService("0.1.0");
+    const repoPath = RepoPath.create(tempDir);
+    await service.init(repoPath, { tools: ["amp"] });
+
+    const settingsPath = join(tempDir, ".amp", "settings.json");
+    const existing = JSON.parse(await Deno.readTextFile(settingsPath));
+    existing["amp.commands"].allowlist.push("git *");
+    existing["amp.ui"] = { theme: "dark" };
+    await Deno.writeTextFile(settingsPath, JSON.stringify(existing, null, 2));
+
+    const upgradeService = new RepoService("0.2.0");
+    await upgradeService.upgrade(repoPath);
+
+    const updated = JSON.parse(await Deno.readTextFile(settingsPath));
+    assertEquals(updated["amp.commands"].allowlist.includes("swamp *"), true);
+    assertEquals(updated["amp.commands"].allowlist.includes("git *"), true);
+    assertEquals(updated["amp.commands"].strict, true);
+    assertEquals(updated["amp.ui"].theme, "dark");
+  });
+});

--- a/src/domain/repo/skill_dirs.ts
+++ b/src/domain/repo/skill_dirs.ts
@@ -29,6 +29,7 @@ import {
  * Used for project-local skill directories and extension skill resolution.
  */
 export const SKILL_DIRS: Record<string, string> = {
+  amp: ".agents/skills",
   claude: ".claude/skills",
   cursor: ".cursor/skills",
   opencode: ".agents/skills",
@@ -44,6 +45,7 @@ export const SKILL_DIRS: Record<string, string> = {
  * require their own vendor-specific paths.
  */
 export const GLOBAL_SKILL_DIRS: Record<string, string> = {
+  amp: ".agents/skills",
   claude: ".claude/skills",
   cursor: ".agents/skills",
   opencode: ".agents/skills",

--- a/src/domain/repo/skill_dirs_test.ts
+++ b/src/domain/repo/skill_dirs_test.ts
@@ -35,7 +35,8 @@ Deno.test("GLOBAL_SKILL_DIRS: kiro uses vendor-specific path", () => {
   assertEquals(GLOBAL_SKILL_DIRS["kiro"], ".kiro/skills");
 });
 
-Deno.test("GLOBAL_SKILL_DIRS: codex/cursor/opencode/copilot share .agents/skills", () => {
+Deno.test("GLOBAL_SKILL_DIRS: amp/codex/cursor/opencode/copilot share .agents/skills", () => {
+  assertEquals(GLOBAL_SKILL_DIRS["amp"], ".agents/skills");
   assertEquals(GLOBAL_SKILL_DIRS["codex"], ".agents/skills");
   assertEquals(GLOBAL_SKILL_DIRS["cursor"], ".agents/skills");
   assertEquals(GLOBAL_SKILL_DIRS["opencode"], ".agents/skills");

--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -40,6 +40,7 @@ function formatToolsList(tools: readonly string[]): string {
 }
 
 const TOOL_NEXT_STEPS: Record<string, string> = {
+  amp: 'Run `amp` in this directory and say "I am new to swamp"',
   claude: "Start Claude Code and run /swamp-getting-started",
   cursor: "Open this project in Cursor and run /swamp-getting-started",
   codex: "Run `codex` and invoke $swamp-getting-started",
@@ -55,11 +56,12 @@ const TOOL_NEXT_STEPS: Record<string, string> = {
  * the user which files were left behind when a tool is dropped from the
  * enrolled list.
  *
- * Some paths are shared (`.agents/skills/` for opencode/codex/copilot),
+ * Some paths are shared (`.agents/skills/` for amp/opencode/codex/copilot),
  * so the renderer subtracts paths that are still in use by another
  * remaining tool before warning the user — see {@link orphanedPathsFor}.
  */
 const TOOL_CLEANUP_PATHS: Partial<Record<string, readonly string[]>> = {
+  amp: [".amp/", ".agents/skills/"],
   claude: [".claude/"],
   cursor: [".cursor/"],
   kiro: [".kiro/", ".vscode/settings.local.json"],


### PR DESCRIPTION
## Summary

- Adds `amp` as a built-in AI tool in `swamp repo init --tool amp`, sharing the `AGENTS.md` / `.agents/skills/` convention with opencode, codex, and copilot
- Scaffolds `.amp/settings.json` with `amp.commands.allowlist` and `amp.commands.strict` on init/upgrade
- Skips audit hook wiring (Amp lacks `run-command` hook action support) — amp is added to the audit doctor skip list alongside codex

## Files changed (19)

**Domain:** `ai_tool.ts`, `custom_tool.ts`, `skill_dirs.ts`, `repo_service.ts`
**Audit doctor:** `doctor_service.ts`, `synthetic_payloads.ts`, `binary_on_path.ts`, `recording_smoke.ts`
**CLI:** `ai_tool_parser.ts`, `repo_init.ts`
**Presentation:** `repo_init.ts` (renderer — next steps + cleanup paths)
**Design docs:** `repo.md`, `global-skills.md`, `audit-doctor.md`
**Tests:** 7 test files updated

## Test plan

- [x] `deno check` passes on all changed source files
- [x] `deno run test` passes for all 7 test files (custom_tool, tool_resolver, skill_dirs, ai_tool_parser, repo_service, doctor_service, synthetic_payloads, binary_on_path, recording_smoke)
- [x] New tests: `RepoService.init with tool amp creates .amp/settings.json` and `RepoService.upgrade with tool amp preserves existing .amp/settings.json entries`
- [x] Full verification workflow passed (build + reviews)

Closes swamp-club#1856

🤖 Generated with [Claude Code](https://claude.com/claude-code)