### PR TITLE
fix(dashboard): branch device-login poll on HTTP status, not error string (swamp-club#1900)

### DIFF
--- a/packages/dashboard/src/views/Login.tsx
+++ b/packages/dashboard/src/views/Login.tsx
@@ -168,16 +168,35 @@ function OAuthLogin(
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ deviceCode: grant.deviceCode }),
         });
-        const data = await resp.json();
 
-        if (data.token) {
+        if (resp.status === 202) return;
+
+        let data: Record<string, string>;
+        try {
+          data = await resp.json();
+        } catch {
+          setError("Unexpected response from server. Please try again.");
+          setState("error");
+          return;
+        }
+
+        if (resp.ok && data.token) {
           onToken(data.token);
-        } else if (data.error === "expired_token") {
+        } else if (resp.status === 410) {
           setError("Login expired. Please try again.");
+          setState("error");
+        } else if (resp.status === 403) {
+          const message = data.reason
+            ? `${data.error}: ${data.reason}`
+            : data.error || "Access denied";
+          setError(message);
+          setState("error");
+        } else {
+          setError(data.error || "Login failed. Please try again.");
           setState("error");
         }
       } catch {
-        // keep polling
+        // network error — keep polling
       }
     }, (grant.interval || 5) * 1000);
 


### PR DESCRIPTION
## Summary

- Fix the dashboard OAuth device-login polling loop to branch on HTTP status codes instead of checking for an error string (`"expired_token"`) that the server never sends
- The server translates the OAuth error code to `"Device code expired"` before responding, so the client's string comparison never matched — all failure modes (expiry, denial, admission refusal, upstream errors) showed as an infinite "Waiting for you to approve..." spinner
- Now handles: `202` (keep polling), `200` + token (login), `410` (expired), `403` (denied with reason), and all others (generic error with message)

## Test plan

- [x] Verified existing `device_auth_handler_test.ts` (17 tests) confirms server response shapes align with the new client branching
- [x] Code review verdict: pass — correct status-code handling, proper interval cleanup on error, JSON parse resilience
- [x] All build checks pass (lint, fmt, type-check, tests, compile)

Closes swamp-club#1900

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Don O'Neill <sntxrr+github@gmail.com>