### PR TITLE
feat(cli): warn to reload serve after extension changes via --server

### DIFF
--- a/design/primitives/serve.md
+++ b/design/primitives/serve.md
@@ -368,7 +368,10 @@ reconciliation loop after `--stale-ttl`.
   `src/serve/boot_reconciliation.ts`).
 - The config poller does not reload extension type registries; new or changed
   extension types need `swamp serve reload` or a restart
-  (`src/cli/commands/serve.ts`, `ConfigPoller` wiring).
+  (`src/cli/commands/serve.ts`, `ConfigPoller` wiring). State-modifying
+  extension commands (`pull`, `install`, `rm`, `update`) warn the user after
+  a successful `--server` operation that `swamp serve reload` is needed to
+  pick up the changes (`src/cli/remote_run.ts`, `warnServerReloadNeeded`).
 - Webhook verification schemes are a closed set; a provider that changes its
   signing convention needs a swamp release (`src/serve/webhook_verifiers.ts`,
   tracked in #716).

--- a/src/cli/commands/extension_install.ts
+++ b/src/cli/commands/extension_install.ts
@@ -37,6 +37,7 @@ import {
   requestServerResponse,
   resolveServerToken,
   resolveServeUrl,
+  warnServerReloadNeeded,
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { ExtensionInstallResponse } from "../../serve/protocol.ts";
@@ -93,6 +94,7 @@ export const extensionInstallCommand = withRemoteOptions(
       })(),
       renderer.handlers(),
     );
+    warnServerReloadNeeded(server);
     return;
   }
 

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -60,6 +60,7 @@ import {
   requestServerResponse,
   resolveServerToken,
   resolveServeUrl,
+  warnServerReloadNeeded,
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { ExtensionPullResponse } from "../../serve/protocol.ts";
@@ -257,6 +258,7 @@ export const extensionPullCommand = withRemoteOptions(
       })(),
       renderer.handlers(),
     );
+    warnServerReloadNeeded(server);
     return;
   }
 

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -47,6 +47,7 @@ import {
   requestServerResponse,
   resolveServerToken,
   resolveServeUrl,
+  warnServerReloadNeeded,
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { ExtensionRmResponse } from "../../serve/protocol.ts";
@@ -101,6 +102,7 @@ export const extensionRemoveCommand = withRemoteOptions(
       })(),
       renderer.handlers(),
     );
+    warnServerReloadNeeded(server);
     return;
   }
 

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -48,6 +48,7 @@ import {
   requestServerResponse,
   resolveServerToken,
   resolveServeUrl,
+  warnServerReloadNeeded,
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { ExtensionUpdateResponse } from "../../serve/protocol.ts";
@@ -109,6 +110,9 @@ export const extensionUpdateCommand = withRemoteOptions(
       })(),
       renderer.handlers(),
     );
+    if (!options.check) {
+      warnServerReloadNeeded(server);
+    }
     return;
   }
 

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -44,6 +44,7 @@ import { deserializeEvent } from "../serve/serializer.ts";
 import type { ServerCredentialRepository } from "../domain/auth/server_credential.ts";
 import { FileServerCredentialRepository } from "../infrastructure/persistence/server_credential_repository.ts";
 import { resolveExtraHeaders } from "../domain/auth/extra_headers.ts";
+import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 
 /**
  * Resolves the server URL from the `--server` flag with env var fallbacks.
@@ -346,6 +347,19 @@ export function withRemoteOptions<T extends AnyCommand>(command: T): T {
       "--ca-cert <path:string>",
       "Path to PEM-encoded CA certificate to trust for TLS connections to the server (env: SWAMP_CA_CERT)",
     ) as T;
+}
+
+/**
+ * Logs a warning after a state-modifying extension operation completes on a
+ * serve instance, reminding the user to reload so the running registries
+ * pick up the change.
+ */
+export function warnServerReloadNeeded(server: string): void {
+  const logger = getSwampLogger(["cli", "remote"]);
+  logger
+    .warn`Extension state changed on the serve instance — run ${
+    "swamp serve reload --server " + server
+  } to pick up the changes`;
 }
 
 /** Timeout for the health probe on connection failure (ms). */

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -33,6 +33,7 @@ import {
   resolveServeUrl,
   runModelMethodOverServer,
   runWorkflowOverServer,
+  warnServerReloadNeeded,
 } from "./remote_run.ts";
 import type { ServerCredential } from "../domain/auth/server_credential.ts";
 import type { ServerCredentialRepository } from "../domain/auth/server_credential.ts";
@@ -1304,4 +1305,10 @@ Deno.test("diagnoseTlsMessage: returns message for expired cert", () => {
 Deno.test("diagnoseTlsMessage: returns undefined for non-TLS errors", () => {
   assertEquals(diagnoseTlsMessage("connection refused"), undefined);
   assertEquals(diagnoseTlsMessage("DNS lookup failed"), undefined);
+});
+
+// ── warnServerReloadNeeded tests ──────────────────────────────────────
+
+Deno.test("warnServerReloadNeeded: does not throw", () => {
+  warnServerReloadNeeded("ws://127.0.0.1:9090");
 });


### PR DESCRIPTION
## Summary

- After a state-modifying extension command (`pull`, `install`, `rm`, `update`) completes on a serve instance via `--server`, log a warning reminding the user to run `swamp serve reload` so the running registries pick up the change
- The warning is suppressed for `extension update --check` since that mode is read-only
- Adds `warnServerReloadNeeded` helper to `src/cli/remote_run.ts` called from the `--server` success path of each command

Fixes swamp-club#1907

Co-authored-by: Simon Helson <shelson@users.noreply.github.com>

## Test plan

- [x] `deno check` passes on all modified files
- [x] `deno lint` passes on all modified files
- [x] `deno fmt` passes on all modified files
- [x] `deno run test src/cli/remote_run_test.ts` — 45 tests pass including new `warnServerReloadNeeded` smoke test
- [x] Verification workflow: build 9/9 passed, reviews 4/4 ran passed (2 skipped by guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)