### PR TITLE
fix(reports): remove verification-attestation from default workflow reports (swamp-club#1918)

### DIFF
--- a/src/domain/reports/builtin/mod.ts
+++ b/src/domain/reports/builtin/mod.ts
@@ -28,7 +28,6 @@ export const BUILTIN_METHOD_REPORTS = ["@swamp/method-summary"];
 /** Built-in workflow-scope report names injected as candidates at call sites. */
 export const BUILTIN_WORKFLOW_REPORTS = [
   "@swamp/workflow-summary",
-  "@swamp/verification-attestation",
 ];
 
 // Register built-in reports (guarded to be idempotent across re-imports)

--- a/src/domain/reports/report_types.ts
+++ b/src/domain/reports/report_types.ts
@@ -27,6 +27,7 @@ import { reportRegistry } from "./report_registry.ts";
 const BUILTIN_NAMES = new Set([
   ...BUILTIN_METHOD_REPORTS,
   ...BUILTIN_WORKFLOW_REPORTS,
+  "@swamp/verification-attestation",
 ]);
 
 export interface ReportTypeInfo {

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -3366,8 +3366,6 @@ Deno.test("CONTRACT: success run emits events in exact order", async () => {
       // (swamp-club#640) — builtin workflow reports emit here.
       "report_started",
       "report_completed",
-      "report_started",
-      "report_completed",
       "completed",
     ]);
   });
@@ -3408,8 +3406,6 @@ Deno.test("CONTRACT: step failure emits events in exact order", async () => {
       "job_completed",
       // Workflow-scope reports run even without reportFilterOptions
       // (swamp-club#640) — builtin workflow reports emit here.
-      "report_started",
-      "report_completed",
       "report_started",
       "report_completed",
       "completed",

--- a/verification/workflow-verify-build.yaml
+++ b/verification/workflow-verify-build.yaml
@@ -21,6 +21,10 @@ inputs:
     - commit
     - branch
 
+reports:
+  require:
+    - "@swamp/verification-attestation"
+
 concurrency: 4
 
 jobs:


### PR DESCRIPTION
## Summary

- Remove `@swamp/verification-attestation` from `BUILTIN_WORKFLOW_REPORTS` so it no longer runs automatically on every workflow execution
- Add explicit `reports.require` to the `verify-build` workflow so the verification flow still produces attestations
- Keep the report in `BUILTIN_NAMES` so it remains marked as a built-in report in listings
- Update CONTRACT event-ordering tests for the reduced default report count

Closes swamp-club#1918

## Test plan

- [x] All 10,901 unit tests pass (2 CONTRACT tests updated)
- [x] Build verification: lint, fmt, type-check, tests, compile all pass
- [x] Code review: VERDICT pass
- [x] Adversarial review: VERDICT pass
- [x] Verified attestation report still emits on verify-build workflow via explicit require

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>