### PR TITLE
fix(cli): suppress missing-pulled-extensions warning during extension install (swamp-club#1762)

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -577,6 +577,20 @@ export interface DeferredWarning {
   error: string;
 }
 
+const MISSING_PULLED_EXTENSIONS_MARKER =
+  "pulled extension(s) have missing source files";
+
+/** @internal Exported for testing */
+export function shouldSuppressMissingExtensionsWarning(
+  commandInfo: CommandInvocationData,
+  warning: DeferredWarning,
+): boolean {
+  return commandInfo.command === "extension" &&
+    commandInfo.subcommand === "install" &&
+    warning.kind === "extensions" &&
+    warning.error.includes(MISSING_PULLED_EXTENSIONS_MARKER);
+}
+
 /**
  * Detects the "neither HOME nor USERPROFILE is set" failure raised by the
  * home-directory path helpers. Used to suppress the misleading per-kind
@@ -1371,6 +1385,15 @@ export async function runCli(args: string[]): Promise<void> {
       managedLockfilePath,
     );
     loaderSpan.end();
+
+    // Suppress missing-pulled-extensions warning during extension install (swamp-club#1762)
+    for (let i = deferredWarnings.length - 1; i >= 0; i--) {
+      if (
+        shouldSuppressMissingExtensionsWarning(commandInfo, deferredWarnings[i])
+      ) {
+        deferredWarnings.splice(i, 1);
+      }
+    }
   }
 
   // Resolve identity and scopes for SWAMP_API_KEY users. Calls whoami only

--- a/src/cli/mod_test.ts
+++ b/src/cli/mod_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals } from "@std/assert";
 import {
   commandNeedsLoaderSetup,
+  type DeferredWarning,
   isHookCommand,
   isLocalhostUrl,
   isTelemetryDisabledByConfig,
@@ -29,6 +30,7 @@ import {
   resolveModelsDir,
   resolveTelemetryEndpoint,
   resolveWorkflowsDir,
+  shouldSuppressMissingExtensionsWarning,
 } from "./mod.ts";
 import { extractCommandInfo } from "./telemetry_integration.ts";
 
@@ -691,6 +693,87 @@ Deno.test("isHookCommand: returns false for model command", () => {
 Deno.test("isHookCommand: returns false for empty args", () => {
   assertEquals(
     isHookCommand(extractCommandInfo([])),
+    false,
+  );
+});
+
+// shouldSuppressMissingExtensionsWarning tests
+
+const missingPulledWarning: DeferredWarning = {
+  kind: "extensions",
+  file: "models/upstream_extensions.json",
+  error:
+    "3 pulled extension(s) have missing source files: @foo/bar, @baz/qux, @a/b (e.g. .swamp/pulled-extensions/models/@foo/bar/mod.ts). Run 'swamp extension install' to restore them.",
+};
+
+const missingHomeWarning: DeferredWarning = {
+  kind: "extensions",
+  file: "",
+  error: "Extension loading is unavailable: no swamp data directory found",
+};
+
+const modelWarning: DeferredWarning = {
+  kind: "model",
+  file: "models/foo.ts",
+  error: "Failed to load user model",
+};
+
+Deno.test("shouldSuppressMissingExtensionsWarning: suppresses for extension install", () => {
+  assertEquals(
+    shouldSuppressMissingExtensionsWarning(
+      extractCommandInfo(["extension", "install"]),
+      missingPulledWarning,
+    ),
+    true,
+  );
+});
+
+Deno.test("shouldSuppressMissingExtensionsWarning: suppresses for extension install with flags", () => {
+  assertEquals(
+    shouldSuppressMissingExtensionsWarning(
+      extractCommandInfo(["--json", "extension", "install", "--quiet"]),
+      missingPulledWarning,
+    ),
+    true,
+  );
+});
+
+Deno.test("shouldSuppressMissingExtensionsWarning: does not suppress for extension pull", () => {
+  assertEquals(
+    shouldSuppressMissingExtensionsWarning(
+      extractCommandInfo(["extension", "pull"]),
+      missingPulledWarning,
+    ),
+    false,
+  );
+});
+
+Deno.test("shouldSuppressMissingExtensionsWarning: does not suppress for model run", () => {
+  assertEquals(
+    shouldSuppressMissingExtensionsWarning(
+      extractCommandInfo(["model", "method", "run"]),
+      missingPulledWarning,
+    ),
+    false,
+  );
+});
+
+Deno.test("shouldSuppressMissingExtensionsWarning: does not suppress missing-home warning during extension install", () => {
+  assertEquals(
+    shouldSuppressMissingExtensionsWarning(
+      extractCommandInfo(["extension", "install"]),
+      missingHomeWarning,
+    ),
+    false,
+  );
+});
+
+Deno.test("shouldSuppressMissingExtensionsWarning: does not suppress non-extensions warnings", () => {
+  assertEquals(
+    shouldSuppressMissingExtensionsWarning(
+      extractCommandInfo(["extension", "install"]),
+      modelWarning,
+    ),
     false,
   );
 });


### PR DESCRIPTION
## Summary

- Suppress the boot-time `[WRN] N pulled extension(s) have missing source files` warning when the invoked command is `swamp extension install` — the command that restores those files
- The warning is self-referential and creates noise in CI logs and first-run output (downstream consumers were working around it with brittle `awk` filters)
- Detection logic in `checkForMissingPulledExtensions` is preserved; only the user-facing emission is filtered

Closes swamp-club#1762

## Test Plan

- 6 new unit tests for `shouldSuppressMissingExtensionsWarning` covering positive and negative cases
- Verification workflow passed: lint, fmt, type-check, tests (73 passed), compile, code review (VERDICT: pass)