### PR TITLE
fix(extensions): match cross-OS catalog rows in doctor repair pruning (swamp-club#1903)

### DIFF
--- a/src/infrastructure/persistence/extension_catalog_store.ts
+++ b/src/infrastructure/persistence/extension_catalog_store.ts
@@ -857,6 +857,20 @@ export class ExtensionCatalogStore {
   }
 
   /**
+   * Removes a bundle type entry by exact raw source_path — the value
+   * stored as the PK in the database, without re-canonicalizing. Use
+   * this when the caller already holds the raw row value from
+   * {@link findAll} and the stored PK may have been canonicalized by a
+   * different OS (e.g. WSL wrote mixed-case paths that Windows's
+   * {@link canonicalizePath} lowercases, breaking PK lookups).
+   */
+  removeByRawSourcePath(rawSourcePath: string): void {
+    this.db.prepare(
+      "DELETE FROM bundle_types WHERE source_path = ?",
+    ).run(rawSourcePath);
+  }
+
+  /**
    * Returns rows whose source_path starts with the given prefix.
    * Used by the hot-reload path to find catalog rows belonging to a
    * pulled extension regardless of whether extension_name is populated.

--- a/src/infrastructure/persistence/extension_catalog_store_test.ts
+++ b/src/infrastructure/persistence/extension_catalog_store_test.ts
@@ -2493,3 +2493,41 @@ Deno.test("removeBySourcePath: deletes by canonicalized path", () => {
   assertEquals(store.count(), 0);
   store.close();
 });
+
+Deno.test("removeByRawSourcePath: deletes by exact stored PK without canonicalizing", () => {
+  const dbPath = makeTempDbPath();
+  const store = new ExtensionCatalogStore(dbPath);
+
+  // Insert a row with a non-canonical path directly via SQL, simulating
+  // a WSL-written row (POSIX canonicalizePath is identity → mixed case
+  // stored as-is). upsert() would canonicalize it, hiding the bug.
+  const db = new DatabaseSync(dbPath);
+  const mixedCasePath =
+    "/mnt/c/Project/Repos/my-repo/extensions/models/MyModel.ts";
+  db.prepare(
+    `INSERT INTO bundle_types (source_path, type_normalized, kind, bundle_path,
+       extension_name, extension_version)
+     VALUES (?, '@ns/my-model', 'model', '/fake/bundle.js',
+       '@local/my-repo', '1.0.0')`,
+  ).run(mixedCasePath);
+  db.close();
+
+  assertEquals(store.count(), 1);
+
+  // removeBySourcePath canonicalizes → lowercases → misses the row
+  store.removeBySourcePath(mixedCasePath.toLowerCase());
+  assertEquals(
+    store.count(),
+    1,
+    "removeBySourcePath should miss non-canonical PK",
+  );
+
+  // removeByRawSourcePath uses the exact stored PK → succeeds
+  store.removeByRawSourcePath(mixedCasePath);
+  assertEquals(
+    store.count(),
+    0,
+    "removeByRawSourcePath should delete by exact PK",
+  );
+  store.close();
+});

--- a/src/infrastructure/persistence/extension_repository.ts
+++ b/src/infrastructure/persistence/extension_repository.ts
@@ -360,17 +360,27 @@ export class ExtensionRepository {
   }
 
   /**
-   * Deletes catalog rows by source path. Used by the W6 repair service
-   * to prune Tombstoned rows. Runs inside a single transaction for
-   * atomicity. Returns the count of rows that actually existed and
-   * were deleted (not the input count).
+   * Deletes catalog rows by canonical source path. Used by the W6
+   * repair service to prune Tombstoned and unreachable rows.
+   *
+   * Matches by canonical form rather than PK lookup so cross-OS
+   * catalog rows are found: a row written on WSL/Linux (where
+   * canonicalizePath is identity, preserving case) stores a mixed-case
+   * PK that Windows's canonicalizePath (lowercase) won't match via
+   * `findBySourcePath`. Iterating `findAll()` and comparing canonical
+   * forms closes the gap; deletion uses the raw PK value so the
+   * DELETE hits the actual stored row.
+   *
+   * Runs inside a single transaction for atomicity. Returns the count
+   * of rows actually deleted.
    */
   deleteBySourcePaths(paths: readonly string[]): number {
+    const targetSet = new Set(paths.map(canonicalizePath));
     let deleted = 0;
     this.catalog.runInTransaction(() => {
-      for (const p of paths) {
-        if (this.catalog.findBySourcePath(p)) {
-          this.catalog.removeBySourcePath(p);
+      for (const row of this.catalog.findAll()) {
+        if (targetSet.has(canonicalizePath(row.source_path))) {
+          this.catalog.removeByRawSourcePath(row.source_path);
           deleted++;
         }
       }

--- a/src/infrastructure/persistence/extension_repository_test.ts
+++ b/src/infrastructure/persistence/extension_repository_test.ts
@@ -24,6 +24,7 @@ import {
   assertStringIncludes,
   assertThrows,
 } from "@std/assert";
+import { DatabaseSync } from "node:sqlite";
 import { canonicalizePath } from "./canonicalize_path.ts";
 import { assertPathEquals } from "./path_test_helpers.ts";
 import { ensureDirSync } from "@std/fs";
@@ -1206,6 +1207,87 @@ Deno.test(
       assertEquals(conflicts[0].localSourcePath, localPath);
     }, {
       lockedVersions: fixedLockedVersions({ "@ns/ext": "2026.03.01.1" }),
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// deleteBySourcePaths — cross-OS canonical-mismatch fix (swamp-club#1903)
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "deleteBySourcePaths: deletes same-OS canonical rows",
+  () => {
+    withRepository((repo, catalog, repoRoot) => {
+      const sourcePath = canonicalizePath(
+        join(repoRoot, "extensions", "models", "echo.ts"),
+      );
+      catalog.upsertWithIdentity({
+        source_path: sourcePath,
+        type_normalized: "@ns/echo",
+        kind: "model",
+        bundle_path: join(repoRoot, ".swamp", "bundles", "echo.js"),
+        version: "1.0.0",
+        description: "",
+        extends_type: "",
+        source_mtime: "",
+        source_fingerprint: "",
+        state: "Tombstoned",
+        extension_name: "@local/test",
+        extension_version: "1.0.0",
+      });
+      assertEquals(catalog.count(), 1);
+
+      const deleted = repo.deleteBySourcePaths([sourcePath]);
+      assertEquals(deleted, 1);
+      assertEquals(catalog.count(), 0);
+    });
+  },
+);
+
+Deno.test({
+  name: "deleteBySourcePaths: deletes cross-OS rows with non-canonical PKs",
+  ignore: Deno.build.os !== "windows",
+  fn() {
+    withRepository((_repo, catalog, repoRoot) => {
+      // Insert a row with a mixed-case PK directly via SQL, simulating
+      // a WSL-written catalog row (POSIX canonicalizePath is identity,
+      // so mixed case is stored as-is). On Windows, canonicalizePath
+      // lowercases, creating a mismatch between the stored PK and the
+      // canonical lookup form. This test verifies the fix.
+      const db = new DatabaseSync(
+        join(repoRoot, ".swamp", "_extension_catalog.db"),
+      );
+      const wslPath =
+        "/mnt/c/Project/Repos/my-repo/extensions/models/MyModel.ts";
+      db.prepare(
+        `INSERT INTO bundle_types
+           (source_path, type_normalized, kind, bundle_path,
+            extension_name, extension_version, state)
+         VALUES (?, '@ns/my-model', 'model', '/fake/bundle.js',
+            '@local/my-repo', '1.0.0', 'Indexed')`,
+      ).run(wslPath);
+      db.close();
+
+      assertEquals(catalog.count(), 1);
+
+      // The caller passes the canonicalized (lowercased) form — this is
+      // what source.id.canonicalPath produces on Windows.
+      const canonicalForm = canonicalizePath(wslPath);
+      const deleted = _repo.deleteBySourcePaths([canonicalForm]);
+      assertEquals(deleted, 1, "should delete cross-OS non-canonical row");
+      assertEquals(catalog.count(), 0);
+    });
+  },
+});
+
+Deno.test(
+  "deleteBySourcePaths: returns 0 when no paths match",
+  () => {
+    withRepository((repo, catalog) => {
+      const deleted = repo.deleteBySourcePaths(["/nonexistent/path.ts"]);
+      assertEquals(deleted, 0);
+      assertEquals(catalog.count(), 0);
     });
   },
 );


### PR DESCRIPTION
## Summary

- Fix `deleteBySourcePaths` to handle cross-OS non-canonical catalog paths
  where rows written from WSL/Linux retain mixed-case `source_path` PKs that
  Windows's `canonicalizePath` (lowercase) can't match via PK lookup
- Rewrite to iterate `findAll()`, match by canonical form, and delete via new
  `removeByRawSourcePath` using the exact stored PK
- Add `removeByRawSourcePath` to `ExtensionCatalogStore` for deletion without
  re-canonicalizing

Closes swamp-club/lab#1903

## Test Plan

- [x] Unit test: `removeByRawSourcePath` deletes by exact stored PK (all platforms)
- [x] Unit test: `deleteBySourcePaths` deletes same-OS canonical rows (all platforms)
- [x] Unit test: `deleteBySourcePaths` deletes cross-OS non-canonical rows (Windows only)
- [x] Unit test: `deleteBySourcePaths` returns 0 when no paths match
- [x] All existing doctor repair, aggregate, catalog store, and repository tests pass
- [x] Verification workflow: lint, fmt, type-check, tests, compile, code review, adversarial review all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Cato Jensen <catjen@users.noreply.github.com>