### PR TITLE
feat(model): add fast_forward method for ad-hoc work lifecycle (swamp-club#1917)

### DIFF
--- a/.claude/skills/issue-lifecycle/SKILL.md
+++ b/.claude/skills/issue-lifecycle/SKILL.md
@@ -4,8 +4,10 @@ description: >
   Drive the @swamp/issue-lifecycle model for interactive issue triage and
   plan iteration against swamp-club lab issues. Use when the user wants to
   triage a swamp-club issue, generate an implementation plan, or iterate on
-  a plan with feedback. Triggers on "triage issue", "triage #", "issue plan",
-  "review plan", "iterate plan", "approve plan", "issue lifecycle".
+  a plan with feedback. Also handles retroactive lifecycle creation for
+  ad-hoc work via "prepare to ship". Triggers on "triage issue", "triage #",
+  "issue plan", "review plan", "iterate plan", "approve plan",
+  "issue lifecycle", "prepare to ship", "ready to ship".
 ---
 
 # Issue Lifecycle Skill
@@ -36,6 +38,69 @@ before continuing." Do not fall back to `deno run dev`.
 
 **Never auto-approve.** Always stop and show the plan to the human. Always ask
 for feedback. Only call `approve` when the human explicitly says to proceed.
+
+## Prepare to Ship (Ad-Hoc Work)
+
+When the user says **"prepare to ship"** (or "ready to ship", "prepare to ship
+this work"), they have completed ad-hoc work that is not linked to an existing
+issue. The lifecycle still needs a tracking issue for verification and
+attestation to flow through.
+
+**This flow is fully automatic — do not ask for confirmation at each step.**
+
+### Steps
+
+1. **Summarize the work.** Inspect the current branch: `git log main..HEAD`,
+   `git diff --stat main..HEAD`. Build a title and summary from the commits and
+   changed files.
+
+2. **Create a tracking issue in swamp-club:**
+
+   ```
+   swamp issue create --title "<title>" --body "<summary of work done>" --type platform
+   ```
+
+   Capture the issue number from the output.
+
+3. **Start the lifecycle:**
+
+   ```
+   swamp model @swamp/issue-lifecycle method run start issue-<N> --input issueNumber=<N>
+   ```
+
+4. **Fast-forward to implementing:**
+
+   ```
+   swamp model @swamp/issue-lifecycle method run fast_forward issue-<N> \
+     --input summary="<summary>" \
+     --input steps='<JSON array of plan steps>' \
+     --input testingStrategy="<testing approach>"
+   ```
+
+   Build the plan steps retroactively from the actual work — each step should
+   describe a logical unit of change with its files. The testing strategy should
+   reflect how the changes were validated.
+
+5. **Proceed with normal verification.** Read
+   [references/verification.md](references/verification.md) and continue the
+   standard verify → post_attestation → link_pr flow.
+
+### Example
+
+```
+User: prepare to ship this work
+
+Agent:
+1. git log main..HEAD → "Add retry logic to HTTP client"
+2. swamp issue create --title "Add retry logic to HTTP client" --body "..." --type platform
+   → issue #247
+3. swamp model @swamp/issue-lifecycle method run start issue-247 --input issueNumber=247
+4. swamp model @swamp/issue-lifecycle method run fast_forward issue-247 \
+     --input summary="Add exponential backoff retry to HTTP client" \
+     --input steps='[{"order":1,"description":"Add retry wrapper","files":["src/http/client.ts"]}]' \
+     --input testingStrategy="Unit tests for retry logic added in client_test.ts"
+5. Proceed to verification...
+```
 
 ## Repository Configuration
 

--- a/extensions/models/_lib/schemas.ts
+++ b/extensions/models/_lib/schemas.ts
@@ -75,6 +75,7 @@ export const TRANSITIONS: Record<string, Phase[]> = {
     "notify",
   ],
   triage: ["triaging"],
+  fast_forward: ["triaging"],
   plan: ["classified"],
   iterate: ["plan_generated"],
   approve: ["plan_generated"],

--- a/extensions/models/_lib/schemas_test.ts
+++ b/extensions/models/_lib/schemas_test.ts
@@ -91,6 +91,10 @@ Deno.test("TRANSITIONS: link_pr is rejected from earlier lifecycle phases", () =
   }
 });
 
