### PR TITLE
feat(cli): show remote mode indicator on server-targeted commands (swamp-club#1933)

### DIFF
--- a/design/enablers/remote-execution.md
+++ b/design/enablers/remote-execution.md
@@ -200,7 +200,10 @@ on all remote commands falls back to the `SWAMP_SERVE_URL` env var (or
 `SWAMP_SERVER_URL` as a secondary fallback) when not provided, so
 `export SWAMP_SERVE_URL=wss://demo.swamp-club.ai` avoids repeating the URL
 on every invocation. Precedence: `--server` flag > `SWAMP_SERVE_URL` >
-`SWAMP_SERVER_URL`.
+`SWAMP_SERVER_URL`. When a command dispatches to a remote server, a
+`Remote   <url>` indicator line is written to stderr before the first
+network I/O, so the user always knows the command is targeting a server
+rather than the local repository.
 
 When `--auth-mode token` is active, the server validates the token presented at
 WebSocket upgrade time via the `swamp/server-token` model's `redeem` method

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -45,6 +45,10 @@ import type { ServerCredentialRepository } from "../domain/auth/server_credentia
 import { FileServerCredentialRepository } from "../infrastructure/persistence/server_credential_repository.ts";
 import { resolveExtraHeaders } from "../domain/auth/extra_headers.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+import {
+  gutterLine,
+  STATUS_COLORS,
+} from "../presentation/output/console_writer.ts";
 
 /**
  * Resolves the server URL from the `--server` flag with env var fallbacks.
@@ -55,6 +59,10 @@ export function resolveServeUrl(
 ): string | undefined {
   return flagValue ?? Deno.env.get("SWAMP_SERVE_URL") ??
     Deno.env.get("SWAMP_SERVER_URL");
+}
+
+export function writeRemoteIndicator(serverUrl: string): void {
+  console.error(gutterLine("Remote", STATUS_COLORS.warn, serverUrl));
 }
 
 /** How long to keep draining after sending `cancel` before giving up. */
@@ -186,6 +194,7 @@ export function requestServerResponse<T>(
   options: RequestResponseOptions,
   request: { type: string; id?: string; payload?: unknown },
 ): Promise<T> {
+  writeRemoteIndicator(options.server);
   const baseUrl = normalizeServerUrl(options.server);
   const extraHeaders = options.headers ?? resolveExtraHeaders();
   const headers: Record<string, string> = { ...extraHeaders };
@@ -770,6 +779,7 @@ async function* streamServerRun(
   options: ServerRunOptions,
   request: OutboundRequest,
 ): AsyncIterable<{ kind: string; [key: string]: unknown }> {
+  writeRemoteIndicator(options.server);
   const state = { runId: undefined as string | undefined, lastSeq: 0 };
   let reconnectRetries = 0;
   let elsewhereRetries = 0;

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -34,6 +34,7 @@ import {
   runModelMethodOverServer,
   runWorkflowOverServer,
   warnServerReloadNeeded,
+  writeRemoteIndicator,
 } from "./remote_run.ts";
 import type { ServerCredential } from "../domain/auth/server_credential.ts";
 import type { ServerCredentialRepository } from "../domain/auth/server_credential.ts";
@@ -1311,4 +1312,37 @@ Deno.test("diagnoseTlsMessage: returns undefined for non-TLS errors", () => {
 
 Deno.test("warnServerReloadNeeded: does not throw", () => {
   warnServerReloadNeeded("ws://127.0.0.1:9090");
+});
+
+// ── writeRemoteIndicator tests ───────────────────────────────────────
+
+Deno.test("writeRemoteIndicator: writes server URL to stderr", () => {
+  const calls: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => {
+    calls.push(args.map(String).join(" "));
+  };
+  try {
+    writeRemoteIndicator("https://serve.example.com");
+    assertEquals(calls.length, 1);
+    assertStringIncludes(calls[0], "Remote");
+    assertStringIncludes(calls[0], "https://serve.example.com");
+  } finally {
+    console.error = originalError;
+  }
+});
+
+Deno.test("writeRemoteIndicator: includes ws URL verbatim", () => {
+  const calls: string[] = [];
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => {
+    calls.push(args.map(String).join(" "));
+  };
+  try {
+    writeRemoteIndicator("wss://internal.corp:4000");
+    assertEquals(calls.length, 1);
+    assertStringIncludes(calls[0], "wss://internal.corp:4000");
+  } finally {
+    console.error = originalError;
+  }
 });


### PR DESCRIPTION
## Summary

When a command dispatches to a remote swamp serve instance, a `Remote <url>` indicator line is now written to stderr before the first network I/O. This makes it immediately obvious that the command is targeting a server rather than the local repository — preventing accidental remote operations when `SWAMP_SERVE_URL` or `SWAMP_SERVER_URL` is set.

The indicator is centralized in the two remote dispatch entry points (`streamServerRun` and `requestServerResponse`) in `src/cli/remote_run.ts`, so all remote-capable commands get it automatically without touching any individual command files.

### Changes

- Added `writeRemoteIndicator()` helper using the existing gutter-line format with warn color
- Called from `streamServerRun` (covers all streaming commands) and `requestServerResponse` (covers all request-response commands)
- 2 unit tests for format and URL inclusion
- Updated `design/enablers/remote-execution.md` to document the indicator

## Test Plan

- `deno run test src/cli/remote_run_test.ts` — 47 tests pass, including 2 new tests for `writeRemoteIndicator`
- Verified the indicator appears in existing streaming and request-response test output
- Full verification workflow passed: lint, fmt, type-check, 10,901 tests, compile, deps audit, code review (VERDICT: pass)