### PR TITLE
fix(data): scope computeLatestFlags grouping by namespace and type (swamp-club#1914)

### DIFF
--- a/src/domain/data/data_query_service.ts
+++ b/src/domain/data/data_query_service.ts
@@ -60,7 +60,8 @@ const logger = getLogger(["swamp", "domain", "data", "query"]);
 export function computeLatestFlags(rows: CatalogRow[]): void {
   const groups = new Map<string, CatalogRow[]>();
   for (const row of rows) {
-    const key = `${row.model_id}\0${row.data_name}`;
+    const key =
+      `${row.namespace}\0${row.type_normalized}\0${row.model_id}\0${row.data_name}`;
     let group = groups.get(key);
     if (!group) {
       group = [];

--- a/src/domain/data/data_query_service_test.ts
+++ b/src/domain/data/data_query_service_test.ts
@@ -1916,3 +1916,25 @@ Deno.test("computeLatestFlags: model-method as latest version demotes everything
   assertEquals(latestRows[0].version, 3);
   assertEquals(latestRows[0].step_name, "");
 });
+
+Deno.test("computeLatestFlags: different namespaces keep independent is_latest", () => {
+  const rows: CatalogRow[] = [
+    makeRow({ namespace: "local", version: 1 }),
+    makeRow({ namespace: "foreign", version: 3 }),
+  ];
+  computeLatestFlags(rows);
+
+  assertEquals(rows[0].is_latest, 1);
+  assertEquals(rows[1].is_latest, 1);
+});
+
+Deno.test("computeLatestFlags: different type_normalized keep independent is_latest", () => {
+  const rows: CatalogRow[] = [
+    makeRow({ type_normalized: "model-a", version: 1 }),
+    makeRow({ type_normalized: "model-b", version: 3 }),
+  ];
+  computeLatestFlags(rows);
+
+  assertEquals(rows[0].is_latest, 1);
+  assertEquals(rows[1].is_latest, 1);
+});

--- a/src/infrastructure/persistence/catalog_store_test.ts
+++ b/src/infrastructure/persistence/catalog_store_test.ts
@@ -1380,3 +1380,31 @@ Deno.test("enforceUniqueLatest: no-op when catalog is clean", () => {
 
   store.close();
 });
+
+Deno.test("enforceUniqueLatest: does not demote foreign namespace rows with same model_id and data_name", () => {
+  const dbPath = makeTempDbPath();
+  const store = new CatalogStore(dbPath);
+
+  store.upsert(makeRow({ namespace: "local", version: 1, is_latest: 1 }));
+  store.bulkUpsertForeign("foreign", [
+    makeRow({ namespace: "foreign", version: 3, is_latest: 1 }),
+  ]);
+
+  const demoted = store.enforceUniqueLatest(computeLatestFlags);
+  assertEquals(demoted, 0);
+
+  const localLatest = store.findLatestRow(
+    "test-model-name",
+    "my-data",
+    "local",
+  );
+  assertEquals(localLatest?.version, 1);
+  const foreignLatest = store.findLatestRow(
+    "test-model-name",
+    "my-data",
+    "foreign",
+  );
+  assertEquals(foreignLatest?.version, 3);
+
+  store.close();
+});


### PR DESCRIPTION
## Summary

- Fixes `computeLatestFlags` grouping by `(model_id, data_name)` without namespace or type_normalized, causing `enforceUniqueLatest` to incorrectly demote foreign namespace rows that share the same model_id and data_name
- Adds `namespace` and `type_normalized` to the grouping key, aligning it with the catalog primary key `(namespace, type_normalized, model_id, data_name, version)` and with `countDuplicateLatest`'s grouping
- Adds cross-namespace unit tests for `computeLatestFlags` and an integration test for `enforceUniqueLatest` with foreign namespace rows

## Test plan

- [x] New unit test: `computeLatestFlags: different namespaces keep independent is_latest`
- [x] New unit test: `computeLatestFlags: different type_normalized keep independent is_latest`
- [x] New integration test: `enforceUniqueLatest: does not demote foreign namespace rows with same model_id and data_name`
- [x] All existing tests pass (10,899 passed, 0 failed)
- [x] Verification workflow green (lint, fmt, type-check, test, compile, code review, adversarial review)

Closes swamp-club#1914

🤖 Generated with [Claude Code](https://claude.com/claude-code)