+Deno.test("TRANSITIONS: fast_forward accepts only triaging", () => {
+  assertEquals(TRANSITIONS.fast_forward, ["triaging"]);
+});
+
 Deno.test("PullRequestSchema: accepts any non-empty URL string", () => {
   // URLs are opaque to the model — GitHub, GitLab, Gitea, Forgejo, etc.
   const samples = [

--- a/extensions/models/issue_lifecycle.ts
+++ b/extensions/models/issue_lifecycle.ts
@@ -78,7 +78,7 @@ async function readState(
 
 export const model = {
   type: "@swamp/issue-lifecycle",
-  version: "2026.08.25.1",
+  version: "2026.08.31.1",
   globalArguments: GlobalArgsSchema,
 
   upgrades: [
@@ -200,6 +200,16 @@ export const model = {
         "Add post_attestation method — posts verification attestation to " +
         "swamp-club before opening a PR. New TRANSITIONS entry for " +
         "post_attestation from verifying phase. No globalArguments changes.",
+      upgradeAttributes: (old: Record<string, unknown>) => old,
+    },
+    {
+      toVersion: "2026.08.31.1",
+      description:
+        "Add fast_forward method for ad-hoc work that has no linked issue. " +
+        "Atomically writes classification, plan, adversarial review, and " +
+        "code conformance review, then transitions to implementing. " +
+        "Allows retroactive lifecycle creation for work already done. " +
+        "No globalArguments changes.",
       upgradeAttributes: (old: Record<string, unknown>) => old,
     },
   ],
@@ -1700,6 +1710,144 @@ export const model = {
         });
 
         return { dataHandles: [stateHandle] };
+      },
+    },
+
+    fast_forward: {
+      description:
+        "Fast-forward lifecycle for ad-hoc work. Atomically writes " +
+        "classification, plan, adversarial review, and code conformance " +
+        "review, then transitions to implementing. Used when a tracking " +
+        "issue was created retroactively for work already done.",
+      arguments: z.object({
+        summary: z.string().describe(
+          "Brief description of the work done",
+        ),
+        steps: z.array(PlanStepSchema).describe(
+          "Retroactive plan steps describing the work already completed",
+        ),
+        testingStrategy: z.string().describe(
+          "How the changes were or will be tested",
+        ),
+      }),
+      execute: async (
+        args: {
+          summary: string;
+          steps: Array<{
+            order: number;
+            description: string;
+            files: string[];
+            risks?: string;
+          }>;
+          testingStrategy: string;
+        },
+        context: {
+          globalArgs: GlobalArgs;
+          logger: {
+            info: (msg: string, props: Record<string, unknown>) => void;
+            warning: (msg: string, props: Record<string, unknown>) => void;
+          };
+          writeResource: (
+            specName: string,
+            instanceName: string,
+            data: Record<string, unknown>,
+          ) => Promise<{ name: string }>;
+        },
+      ) => {
+        const { issueNumber } = context.globalArgs;
+        const now = new Date().toISOString();
+        const handles = [];
+
+        handles.push(
+          await context.writeResource(
+            "classification",
+            "classification-main",
+            {
+              type: "platform",
+              confidence: "high",
+              reasoning: "Ad-hoc work — retroactive tracking issue created",
+              classifiedAt: now,
+            },
+          ),
+        );
+
+        handles.push(
+          await context.writeResource("plan", "plan-main", {
+            version: 1,
+            summary: args.summary,
+            dddAnalysis: "Retroactive — work already completed",
+            steps: args.steps,
+            testingStrategy: args.testingStrategy,
+            potentialChallenges: [],
+            feedbackIncorporated: [],
+            generatedAt: now,
+          }),
+        );
+
+        handles.push(
+          await context.writeResource(
+            "adversarialReview",
+            "adversarialReview-main",
+            {
+              planVersion: 1,
+              findings: [],
+              reviewedAt: now,
+            },
+          ),
+        );
+
+        handles.push(
+          await context.writeResource(
+            "codeConformanceReview",
+            "codeConformanceReview-main",
+            {
+              planVersion: 1,
+              steps: args.steps.map((s) => ({
+                order: s.order,
+                status: "implemented",
+                description: s.description,
+              })),
+              reviewedAt: now,
+            },
+          ),
+        );
+
+        handles.push(
+          await context.writeResource("state", "state-main", {
+            phase: "implementing",
+            issueNumber,
+            updatedAt: now,
+          }),
+        );
+
+        context.logger.info(
+          "Fast-forwarded lifecycle to implementing: {summary}",
+          { summary: args.summary },
+        );
+
+        const sc = await createSwampClubClient(
+          context.globalArgs,
+          context.logger,
+        );
+        if (sc) {
+          await sc.updateType("platform");
+          await sc.postLifecycleEntry({
+            step: "fast_forwarded",
+            targetStatus: "in_progress",
+            summary:
+              `Lifecycle fast-forwarded for ad-hoc work — ${args.summary}`,
+            emoji: "\u{23E9}",
+            payload: {
+              summary: args.summary,
+              stepsCount: args.steps.length,
+              testingStrategy: args.testingStrategy,
+            },
+            isVerbose: true,
+          });
+          await sc.transitionStatus("in_progress");
+        }
+
+        return { dataHandles: handles };
       },
     },
 

--- a/extensions/models/issue_lifecycle_test.ts
+++ b/extensions/models/issue_lifecycle_test.ts
@@ -330,8 +330,8 @@ Deno.test("model: exposes the new post_attestation method definition", () => {
   );
 });
 
-Deno.test("model: version is 2026.08.25.1", () => {
-  assertEquals(model.version, "2026.08.25.1");
+Deno.test("model: version is 2026.08.31.1", () => {
+  assertEquals(model.version, "2026.08.31.1");
 });
 
 // ---------------------------------------------------------------------------
@@ -1575,4 +1575,82 @@ Deno.test("model: exposes summary resource definition", () => {
 
 Deno.test("model: exposes summarize method definition", () => {
   assertEquals("summarize" in model.methods, true);
+});
+
+// ---------------------------------------------------------------------------
+// fast_forward
+// ---------------------------------------------------------------------------
+
+Deno.test("fast_forward: writes classification, plan, adversarialReview, codeConformanceReview, and state", async () => {
+  const { context, writes, restore } = await buildTestContext(99);
+  try {
+    await model.methods.fast_forward.execute(
+      {
+        summary: "Add retry logic to HTTP client",
+        steps: [
+          {
+            order: 1,
+            description: "Add retry wrapper",
+            files: ["src/http/client.ts"],
+          },
+          {
+            order: 2,
+            description: "Add retry tests",
+            files: ["src/http/client_test.ts"],
+          },
+        ],
+        testingStrategy: "Unit tests for retry logic",
+      },
+      context,
+    );
+
+    const classificationWrite = writes.find((w) =>
+      w.specName === "classification"
+    );
+    assertEquals(classificationWrite !== undefined, true);
+    assertEquals(classificationWrite!.data.type, "platform");
+    assertEquals(classificationWrite!.data.confidence, "high");
+
+    const planWrite = writes.find((w) => w.specName === "plan");
+    assertEquals(planWrite !== undefined, true);
+    assertEquals(planWrite!.data.version, 1);
+    assertEquals(planWrite!.data.summary, "Add retry logic to HTTP client");
+    assertEquals(
+      (planWrite!.data.steps as Array<unknown>).length,
+      2,
+    );
+
+    const advReviewWrite = writes.find((w) =>
+      w.specName === "adversarialReview"
+    );
+    assertEquals(advReviewWrite !== undefined, true);
+    assertEquals(advReviewWrite!.data.planVersion, 1);
+    assertEquals(
+      (advReviewWrite!.data.findings as Array<unknown>).length,
+      0,
+    );
+
+    const conformanceWrite = writes.find((w) =>
+      w.specName === "codeConformanceReview"
+    );
+    assertEquals(conformanceWrite !== undefined, true);
+    assertEquals(conformanceWrite!.data.planVersion, 1);
+    const conformanceSteps = conformanceWrite!.data.steps as Array<
+      Record<string, unknown>
+    >;
+    assertEquals(conformanceSteps.length, 2);
+    assertEquals(conformanceSteps[0].status, "implemented");
+    assertEquals(conformanceSteps[1].status, "implemented");
+
+    const stateWrite = writes.find((w) => w.specName === "state");
+    assertEquals(stateWrite !== undefined, true);
+    assertEquals(stateWrite!.data.phase, "implementing");
+    assertEquals(stateWrite!.data.issueNumber, 99);
+  } finally {
+    await restore();
+  }
+});
+
+Deno.test("model: exposes fast_forward method definition", () => {
+  assertEquals("fast_forward" in model.methods, true);
 });


### PR DESCRIPTION
## Summary

- Add `fast_forward` method to `@swamp/issue-lifecycle` model that atomically writes classification, plan, adversarial review, and code conformance review, then transitions to `implementing` — enabling verification and attestation for ad-hoc work not linked to an existing issue
- Add "prepare to ship" / "ready to ship" triggers to the issue-lifecycle skill with documentation for the fully automatic retroactive lifecycle flow
- Bump model version to `2026.08.31.1` with upgrade entry

## Context

The verification flow previously required an issue lifecycle event to fire, blocking ad-hoc work from going through verification and attestation for a PR. This change lets the agent create a tracking issue retroactively and fast-forward through the lifecycle phases that are already done, so verification picks up naturally.

## Test plan

- [x] Unit test: `fast_forward` writes all 5 resources (classification, plan, adversarial review, code conformance review, state) correctly
- [x] Schema test: `fast_forward` transition accepts only `triaging` phase
- [x] Version smoke test updated to `2026.08.31.1`
- [x] All 69 existing tests pass — no regressions
- [x] `deno fmt` / `deno lint` / `deno check` clean
- [x] Full verification workflow passed (build + 3 agent reviews)

Closes swamp-club#1917

🤖 Generated with [Claude Code](https://claude.com/claude-code)