### PR TITLE
fix(dashboard): guard device-token poll to prevent overlapping requests (swamp-club#1899)

### DIFF
--- a/packages/dashboard/src/views/Login.tsx
+++ b/packages/dashboard/src/views/Login.tsx
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useSwamp } from "../client/SwampProvider";
 import { Logo } from "../components/Logo";
 
@@ -158,15 +158,22 @@ function OAuthLogin(
       });
   }, []);
 
+  const inFlight = useRef(false);
+
   useEffect(() => {
     if (!grant || state !== "waiting") return;
 
+    const ac = new AbortController();
+
     const interval = setInterval(async () => {
+      if (inFlight.current) return;
+      inFlight.current = true;
       try {
         const resp = await fetch("/auth/device/token", {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ deviceCode: grant.deviceCode }),
+          signal: ac.signal,
         });
 
         if (resp.status === 202) return;
@@ -195,12 +202,17 @@ function OAuthLogin(
           setError(data.error || "Login failed. Please try again.");
           setState("error");
         }
-      } catch {
-        // network error — keep polling
+      } catch (err: unknown) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+      } finally {
+        inFlight.current = false;
       }
     }, (grant.interval || 5) * 1000);
 
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      ac.abort();
+    };
   }, [grant, state, onToken]);
 
   return (

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -3751,7 +3751,10 @@ export const serveCommand = new Command()
         // Device authorization endpoints (OAuth mode only)
         if (authConfig.mode === "oauth" && authConfig.oauthClientId) {
           const url = new URL(req.url);
-          if (url.pathname === "/auth/device") {
+          if (
+            url.pathname === "/auth/device" ||
+            url.pathname === "/auth/device/token"
+          ) {
             const deviceRemoteAddr = trustProxy
               ? (req.headers.get("x-forwarded-for")
                 ?.split(",")[0]?.trim() ??


### PR DESCRIPTION
## Summary

- Add `useRef` in-flight guard and `AbortController` to the dashboard's OAuth device-token poll loop to prevent overlapping `fetch` requests that trigger a Deno HTTP runtime panic (`Expected to be last strong reference`)
- Extend server-side IP burst rate limiting to cover `/auth/device/token` (previously only `/auth/device` was gated) as defense-in-depth
- The CLI path (`swamp auth server-login`) is unaffected — it uses a sequential `while` loop with `await delay()`

Closes swamp-club#1899

## Test plan

- [x] Verification workflow: lint, fmt, type-check, tests, compile, deps audit all pass
- [x] Code review: pass (explicit route matching after reviewer caught `startsWith` being too broad)
- [x] UX review: pass (no user-facing behavior change)
- [ ] Manual: deploy to a test instance with OAuth and verify device-flow login completes without server panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhHdUpVqpuww5xhkXLMHjs