### PR TITLE
feat(verification): add verify-skills workflow for local skill checks (swamp-club#1870)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1071,6 +1071,9 @@ jobs:
           check_hash "ci-security-review prompt" '.configIntegrity.prompts."ci-security-review"' "verification/review-prompts/ci-security-review.md"
           check_hash "verify-build workflow" '.configIntegrity.workflows."verify-build"' "verification/workflow-verify-build.yaml"
           check_hash "verify-reviews workflow" '.configIntegrity.workflows."verify-reviews"' "verification/workflow-verify-reviews.yaml"
+          check_hash "verify-skills workflow" '.configIntegrity.workflows."verify-skills"' "verification/workflow-verify-skills.yaml"
+          check_hash "review-skills script" '.configIntegrity.scripts."review-skills"' "scripts/review_skills.ts"
+          check_hash "eval-skill-triggers config" '.configIntegrity.scripts."eval-skill-triggers"' "evals/promptfoo/package.json"
 
           # -- 6. Steps summary table --
           {

--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -70,17 +70,49 @@ The claude CLI authenticates via one of two methods:
 2. **claude.ai login** — if no env file exists, the CLI uses your existing
    claude.ai login. No additional setup needed.
 
+The skill verification workflow also needs:
+
+- **`TESSL_TOKEN`** — for `deno task review-skills` (calls `npx tessl`). Add it
+  to `verify.env`. If missing, skill review is skipped gracefully (exit 0).
+- **`ANTHROPIC_API_KEY`** — for `deno task eval-skill-triggers` (calls the
+  Anthropic API). Already available from `verify.env` or claude.ai login. If
+  missing, trigger evals are skipped gracefully (exit 0).
+
 To create the env file (optional):
 
 ```
-echo "ANTHROPIC_API_KEY=sk-ant-..." > ~/.config/swamp/verify.env
+cat > ~/.config/swamp/verify.env << 'EOF'
+ANTHROPIC_API_KEY=sk-ant-...
+TESSL_TOKEN=tsk-...
+EOF
 chmod 600 ~/.config/swamp/verify.env
 ```
 
-## Running Both in Parallel
+## Skill Verification (Host Workflow)
 
-The agent launches the build and review workflows simultaneously. Both must
-pass for verification to succeed.
+Skill checks run as a swamp workflow on the host, following the same worktree
+pattern as the build and review workflows. Isolation comes from a fresh
+`git worktree` at the verified commit in `/tmp/swamp-verify-skills-<run-id>`.
+
+```
+SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-skills \
+  --input commit=<SHA> \
+  --input branch=<branch>
+```
+
+The workflow detects changed files and guards both steps behind a skill-path
+filter (`.claude/skills/**`, `CLAUDE.md`, `scripts/review_skills.ts`,
+`evals/promptfoo/**`). When no skill files changed, both steps are skipped.
+
+| Step | Command | Env Var | Skip Behavior |
+| --- | --- | --- | --- |
+| skill-review | `deno task review-skills` | `TESSL_TOKEN` | Skipped (exit 0) if missing |
+| skill-trigger-eval | `deno task eval-skill-triggers` | `ANTHROPIC_API_KEY` | Skipped (exit 0) if missing |
+
+## Running All Three in Parallel
+
+The agent launches the build, review, and skill workflows simultaneously. All
+three must pass for verification to succeed.
 
 After each workflow completes, present the commands to the user so they can
 inspect the attestations. Use `--input commit=<SHA>` to find the correct run
@@ -92,10 +124,13 @@ SWAMP_WORKFLOWS_DIR=verification swamp workflow history search \
   --workflow verify-build --input commit=<SHA> --json
 SWAMP_WORKFLOWS_DIR=verification swamp workflow history search \
   --workflow verify-reviews --input commit=<SHA> --json
+SWAMP_WORKFLOWS_DIR=verification swamp workflow history search \
+  --workflow verify-skills --input commit=<SHA> --json
 
 # 2. Get detailed step data (duration, status, data artifacts)
 SWAMP_WORKFLOWS_DIR=verification swamp workflow history get <build-run-id> --json
 SWAMP_WORKFLOWS_DIR=verification swamp workflow history get <reviews-run-id> --json
+SWAMP_WORKFLOWS_DIR=verification swamp workflow history get <skills-run-id> --json
 
 # 3. Read step output (e.g. review findings or build errors)
 SWAMP_WORKFLOWS_DIR=verification swamp data get \
@@ -104,9 +139,9 @@ SWAMP_WORKFLOWS_DIR=verification swamp data get \
 
 ## Verification Checklist
 
-After both workflows complete, the agent constructs a **combined verification
-checklist** from the two workflow run outputs and presents it to the user. This
-is the single view of everything that ran.
+After all three workflows complete, the agent constructs a **combined
+verification checklist** from the workflow run outputs and presents it to the
+user. This is the single view of everything that ran.
 
 ```
 Verification Checklist (commit <short-sha>)
@@ -138,8 +173,12 @@ Verification Checklist (commit <short-sha>)
 ○ CI Security Review
   ○ review           review-ci-security  —     skipped (no workflow changes)
 
-Gate: 8/8 passed, 3 skipped (guard)
-Total: 1m 45s
+✓ Skill Review
+  ✓ skill-review     skills-review      5.2s
+  ✓ skill-trigger-eval skills-trigger-eval 42.0s
+
+Gate: 10/10 passed, 3 skipped (guard)
+Total: 2m 15s
 ```
 
 To construct this checklist:
@@ -150,6 +189,8 @@ To construct this checklist:
      --workflow verify-build --input commit=<SHA> --json
    SWAMP_WORKFLOWS_DIR=verification swamp workflow history search \
      --workflow verify-reviews --input commit=<SHA> --json
+   SWAMP_WORKFLOWS_DIR=verification swamp workflow history search \
+     --workflow verify-skills --input commit=<SHA> --json
    ```
    The `--input commit=<SHA>` filter ensures you get the correct run when
    multiple verifications run in parallel across worktrees.
@@ -158,6 +199,7 @@ To construct this checklist:
    ```
    SWAMP_WORKFLOWS_DIR=verification swamp workflow history get <build-run-id> --json
    SWAMP_WORKFLOWS_DIR=verification swamp workflow history get <reviews-run-id> --json
+   SWAMP_WORKFLOWS_DIR=verification swamp workflow history get <skills-run-id> --json
    ```
    The `history get` output includes per-step `duration` (in ms) and status.
 
@@ -206,7 +248,12 @@ To construct this checklist:
        },
        "workflows": {
          "verify-build": "<sha256 of verification/workflow-verify-build.yaml>",
-         "verify-reviews": "<sha256 of verification/workflow-verify-reviews.yaml>"
+         "verify-reviews": "<sha256 of verification/workflow-verify-reviews.yaml>",
+         "verify-skills": "<sha256 of verification/workflow-verify-skills.yaml>"
+       },
+       "scripts": {
+         "review-skills": "<sha256 of scripts/review_skills.ts>",
+         "eval-skill-triggers": "<sha256 of evals/promptfoo/package.json>"
        }
      },
      "reviewConfig": {
@@ -238,33 +285,49 @@ To construct this checklist:
          "model": "review-ux",
          "status": "skipped",
          "reason": "guard: no UX changes"
+       },
+       {
+         "job": "skills",
+         "step": "skill-review",
+         "model": "skills-review",
+         "status": "succeeded",
+         "durationMs": 5200
+       },
+       {
+         "job": "skills",
+         "step": "skill-trigger-eval",
+         "model": "skills-trigger-eval",
+         "status": "succeeded",
+         "durationMs": 42000
        }
      ],
      "gate": {
        "allPassed": true,
-       "stepsCompleted": 8,
-       "stepsTotal": 11,
+       "stepsCompleted": 10,
+       "stepsTotal": 13,
        "stepsSkipped": 3
      },
      "timing": {
        "startedAt": "<ISO 8601>",
        "completedAt": "<ISO 8601>",
-       "totalDurationMs": 105000
+       "totalDurationMs": 135000
      },
      "runs": {
        "build": "<workflow-run-id>",
-       "reviews": "<workflow-run-id>"
+       "reviews": "<workflow-run-id>",
+       "skills": "<workflow-run-id>"
      }
    }
    ```
 
-   The `configIntegrity` section proves the review prompts, workflows, and
-   CLAUDE.md used match the versions at the verified commit. Anyone can
-   checkout that commit, hash the files, and verify they match. Compute
-   hashes with:
+   The `configIntegrity` section proves the review prompts, workflows, skill
+   scripts, and CLAUDE.md used match the versions at the verified commit.
+   Anyone can checkout that commit, hash the files, and verify they match.
+   Compute hashes with:
 
    ```bash
-   sha256sum CLAUDE.md verification/review-prompts/*.md verification/workflow-verify-*.yaml
+   sha256sum CLAUDE.md verification/review-prompts/*.md verification/workflow-verify-*.yaml \
+     scripts/review_skills.ts evals/promptfoo/package.json
    ```
 
 6. Present the checklist AND the workflow run file paths to the user so they
@@ -273,6 +336,7 @@ To construct this checklist:
    ```
    Build run:  .swamp/workflow-runs/<id>/workflow-run-<build-run-id>.yaml
    Review run: .swamp/workflow-runs/<id>/workflow-run-<review-run-id>.yaml
+   Skills run: .swamp/workflow-runs/<id>/workflow-run-<skills-run-id>.yaml
    ```
 
 7. Determine the overall result. **Only call `verification_passed` when
@@ -327,6 +391,10 @@ user what went wrong and what you're going to do:
   I'll address each finding and re-run verification."
 - **Compile errors**: "Compilation failed. I'll fix the build error and
   re-run."
+- **Skill review failures**: "Skill review scored below 90% threshold. I'll
+  update the skill and re-run verification."
+- **Skill trigger eval failures**: "Trigger eval pass rate below threshold.
+  I'll fix the trigger config and re-run verification."
 
 ### 2. Read the failure details
 
@@ -352,6 +420,12 @@ SWAMP_WORKFLOWS_DIR=verification swamp data get \
   --workflow verify-reviews --run <run-id> log --json
 ```
 
+For skill check output, query the skills workflow:
+```bash
+SWAMP_WORKFLOWS_DIR=verification swamp data get \
+  --workflow verify-skills --run <run-id> log --json
+```
+
 ### 3. Fix the issues
 
 - **Lint errors**: run `deno lint` locally, fix the flagged issues
@@ -362,6 +436,10 @@ SWAMP_WORKFLOWS_DIR=verification swamp data get \
 - **Compile errors**: fix the build issue, run `deno task compile` locally
 - **Review blocking findings**: read each finding, fix the code issue,
   explain to the user what was changed and why
+- **Skill review failures**: update the skill content to improve the review
+  score, run `deno run review-skills` locally to verify
+- **Skill trigger eval failures**: check trigger config in
+  `evals/promptfoo/`, run `deno run eval-skill-triggers` locally to verify
 
 ### 4. Re-run verification
 
@@ -375,13 +453,17 @@ SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-build \
 SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-reviews \
   --input commit=$(git rev-parse HEAD) \
   --input branch=$(git branch --show-current)
+
+SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-skills \
+  --input commit=$(git rev-parse HEAD) \
+  --input branch=$(git branch --show-current)
 ```
 
 ### 5. Repeat until green
 
-Repeat steps 1–4 until all build steps pass and all reviews return
-`VERDICT: pass`. Present the full verification checklist to the user after
-each run.
+Repeat steps 1–4 until all build steps pass, all reviews return
+`VERDICT: pass`, and all skill checks pass or are skipped. Present the full
+verification checklist to the user after each run.
 
 Do NOT open a PR until the user has seen a fully green checklist,
 confirmed they want to proceed, and the attestation has been posted to

--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -73,7 +73,8 @@ The claude CLI authenticates via one of two methods:
 The skill verification workflow also needs:
 
 - **`TESSL_TOKEN`** — for `deno task review-skills` (calls `npx tessl`). Add it
-  to `verify.env`. If missing, skill review is skipped gracefully (exit 0).
+  to `verify.env`. If missing, skill review **fails** (exit 1) — an incomplete
+  verification is not a valid attestation.
 - **`ANTHROPIC_API_KEY`** — for `deno task eval-skill-triggers` (calls the
   Anthropic API). Already available from `verify.env` or claude.ai login. If
   missing, trigger evals are skipped gracefully (exit 0).
@@ -104,9 +105,9 @@ The workflow detects changed files and guards both steps behind a skill-path
 filter (`.claude/skills/**`, `CLAUDE.md`, `scripts/review_skills.ts`,
 `evals/promptfoo/**`). When no skill files changed, both steps are skipped.
 
-| Step | Command | Env Var | Skip Behavior |
+| Step | Command | Env Var | Missing Behavior |
 | --- | --- | --- | --- |
-| skill-review | `deno task review-skills` | `TESSL_TOKEN` | Skipped (exit 0) if missing |
+| skill-review | `deno task review-skills` | `TESSL_TOKEN` | **Fails** (exit 1) — must be configured |
 | skill-trigger-eval | `deno task eval-skill-triggers` | `ANTHROPIC_API_KEY` | Skipped (exit 0) if missing |
 
 ## Running All Three in Parallel

--- a/deno.json
+++ b/deno.json
@@ -15,7 +15,7 @@
     "audit": "deno run --allow-read --allow-net=api.osv.dev --allow-env=GITHUB_STEP_SUMMARY --allow-write scripts/audit_deps.ts",
     "sbom": "deno run --allow-read --allow-run --allow-net=api.jsr.io,registry.npmjs.org --allow-write=sbom.cdx.json,scripts/jsr_license_cache.json scripts/generate_sbom.ts",
     "audit-actions": "deno run --allow-read --allow-net=api.github.com --allow-env=GITHUB_STEP_SUMMARY,GITHUB_TOKEN --allow-write scripts/audit_actions.ts",
-    "review-skills": "deno run --allow-read --allow-run --allow-env=GITHUB_STEP_SUMMARY --allow-write scripts/review_skills.ts",
+    "review-skills": "deno run --allow-read --allow-run --allow-env=GITHUB_STEP_SUMMARY,TESSL_TOKEN --allow-write scripts/review_skills.ts",
     "eval-skill-triggers": "deno run --allow-read --allow-run --allow-env --allow-write --allow-net scripts/eval_skill_triggers_promptfoo.ts",
     "build-dashboard": "cd packages/dashboard && npm run build"
   },

--- a/scripts/review_skills.ts
+++ b/scripts/review_skills.ts
@@ -156,18 +156,11 @@ function buildSummaryTable(scores: SkillScore[], allPassed: boolean): string {
 
 async function main(): Promise<void> {
   if (!Deno.env.get("TESSL_TOKEN")) {
-    const message = "Skipping skill review: TESSL_TOKEN environment variable is not set.";
-    console.warn(message);
-
-    const summaryFile = Deno.env.get("GITHUB_STEP_SUMMARY");
-    if (summaryFile) {
-      await Deno.writeTextFile(
-        summaryFile,
-        "## Skill Review Results\n\n**Skipped** — `TESSL_TOKEN` not configured.\n",
-      );
-    }
-
-    return;
+    console.error(
+      "TESSL_TOKEN environment variable is not set. " +
+        "Add it to ~/.config/swamp/verify.env to run skill reviews.",
+    );
+    Deno.exit(1);
   }
 
   const assets = new SkillAssets();

--- a/scripts/review_skills.ts
+++ b/scripts/review_skills.ts
@@ -155,6 +155,21 @@ function buildSummaryTable(scores: SkillScore[], allPassed: boolean): string {
 }
 
 async function main(): Promise<void> {
+  if (!Deno.env.get("TESSL_TOKEN")) {
+    const message = "Skipping skill review: TESSL_TOKEN environment variable is not set.";
+    console.warn(message);
+
+    const summaryFile = Deno.env.get("GITHUB_STEP_SUMMARY");
+    if (summaryFile) {
+      await Deno.writeTextFile(
+        summaryFile,
+        "## Skill Review Results\n\n**Skipped** — `TESSL_TOKEN` not configured.\n",
+      );
+    }
+
+    return;
+  }
+
   const assets = new SkillAssets();
   const skillNames = assets.getSkillNames();
 

--- a/verification/workflow-verify-skills.yaml
+++ b/verification/workflow-verify-skills.yaml
@@ -1,0 +1,116 @@
+id: a1c3e5f7-8b2d-4f6a-9c0e-1d3f5a7b9c2e
+name: verify-skills
+description: |
+  Skill verification: review bundled skills for quality and run trigger/routing
+  evals. Gated by skill-path changes — skips when no skill files changed. Runs
+  on the host in a fresh git worktree checked out at the verified commit.
+version: 1
+
+tags:
+  purpose: pre-pr-verification
+
+inputs:
+  properties:
+    commit:
+      type: string
+      description: Commit SHA being verified.
+    branch:
+      type: string
+      description: Branch name being verified.
+  required:
+    - commit
+    - branch
+
+concurrency: 2
+
+jobs:
+  # ── Fresh Checkout ──────────────────────────────────────────
+  - name: setup
+    description: Create a clean worktree at the verified commit.
+    steps:
+      - name: checkout
+        task:
+          type: model_method
+          modelType: "command/shell"
+          modelName: skills-setup-${{ run.id }}
+          methodName: execute
+          inputs:
+            run: |
+              set -e
+              git fetch origin main
+              CHECKOUT_DIR="/tmp/swamp-verify-skills-${{ run.id }}"
+              rm -rf "$CHECKOUT_DIR"
+              git worktree prune
+              git worktree add --detach "$CHECKOUT_DIR" "${{ inputs.commit }}"
+
+  # ── Detect Changed Files ──────────────────────────────────────
+  - name: detect-changes
+    description: Compute changed file list for guard expressions.
+    dependsOn:
+      - job: setup
+        condition:
+          type: succeeded
+    steps:
+      - name: changed-files
+        task:
+          type: model_method
+          modelType: "@swamp/git"
+          modelName: repo
+          methodName: diff
+          inputs:
+            base: "origin/main"
+            nameOnly: true
+
+  # ── Skill Checks ─────────────────────────────────────────────
+  - name: skills
+    description: Run skill review and trigger evals, guarded by skill-path changes.
+    dependsOn:
+      - job: detect-changes
+        condition:
+          type: succeeded
+    steps:
+      - name: skill-review
+        guard: "${{ data.latest('repo', 'diff').attributes.files.filter(f, f.startsWith('.claude/skills/') || f == 'CLAUDE.md' || f == 'scripts/review_skills.ts' || f.startsWith('evals/promptfoo/')).size() == 0 }}"
+        task:
+          type: model_method
+          modelType: "command/shell"
+          modelName: skills-review-${{ run.id }}
+          methodName: execute
+          inputs:
+            run: "deno task review-skills"
+            workingDir: "/tmp/swamp-verify-skills-${{ run.id }}"
+
+      - name: skill-trigger-eval
+        guard: "${{ data.latest('repo', 'diff').attributes.files.filter(f, f.startsWith('.claude/skills/') || f == 'CLAUDE.md' || f == 'scripts/review_skills.ts' || f.startsWith('evals/promptfoo/')).size() == 0 }}"
+        task:
+          type: model_method
+          modelType: "command/shell"
+          modelName: skills-trigger-eval-${{ run.id }}
+          methodName: execute
+          inputs:
+            run: "deno task eval-skill-triggers"
+            workingDir: "/tmp/swamp-verify-skills-${{ run.id }}"
+
+  # ── Cleanup ──────────────────────────────────────────────────
+  - name: cleanup
+    description: Remove the temporary worktree.
+    dependsOn:
+      - job: skills
+        condition:
+          type: always
+    steps:
+      - name: remove-worktree
+        task:
+          type: model_method
+          modelType: "command/shell"
+          modelName: skills-cleanup-${{ run.id }}
+          methodName: execute
+          inputs:
+            run: |
+              CHECKOUT_DIR="/tmp/swamp-verify-skills-${{ run.id }}"
+              git worktree remove --force "$CHECKOUT_DIR" 2>/dev/null || true
+              git worktree prune
+              # Remove ephemeral auto-definitions created for this run
+              REPO_ROOT="$(git rev-parse --git-common-dir)/.."
+              find "$REPO_ROOT/.swamp/auto-definitions" -name "*-${{ run.id }}.yaml" -delete 2>/dev/null || true
+            ignoreExitCode: true


### PR DESCRIPTION
## Summary

- Add a new `verify-skills` workflow that runs skill review and trigger evals locally before PRs open, gated by skill-path changes (`.claude/skills/**`, `CLAUDE.md`, `scripts/review_skills.ts`, `evals/promptfoo/**`)
- Make `review_skills.ts` fail with a clear error when `TESSL_TOKEN` is missing — a silent skip would produce a green gate without actually running the skill check
- Extend attestation schema with skill step results, config integrity checksums for `scripts/review_skills.ts` and `evals/promptfoo/package.json`, and `verify-skills` workflow hash
- Update CI attestation validator with `check_hash` calls for the new config integrity files

## Test Plan

- [x] `verify-skills` workflow runs both skill-review and skill-trigger-eval when skill files changed
- [x] Guard expressions correctly skip steps when no skill files changed
- [x] `review_skills.ts` fails with clear error when `TESSL_TOKEN` is missing
- [x] Full verification (build + reviews + skills) passes on the committed changes
- [x] Attestation posted to swamp-club with new schema fields

Closes swamp-club#1870

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>