### PR TITLE
fix(extensions): add --extensions-dir to quality command for monorepo support (swamp-club#1915)

### DIFF
--- a/src/cli/commands/extension_quality.ts
+++ b/src/cli/commands/extension_quality.ts
@@ -32,6 +32,7 @@ import { createExtensionQualityRenderer } from "../../presentation/renderers/ext
 import {
   createContext,
   type GlobalOptions,
+  resolveExtensionsDir,
   resolveRepoDir,
 } from "../context.ts";
 import { requireInitializedRepoReadOnly } from "../repo_context.ts";
@@ -44,6 +45,7 @@ import { loadIdentity } from "../load_identity.ts";
 
 interface ExtensionQualityOptions extends GlobalOptions {
   repoDir?: string;
+  extensionsDir?: string;
 }
 
 /**
@@ -92,12 +94,17 @@ export const extensionQualityCommand = new Command()
     "--repo-dir <dir:string>",
     "Repository directory (env: SWAMP_REPO_DIR)",
   )
+  .option(
+    "--extensions-dir <dir:string>",
+    "Extensions source directory (env: SWAMP_EXTENSIONS_DIR)",
+  )
   .action(
     async function (options: ExtensionQualityOptions, manifestPath: string) {
       const cliCtx = createContext(options, ["extension", "quality"]);
       cliCtx.logger.debug`Starting extension quality`;
 
       const repoDir = resolveRepoDir(options.repoDir);
+      const extensionsDir = resolveExtensionsDir(options.extensionsDir);
       if (isPulledExtensionManifest(repoDir, manifestPath)) {
         throw new UserError(
           "Cannot run quality on a pulled extension. Pulled extensions are read-only " +
@@ -116,6 +123,7 @@ export const extensionQualityCommand = new Command()
         manifestPath,
         repoContext,
         logger: cliCtx.logger,
+        extensionsDir,
       });
 
       const absoluteManifestPath = resolve(repoDir, manifestPath);

--- a/src/cli/resolve_extension_files.ts
+++ b/src/cli/resolve_extension_files.ts
@@ -251,6 +251,11 @@ export async function resolveExtensionFiles(
     }
   }
 
+  const monorepoHint = useManifestBase
+    ? ""
+    : "\nIf your extension is in a monorepo subdirectory, use --extensions-dir " +
+      "to set the resolution base, or add paths.base: manifest to the manifest.";
+
   // 3. Collect model files from manifest
   const modelEntryPoints: string[] = [];
   for (const modelRef of manifest.models) {
@@ -259,7 +264,8 @@ export async function resolveExtensionFiles(
       await Deno.stat(modelPath);
     } catch {
       throw new UserError(
-        `Model file not found: ${modelRef} (expected at ${modelPath})`,
+        `Model file not found: ${modelRef} (expected at ${modelPath})` +
+          monorepoHint,
       );
     }
     modelEntryPoints.push(modelPath);
@@ -300,7 +306,7 @@ export async function resolveExtensionFiles(
         throw new UserError(
           `Workflow file not found: ${wfRef} (looked in ${
             wfCandidateDirs.join(", ")
-          })`,
+          })` + monorepoHint,
         );
       }
       // Derive a unique archive name from the manifest reference directory
@@ -369,7 +375,8 @@ export async function resolveExtensionFiles(
       await Deno.stat(vaultPath);
     } catch {
       throw new UserError(
-        `Vault file not found: ${vaultRef} (expected at ${vaultPath})`,
+        `Vault file not found: ${vaultRef} (expected at ${vaultPath})` +
+          monorepoHint,
       );
     }
     vaultEntryPoints.push(vaultPath);
@@ -393,7 +400,8 @@ export async function resolveExtensionFiles(
       await Deno.stat(driverPath);
     } catch {
       throw new UserError(
-        `Driver file not found: ${driverRef} (expected at ${driverPath})`,
+        `Driver file not found: ${driverRef} (expected at ${driverPath})` +
+          monorepoHint,
       );
     }
     driverEntryPoints.push(driverPath);
@@ -417,7 +425,8 @@ export async function resolveExtensionFiles(
       await Deno.stat(datastorePath);
     } catch {
       throw new UserError(
-        `Datastore file not found: ${datastoreRef} (expected at ${datastorePath})`,
+        `Datastore file not found: ${datastoreRef} (expected at ${datastorePath})` +
+          monorepoHint,
       );
     }
     datastoreEntryPoints.push(datastorePath);
@@ -441,7 +450,8 @@ export async function resolveExtensionFiles(
       await Deno.stat(reportPath);
     } catch {
       throw new UserError(
-        `Report file not found: ${reportRef} (expected at ${reportPath})`,
+        `Report file not found: ${reportRef} (expected at ${reportPath})` +
+          monorepoHint,
       );
     }
     reportEntryPoints.push(reportPath);

--- a/src/cli/resolve_extension_files_test.ts
+++ b/src/cli/resolve_extension_files_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { stringify as stringifyYaml } from "@std/yaml";
 import { getLogger } from "@logtape/logtape";
@@ -1445,5 +1445,81 @@ Deno.test("resolveExtensionFiles paths.base=typedDir allows models/ prefix in en
     assertEquals(result.modelEntryPoints, [
       join(modelsDir, "models", "project.ts"),
     ]);
+  });
+});
+
+// ── extensionsDir override (monorepo support) ────────────────────────────
+
+Deno.test("resolveExtensionFiles extensionsDir overrides repo root for typed-key resolution", async () => {
+  await withTempRepo(async (dir) => {
+    // Simulate monorepo: extension lives in a subdirectory with its own
+    // extensions/<type>/ tree, separate from the repo root's tree.
+    const extSubdir = join(dir, "my-datastore-ext");
+    const datastoresDir = join(extSubdir, "extensions", "datastores");
+    await Deno.mkdir(datastoresDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(datastoresDir, "my_store.ts"),
+      'export const type = "my_store";',
+    );
+
+    const manifestPath = join(extSubdir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/monorepo-ds",
+        version: "2026.08.31.1",
+        datastores: ["my_store.ts"],
+      }),
+    );
+
+    const result = await resolveExtensionFiles({
+      repoDir: dir,
+      manifestPath,
+      repoContext: stubRepoContext,
+      logger,
+      extensionsDir: extSubdir,
+    });
+
+    assertEquals(result.datastoresDir, datastoresDir);
+    assertEquals(result.datastoreEntryPoints, [
+      join(datastoresDir, "my_store.ts"),
+    ]);
+  });
+});
+
+Deno.test("resolveExtensionFiles without extensionsDir fails for monorepo datastore", async () => {
+  await withTempRepo(async (dir) => {
+    const extSubdir = join(dir, "my-datastore-ext");
+    const datastoresDir = join(extSubdir, "extensions", "datastores");
+    await Deno.mkdir(datastoresDir, { recursive: true });
+    await Deno.writeTextFile(
+      join(datastoresDir, "my_store.ts"),
+      'export const type = "my_store";',
+    );
+
+    const manifestPath = join(extSubdir, "manifest.yaml");
+    await Deno.writeTextFile(
+      manifestPath,
+      stringifyYaml({
+        manifestVersion: 1,
+        name: "@test/monorepo-ds-fail",
+        version: "2026.08.31.1",
+        datastores: ["my_store.ts"],
+      }),
+    );
+
+    const err = await assertRejects(
+      () =>
+        resolveExtensionFiles({
+          repoDir: dir,
+          manifestPath,
+          repoContext: stubRepoContext,
+          logger,
+        }),
+      UserError,
+    );
+    assertStringIncludes(err.message, "Datastore file not found");
+    assertStringIncludes(err.message, "--extensions-dir");
   });
 });


### PR DESCRIPTION
## Summary

- Add `--extensions-dir` flag to `swamp extension quality` (parity with push and fmt) so monorepo vendored extensions can specify their resolution base
- Improve all typed-key "file not found" error messages to suggest `--extensions-dir` or `paths.base: manifest` for monorepo layouts
- Add unit tests verifying `extensionsDir` override resolves correctly and error messages include hints

Fixes swamp-club#1915 — reported by @magistr

## Test plan

- [x] New test: `extensionsDir` overrides repo root for typed-key resolution (monorepo scenario)
- [x] New test: error message includes `--extensions-dir` hint when resolution fails without it
- [x] All 48 existing resolve_extension_files tests pass
- [x] Full verification: lint, fmt, type-check, tests, compile, code review, adversarial review, ux review — all passed
- [x] Attestation posted: `e74bb639-9352-43cf-b0a4-b65814317517`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: magistr <magistr@users.noreply.github.com>