### PR TITLE
fix(core): namespace-scope datastore lock key and pass namespace to all pushChanged sites (swamp-club#1897)

### DIFF
--- a/design/datastores.md
+++ b/design/datastores.md
@@ -1081,12 +1081,14 @@ mode. A background heartbeat rewrites the lockfile content with a fresh
 timestamp. Stale locks (where `acquiredAt + ttlMs < now`) are removed and
 retried.
 
-When a `namespace` is configured, the **global** lock key moves to
-`{datastorePath}/.locks/{namespace}.lock` (`datastoreGlobalLockOptions`), so two
-repos writing to different namespaces of a shared datastore never contend on
-structural commands. `FileLock` lazily creates the `.locks/` directory on first
-acquire. This is a lock-**path** change only — the lifecycle protocol below is
-unchanged. Per-model lock keys are namespaced:
+When a `namespace` is configured, `datastoreGlobalLockOptions` returns
+`{ lockKey: ".datastore.lock", namespace }`. Both `FileLock` and remote lock
+providers (S3, GCS) prefix the lock key under `{namespace}/`, placing it at
+`{datastorePath}/{namespace}/.datastore.lock`. Two repos writing to different
+namespaces of a shared datastore never contend on structural commands, and the
+lock key stays within the namespace prefix so IAM credentials scoped to the
+prefix can access it. This is a lock-**path** change only — the lifecycle
+protocol below is unchanged. Per-model lock keys are namespaced:
 `{namespace}/data/{type}/{modelId}/.lock` when a namespace is set,
 `data/{type}/{modelId}/.lock` otherwise. The `modelLockKey()` helper in
 `lock.ts` constructs the key; `createModelLock` and `acquireModelLocks` read

--- a/packages/testing/datastore_test_context.ts
+++ b/packages/testing/datastore_test_context.ts
@@ -112,7 +112,10 @@ export function createDatastoreTestContext(
     _datastorePath: string,
     lockOptions?: LockOptions,
   ): DistributedLock {
-    const lockKey = lockOptions?.lockKey ?? "default";
+    const baseLockKey = lockOptions?.lockKey ?? "default";
+    const lockKey = lockOptions?.namespace
+      ? `${lockOptions.namespace}/${baseLockKey}`
+      : baseLockKey;
     const nonce = crypto.randomUUID();
 
     const lock: DistributedLock = {

--- a/packages/testing/datastore_types.ts
+++ b/packages/testing/datastore_types.ts
@@ -38,6 +38,7 @@ export interface LockInfo {
 /** Configuration for lock behavior. */
 export interface LockOptions {
   lockKey?: string;
+  namespace?: string;
   ttlMs?: number;
   retryIntervalMs?: number;
   maxWaitMs?: number;

--- a/src/cli/commands/access_token_mint.ts
+++ b/src/cli/commands/access_token_mint.ts
@@ -28,6 +28,7 @@ import {
   requireInitializedRepoUnlocked,
 } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import {
   consumeStream,
@@ -237,9 +238,12 @@ export const accessTokenMintCommand = new Command()
       }
 
       if (syncService) {
+        const namespace = isCustomDatastoreConfig(datastoreConfig)
+          ? datastoreConfig.namespace
+          : undefined;
         try {
           await syncService.markDirty();
-          await syncService.pushChanged();
+          await syncService.pushChanged({ namespace });
 
           repoContext.catalogStore.invalidate();
           const verifyResult = await findDefinitionByIdOrName(

--- a/src/cli/commands/datastore_config_migrate.ts
+++ b/src/cli/commands/datastore_config_migrate.ts
@@ -130,8 +130,11 @@ export const datastoreConfigMigrateCommand = new Command()
 
     let pushed = false;
     if (syncService && (copied.length > 0 || managedConfigSet)) {
+      const namespace = isCustomDatastoreConfig(datastoreConfig)
+        ? datastoreConfig.namespace
+        : undefined;
       await syncService.markDirty();
-      await syncService.pushChanged();
+      await syncService.pushChanged({ namespace });
       pushed = true;
     }
 

--- a/src/cli/commands/model_create.ts
+++ b/src/cli/commands/model_create.ts
@@ -33,6 +33,7 @@ import {
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
@@ -122,6 +123,7 @@ export const modelCreateCommand = withRemoteOptions(
     const resolvedRepoDir = resolveRepoDir(options.repoDir);
     const {
       repoDir,
+      datastoreConfig,
       datastoreResolver: resolver,
       syncService,
     } = await requireInitializedRepoUnlocked({
@@ -145,8 +147,11 @@ export const modelCreateCommand = withRemoteOptions(
     );
 
     if (syncService && managedConfig) {
+      const namespace = isCustomDatastoreConfig(datastoreConfig)
+        ? datastoreConfig.namespace
+        : undefined;
       await syncService.markDirty();
-      await syncService.pushChanged();
+      await syncService.pushChanged({ namespace });
     }
 
     cliCtx.logger.debug("Model create command completed");

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1623,8 +1623,11 @@ export const serveCommand = new Command()
         modelsDir,
       );
       if (syncService) {
+        const namespace = isCustomDatastoreConfig(datastoreConfig)
+          ? datastoreConfig.namespace
+          : undefined;
         await syncService.markDirty();
-        await syncService.pushChanged();
+        await syncService.pushChanged({ namespace });
       }
     }
 

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -31,6 +31,7 @@ import {
   requireInitializedRepoUnlocked,
 } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import {
   resolveResumableRun,
   resolveSuspendedRun,
@@ -465,8 +466,11 @@ export const workflowResumeCommand = withRemoteOptions(
       await consumeStream(resumeGenerator(), renderer.handlers());
     } finally {
       if (unlocked.syncService) {
+        const namespace = isCustomDatastoreConfig(unlocked.datastoreConfig)
+          ? unlocked.datastoreConfig.namespace
+          : undefined;
         try {
-          await unlocked.syncService.pushChanged();
+          await unlocked.syncService.pushChanged({ namespace });
         } catch (pushErr) {
           cliCtx.logger
             .warn`Post-resume push failed; terminal status may be delayed: ${

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -35,6 +35,7 @@ import {
   requireInitializedRepoUnlocked,
 } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import {
   type DirectTypeResolver,
@@ -577,8 +578,11 @@ export const workflowRunCommand = new Command()
       throw new UserError(`Workflow execution failed: ${message}`);
     } finally {
       if (unlocked.syncService) {
+        const namespace = isCustomDatastoreConfig(unlocked.datastoreConfig)
+          ? unlocked.datastoreConfig.namespace
+          : undefined;
         try {
-          await unlocked.syncService.pushChanged();
+          await unlocked.syncService.pushChanged({ namespace });
         } catch (pushErr) {
           ctx.logger
             .warn`Post-run push failed; terminal status may be delayed: ${

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -1190,8 +1190,12 @@ export async function acquireModelLocks(
       // Hard timeout to prevent indefinite hangs
       const globalElapsed = Date.now() - globalWaitStart;
       if (globalElapsed >= globalMaxWaitMs) {
+        const lockOpts = datastoreGlobalLockOptions(config);
+        const displayKey = lockOpts?.namespace
+          ? `${lockOpts.namespace}/.datastore.lock`
+          : ".datastore.lock";
         throw new LockTimeoutError(
-          datastoreGlobalLockOptions(config)?.lockKey ?? ".datastore.lock",
+          displayKey,
           info,
           globalElapsed,
         );
@@ -1280,8 +1284,12 @@ export async function acquireModelLocks(
         }
         const retryElapsed = Date.now() - retryWaitStart;
         if (retryElapsed >= retryMaxWaitMs) {
+          const retryLockOpts = datastoreGlobalLockOptions(config);
+          const retryDisplayKey = retryLockOpts?.namespace
+            ? `${retryLockOpts.namespace}/.datastore.lock`
+            : ".datastore.lock";
           throw new LockTimeoutError(
-            datastoreGlobalLockOptions(config)?.lockKey ?? ".datastore.lock",
+            retryDisplayKey,
             info,
             retryElapsed,
           );
@@ -1663,7 +1671,7 @@ export function datastoreGlobalLockOptions(
 ): LockOptions | undefined {
   const namespace = config.namespace ?? "";
   if (namespace.length === 0) return undefined;
-  return { lockKey: `.locks/${namespace}.lock` };
+  return { lockKey: ".datastore.lock", namespace };
 }
 
 /**

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -1653,11 +1653,10 @@ export function acquireVaultSync(
  *
  * Solo mode (no namespace) returns `undefined`, so the lock falls back to the
  * single shared `.datastore.lock` — byte-identical to before. When a namespace
- * is configured, the global lock moves to `.locks/{namespace}.lock` so repos
- * sharing a datastore never contend on structural commands. This is a PATH
- * change only: the lock lifecycle (symmetric drain, TOCTOU rechecks) is
- * unchanged. `FileLock` lazily creates the `.locks/` directory on first
- * acquire via `ensureDir(dirname(lockPath))`.
+ * is configured, returns `{ lockKey: ".datastore.lock", namespace }` so the
+ * lock provider places the key at `{namespace}/.datastore.lock`, keeping it
+ * within the namespace prefix for IAM-scoped credentials. Repos sharing a
+ * datastore with different namespaces never contend on structural commands.
  *
  * Every construction of the GLOBAL datastore lock — the structural-command
  * acquire, the `acquireModelLocks` drain-coordination inspect, the per-model

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -1704,14 +1704,15 @@ Deno.test("datastoreGlobalLockOptions: solo mode falls back to the single .datas
   assertEquals(datastoreGlobalLockOptions(explicitEmpty), undefined);
 });
 
-Deno.test("datastoreGlobalLockOptions: namespaced repo uses .locks/{namespace}.lock", () => {
+Deno.test("datastoreGlobalLockOptions: namespaced repo passes namespace in LockOptions", () => {
   const config: DatastoreConfig = {
     type: "filesystem",
     path: "/ds",
     namespace: "infra",
   };
   assertEquals(datastoreGlobalLockOptions(config), {
-    lockKey: ".locks/infra.lock",
+    lockKey: ".datastore.lock",
+    namespace: "infra",
   });
 });
 
@@ -1723,7 +1724,8 @@ Deno.test("datastoreGlobalLockOptions: applies to custom datastores too", () => 
     namespace: "security",
   };
   assertEquals(datastoreGlobalLockOptions(config), {
-    lockKey: ".locks/security.lock",
+    lockKey: ".datastore.lock",
+    namespace: "security",
   });
 });
 

--- a/src/domain/datastore/distributed_lock.ts
+++ b/src/domain/datastore/distributed_lock.ts
@@ -47,6 +47,12 @@ export interface LockInfo {
 export interface LockOptions {
   /** Backend-specific key/path for the lock (default varies by backend). */
   lockKey?: string;
+  /**
+   * Namespace prefix for scoping the lock key. When set, the lock provider
+   * places the key under `{namespace}/` so IAM credentials scoped to the
+   * namespace prefix can access it.
+   */
+  namespace?: string;
   /** TTL in ms (default: 30_000). */
   ttlMs?: number;
   /** Retry interval in ms (default: 1_000). */
@@ -94,12 +100,16 @@ export interface DistributedLock {
  * Returns true when the lock key identifies the global (non-namespaced)
  * datastore lock. Covers both the bare key (`".datastore.lock"` from
  * S3/GCS locks) and the full filesystem path (`"/…/.datastore.lock"`
- * from FileLock). Namespaced keys live under `.locks/` and won't match.
+ * from FileLock). Namespaced keys have the form `"{ns}/.datastore.lock"`
+ * (short) or `"{base}/{ns}/.datastore.lock"` (full path, where the
+ * namespace segment is a non-hidden directory name).
  */
 function isGlobalDatastoreLock(lockKey: string): boolean {
-  return (lockKey === ".datastore.lock" ||
-    lockKey.endsWith("/.datastore.lock")) &&
-    !lockKey.includes("/.locks/");
+  if (lockKey === ".datastore.lock") return true;
+  if (!lockKey.endsWith("/.datastore.lock")) return false;
+  const parts = lockKey.split("/");
+  const parentSegment = parts[parts.length - 2];
+  return parentSegment?.startsWith(".") ?? false;
 }
 
 /**

--- a/src/domain/datastore/distributed_lock.ts
+++ b/src/domain/datastore/distributed_lock.ts
@@ -97,19 +97,15 @@ export interface DistributedLock {
 }
 
 /**
- * Returns true when the lock key identifies the global (non-namespaced)
- * datastore lock. Covers both the bare key (`".datastore.lock"` from
- * S3/GCS locks) and the full filesystem path (`"/…/.datastore.lock"`
- * from FileLock). Namespaced keys have the form `"{ns}/.datastore.lock"`
- * (short) or `"{base}/{ns}/.datastore.lock"` (full path, where the
- * namespace segment is a non-hidden directory name).
+ * Returns true when the lock key identifies the solo-mode (non-namespaced)
+ * global datastore lock. Matches the short display key `.datastore.lock`
+ * used by `acquireModelLocks` error paths. Full filesystem paths from
+ * `FileLock.acquire()` do not match — the hint is only shown for the
+ * display-key paths where it can reliably distinguish solo from namespaced
+ * (e.g. `infra/.datastore.lock`).
  */
 function isGlobalDatastoreLock(lockKey: string): boolean {
-  if (lockKey === ".datastore.lock") return true;
-  if (!lockKey.endsWith("/.datastore.lock")) return false;
-  const parts = lockKey.split("/");
-  const parentSegment = parts[parts.length - 2];
-  return parentSegment?.startsWith(".") ?? false;
+  return lockKey === ".datastore.lock";
 }
 
 /**

--- a/src/domain/datastore/distributed_lock_test.ts
+++ b/src/domain/datastore/distributed_lock_test.ts
@@ -69,23 +69,23 @@ Deno.test("LockTimeoutError: global lock key includes namespace hint", () => {
   assertStringIncludes(error.message, "swamp datastore namespace migrate");
 });
 
-Deno.test("LockTimeoutError: filesystem global lock path includes namespace hint", () => {
+Deno.test("LockTimeoutError: filesystem full path omits namespace hint (display keys only)", () => {
   const error = new LockTimeoutError(
     "/home/user/.swamp/.datastore.lock",
     null,
     5000,
   );
-  assertStringIncludes(error.message, "swamp datastore namespace set");
-});
-
-Deno.test("LockTimeoutError: namespaced lock key omits namespace hint", () => {
-  const error = new LockTimeoutError(".locks/infra.lock", null, 5000);
   assertEquals(error.message.includes("namespace set"), false);
 });
 
-Deno.test("LockTimeoutError: filesystem namespaced lock path omits namespace hint", () => {
+Deno.test("LockTimeoutError: namespaced display key omits namespace hint", () => {
+  const error = new LockTimeoutError("infra/.datastore.lock", null, 5000);
+  assertEquals(error.message.includes("namespace set"), false);
+});
+
+Deno.test("LockTimeoutError: namespaced filesystem path omits namespace hint", () => {
   const error = new LockTimeoutError(
-    "/home/user/.swamp/.locks/infra.lock",
+    "/home/user/.swamp/infra/.datastore.lock",
     null,
     5000,
   );

--- a/src/infrastructure/persistence/file_lock.ts
+++ b/src/infrastructure/persistence/file_lock.ts
@@ -78,7 +78,10 @@ export class FileLock implements DistributedLock {
 
   constructor(basePath: string, options?: LockOptions) {
     const lockFile = options?.lockKey ?? DEFAULT_LOCK_PATH;
-    this.lockPath = `${basePath}/${lockFile}`;
+    const ns = options?.namespace;
+    this.lockPath = ns
+      ? `${basePath}/${ns}/${lockFile}`
+      : `${basePath}/${lockFile}`;
     this.ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
     this.retryIntervalMs = options?.retryIntervalMs ??
       DEFAULT_RETRY_INTERVAL_MS;

--- a/src/infrastructure/persistence/file_lock_test.ts
+++ b/src/infrastructure/persistence/file_lock_test.ts
@@ -284,23 +284,24 @@ Deno.test("FileLock - custom lock key", async () => {
   });
 });
 
-Deno.test("FileLock - namespaced lock key lazily creates the .locks directory", async () => {
+Deno.test("FileLock - namespace option scopes lock under namespace directory", async () => {
   await withTempDir(async (dir) => {
-    // Giga-swamp per-namespace global lock key: `.locks/{namespace}.lock`.
     const lock = new FileLock(dir, {
-      lockKey: ".locks/infra.lock",
+      namespace: "infra",
       ttlMs: 5000,
     });
 
-    // The `.locks` directory must NOT exist before acquisition.
-    await assertRejects(() => Deno.stat(join(dir, ".locks")));
+    // The namespace directory must NOT exist before acquisition.
+    await assertRejects(() => Deno.stat(join(dir, "infra")));
 
     await lock.acquire();
 
-    // Acquiring lazily creates `.locks/` and the namespaced lock file.
-    const dirStat = await Deno.stat(join(dir, ".locks"));
+    // Acquiring lazily creates the namespace directory and the lock file.
+    const dirStat = await Deno.stat(join(dir, "infra"));
     assertEquals(dirStat.isDirectory, true);
-    const fileStat = await Deno.stat(join(dir, ".locks", "infra.lock"));
+    const fileStat = await Deno.stat(
+      join(dir, "infra", ".datastore.lock"),
+    );
     assertEquals(fileStat.isFile, true);
 
     await lock.release();
@@ -312,11 +313,11 @@ Deno.test("FileLock - different namespaces acquire their locks concurrently", as
     // Two repos sharing a datastore but in different namespaces must not
     // contend on the global lock.
     const infra = new FileLock(dir, {
-      lockKey: ".locks/infra.lock",
+      namespace: "infra",
       ttlMs: 5000,
     });
     const security = new FileLock(dir, {
-      lockKey: ".locks/security.lock",
+      namespace: "security",
       ttlMs: 5000,
     });
 
@@ -329,6 +330,24 @@ Deno.test("FileLock - different namespaces acquire their locks concurrently", as
 
     await infra.release();
     await security.release();
+  });
+});
+
+Deno.test("FileLock - namespace with custom lockKey", async () => {
+  await withTempDir(async (dir) => {
+    const lock = new FileLock(dir, {
+      lockKey: ".datastore.lock",
+      namespace: "prod",
+      ttlMs: 5000,
+    });
+    await lock.acquire();
+
+    const fileStat = await Deno.stat(
+      join(dir, "prod", ".datastore.lock"),
+    );
+    assertEquals(fileStat.isFile, true);
+
+    await lock.release();
   });
 });
 

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -73,7 +73,10 @@ import { SecretRedactor } from "../domain/secrets/mod.ts";
 import { modelRegistry } from "../domain/models/model.ts";
 import { vaultTypeRegistry } from "../domain/vaults/vault_type_registry.ts";
 import { reportRegistry } from "../domain/reports/report_registry.ts";
-import type { DatastoreConfig } from "../domain/datastore/datastore_config.ts";
+import {
+  type DatastoreConfig,
+  isCustomDatastoreConfig,
+} from "../domain/datastore/datastore_config.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import { DefaultDatastorePathResolver } from "../infrastructure/persistence/default_datastore_path_resolver.ts";
 import { acquireModelLocks } from "../cli/repo_context.ts";
@@ -472,8 +475,11 @@ export async function executeWorkflowWithLocks(
     await finishRunTelemetry(runTelemetry, failure);
   } finally {
     if (syncService) {
+      const namespace = isCustomDatastoreConfig(datastoreConfig)
+        ? datastoreConfig.namespace
+        : undefined;
       try {
-        await syncService.pushChanged();
+        await syncService.pushChanged({ namespace });
       } catch (pushErr) {
         logger.warn(
           "Post-run push failed; terminal status may be delayed: {error}",

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -632,8 +632,11 @@ export async function handleExtensionInstall(
     }
 
     if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
       await ctx.syncService.markDirty();
-      await ctx.syncService.pushChanged();
+      await ctx.syncService.pushChanged({ namespace });
     }
 
     send(socket, {
@@ -749,8 +752,11 @@ export async function handleExtensionPull(
     }
 
     if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
       await ctx.syncService.markDirty();
-      await ctx.syncService.pushChanged();
+      await ctx.syncService.pushChanged({ namespace });
     }
 
     send(socket, {
@@ -824,8 +830,11 @@ export async function handleExtensionRm(
     }
 
     if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
       await ctx.syncService.markDirty();
-      await ctx.syncService.pushChanged();
+      await ctx.syncService.pushChanged({ namespace });
     }
 
     send(socket, {
@@ -1015,8 +1024,11 @@ export async function handleExtensionUpdate(
     }
 
     if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
       await ctx.syncService.markDirty();
-      await ctx.syncService.pushChanged();
+      await ctx.syncService.pushChanged({ namespace });
     }
 
     send(socket, {
@@ -1184,8 +1196,11 @@ export async function handleVaultMigrate(
     }
 
     if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
       await ctx.syncService.markDirty();
-      await ctx.syncService.pushChanged();
+      await ctx.syncService.pushChanged({ namespace });
     }
 
     send(socket, {

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -792,8 +792,11 @@ export async function handleModelCreate(
     }
 
     if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
       await ctx.syncService.markDirty();
-      await ctx.syncService.pushChanged();
+      await ctx.syncService.pushChanged({ namespace });
     }
 
     send(socket, {
@@ -882,8 +885,11 @@ export async function handleModelDelete(
     }
 
     if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
       await ctx.syncService.markDirty();
-      await ctx.syncService.pushChanged();
+      await ctx.syncService.pushChanged({ namespace });
     }
 
     send(socket, {

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -82,6 +82,7 @@ import type {
   WorkflowValidatePayload,
 } from "../protocol.ts";
 import { acquireModelLocks } from "../../cli/repo_context.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import {
   resolveResumableRun,
   resolveSuspendedRun,
@@ -1162,8 +1163,11 @@ export async function handleWorkflowResume(
       }
     } finally {
       if (ctx.syncService) {
+        const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+          ? ctx.datastoreConfig.namespace
+          : undefined;
         try {
-          await ctx.syncService.pushChanged();
+          await ctx.syncService.pushChanged({ namespace });
         } catch (pushErr) {
           logger.warn(
             "Post-resume push failed; terminal status may be delayed: {error}",
@@ -1338,8 +1342,11 @@ export async function handleWorkflowResume(
       }
     } finally {
       if (ctx.syncService) {
+        const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+          ? ctx.datastoreConfig.namespace
+          : undefined;
         try {
-          await ctx.syncService.pushChanged();
+          await ctx.syncService.pushChanged({ namespace });
         } catch (pushErr) {
           logger.warn(
             "Post-resume push failed; terminal status may be delayed: {error}",


### PR DESCRIPTION
## Summary

- **Lock key fix**: `datastoreGlobalLockOptions` now returns `{ lockKey: ".datastore.lock", namespace }` instead of baking namespace into the key path (`.locks/{namespace}.lock`). Both `FileLock` and remote lock providers (S3/GCS) prefix the key under `{namespace}/`, keeping it within the namespace prefix so IAM-scoped credentials can access it.
- **pushChanged namespace propagation**: Pass namespace to all 14 `pushChanged()` call sites that previously omitted it — serve handlers (model create/delete, extension install/pull/rm/update, vault migrate, workflow resume), `executeWorkflowWithLocks`, and CLI commands (workflow run/resume, model create, serve, access token mint, datastore config migrate).
- **Extension contract**: Added `namespace` to `LockOptions` in both the domain type and the extension-facing type in `packages/testing`, and updated the test context's `createLock` to incorporate namespace into its lock key.

## Test Plan

- Updated `datastoreGlobalLockOptions` unit tests for new return shape
- Added `FileLock` namespace tests: directory scoping, concurrent namespace isolation, namespace+custom lockKey
- Updated `LockTimeoutError` tests for simplified `isGlobalDatastoreLock`
- All existing tests pass (repo_context: 60, file_lock: 20, distributed_lock: 7, lock: 38, test_context: 19)
- Verification workflow passed: lint, fmt, type-check, tests, compile, deps audit, code review, adversarial review, UX review (12/13 steps, 1 skipped by guard)
- Attestation posted to swamp-club

Closes swamp-club#1897

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>