### PR TITLE
fix(datastore): move catalog export outside global lock and add cooperative yielding (swamp-club#1932)

### DIFF
--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -1402,10 +1402,15 @@ export async function acquireModelLocks(
 }
 
 /**
- * Single-phase push: everything under the global lock (existing behavior).
+ * Single-phase push: catalog export outside the lock, pushChanged under it.
  *
- * Acquires the global lock, writes catalog export, calls `pushChanged`,
- * then releases. Used when the extension does not advertise `twoPhaseSync`.
+ * Writes the catalog export before acquiring the global lock, then acquires
+ * the lock and calls `pushChanged`. The export is a full snapshot of the
+ * local catalog — safe to write outside the lock because a later concurrent
+ * writer simply overwrites with a more complete snapshot (same reasoning as
+ * the two-phase path).
+ *
+ * Used when the extension does not advertise `twoPhaseSync`.
  */
 export async function flushSinglePhasePush(
   provider: DatastoreProvider,
@@ -1419,6 +1424,19 @@ export async function flushSinglePhasePush(
   progressWriter?: LockProgressWriter,
 ): Promise<void> {
   const write = progressWriter ?? defaultLockWriter;
+
+  // Write catalog export before acquiring the global lock so the
+  // synchronous SQLite read + JSON serialization doesn't hold the lock
+  // and block concurrent writers. Safe for the same reason as two-phase:
+  // the export is a full snapshot that a later writer simply overwrites.
+  await writeCatalogExportIfNeeded(
+    syncService,
+    config,
+    namespace,
+    catalogStore,
+    progressWriter,
+  );
+
   const pushLock = provider.createLock(
     config.datastorePath,
     {
@@ -1441,14 +1459,6 @@ export async function flushSinglePhasePush(
       );
     }
     write(dim("Pushing changes to datastore..."));
-
-    await writeCatalogExportIfNeeded(
-      syncService,
-      config,
-      namespace,
-      catalogStore,
-      progressWriter,
-    );
 
     let pushed: number | void;
     if (caps?.scopedSync) {

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -50,7 +50,11 @@ import {
   type DatastoreConfig,
   isCustomDatastoreConfig,
 } from "../domain/datastore/datastore_config.ts";
-import type { PushManifest } from "../domain/datastore/datastore_sync_service.ts";
+import type {
+  DatastoreSyncService,
+  PushManifest,
+} from "../domain/datastore/datastore_sync_service.ts";
+import { CatalogStore } from "../infrastructure/persistence/catalog_store.ts";
 import { LockTimeoutError } from "../domain/datastore/distributed_lock.ts";
 import { RepoPath } from "../domain/repo/repo_path.ts";
 import { RepoService } from "../domain/repo/repo_service.ts";
@@ -2369,4 +2373,89 @@ Deno.test("resolveManagedConfigPaths: custom modelsDir is used when managedConfi
     lockfilePath,
     join(repo, "custom", "models", "upstream_extensions.json"),
   );
+});
+
+// ── flushSinglePhasePush: catalog export ordering ──────────────────────────
+
+Deno.test("flushSinglePhasePush: writes catalog export before acquiring global lock", async () => {
+  const events: string[] = [];
+  const provider = createMockProvider(events);
+
+  const dir = await Deno.makeTempDir({ prefix: "swamp-export-order-test-" });
+  try {
+    const dbPath = join(dir, "_catalog.db");
+    const cachePath = join(dir, "cache");
+    await ensureDir(join(cachePath, "test-ns"));
+    const catalogStore = new CatalogStore(dbPath);
+    try {
+      catalogStore.upsert({
+        namespace: "test-ns",
+        type_normalized: "test-model",
+        model_id: "model-001",
+        data_name: "my-data",
+        id: "data-uuid-001",
+        version: 1,
+        is_latest: 1,
+        model_name: "test-model-name",
+        spec_name: "result",
+        data_type: "resource",
+        content_type: "application/json",
+        lifetime: "infinite",
+        owner_type: "model-method",
+        owner_ref: "",
+        workflow_run_id: "",
+        workflow_name: "",
+        job_name: "",
+        step_name: "",
+        source: "",
+        streaming: 0,
+        size: 256,
+        created_at: "2026-01-01T00:00:00.000Z",
+        tags: "{}",
+      });
+
+      const syncService: DatastoreSyncService = {
+        pullChanged: () => Promise.resolve(0),
+        pushChanged: () => {
+          events.push("pushChanged");
+          return Promise.resolve(0);
+        },
+        markDirty: () => {
+          events.push("markDirty");
+          return Promise.resolve();
+        },
+        capabilities: () => ({ scopedSync: true }),
+      };
+
+      await flushSinglePhasePush(
+        provider,
+        syncService,
+        { ...createMockConfig("test-ns"), cachePath },
+        { scopedSync: true },
+        [{ modelType: "test", modelId: "m1" }],
+        "test-ns",
+        catalogStore,
+        createMockLogger(),
+      );
+
+      const markDirtyIdx = events.indexOf("markDirty");
+      const lockAcquireIdx = events.indexOf("global-lock-acquire");
+      assertEquals(
+        markDirtyIdx < lockAcquireIdx,
+        true,
+        `catalog export (markDirty at ${markDirtyIdx}) should run before lock acquire (at ${lockAcquireIdx}): ${
+          JSON.stringify(events)
+        }`,
+      );
+
+      const exportPath = join(cachePath, "test-ns", ".catalog-export.json");
+      const content = await Deno.readTextFile(exportPath);
+      const parsed = JSON.parse(content);
+      assertEquals(parsed.length, 1);
+    } finally {
+      catalogStore.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
 });

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -74,7 +74,7 @@ import type {
   MarkDirtyHook,
 } from "../../domain/datastore/datastore_sync_service.ts";
 import { SWAMP_SUBDIRS, swampPath } from "./paths.ts";
-import { CatalogStore } from "./catalog_store.ts";
+import { CatalogStore, ITERATE_PAGE_SIZE } from "./catalog_store.ts";
 import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import { join } from "@std/path";
 
@@ -151,19 +151,44 @@ export function createCatalogStore(
  * namespace. The file contains all catalog rows for that namespace as a
  * flat JSON array. Extensions upload this file to the remote datastore
  * via {@link DatastoreSyncService.exportCatalog}.
+ *
+ * Uses cooperative yielding: iterates the catalog page by page, writing
+ * each row's JSON incrementally, and yields the event loop between pages
+ * so concurrent async work (HTTP handlers, WebSocket messages, workflow
+ * steps) is not starved by the synchronous SQLite reads.
  */
 export async function writeCatalogExport(
   catalogStore: CatalogStore,
   cachePath: string,
   namespace: string,
 ): Promise<number> {
-  const rows = [...catalogStore.iterateNamespace(namespace)];
   const exportPath = join(cachePath, namespace, ".catalog-export.json");
-  await Deno.writeTextFile(
-    exportPath,
-    JSON.stringify(rows, null, 2) + "\n",
-  );
-  return rows.length;
+  const encoder = new TextEncoder();
+  const file = await Deno.open(exportPath, {
+    write: true,
+    create: true,
+    truncate: true,
+  });
+  try {
+    let rowCount = 0;
+    let first = true;
+    await file.write(encoder.encode("[\n"));
+    for (const row of catalogStore.iterateNamespace(namespace)) {
+      if (!first) {
+        await file.write(encoder.encode(",\n"));
+      }
+      first = false;
+      await file.write(encoder.encode(JSON.stringify(row, null, 2)));
+      rowCount++;
+      if (rowCount % ITERATE_PAGE_SIZE === 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+    }
+    await file.write(encoder.encode("\n]\n"));
+    return rowCount;
+  } finally {
+    file.close();
+  }
 }
 
 // =============================================================================

--- a/src/infrastructure/persistence/repository_factory_test.ts
+++ b/src/infrastructure/persistence/repository_factory_test.ts
@@ -17,15 +17,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { join } from "@std/path";
 import {
   catalogDbPath,
   createRepositoryContext,
   createUnifiedDataRepository,
   namespaceFromResolver,
+  writeCatalogExport,
 } from "./repository_factory.ts";
-import { CatalogStore } from "./catalog_store.ts";
+import {
+  type CatalogRow,
+  CatalogStore,
+  ITERATE_PAGE_SIZE,
+} from "./catalog_store.ts";
 import {
   createNamespace,
   SOLO_NAMESPACE,
@@ -163,4 +168,167 @@ Deno.test("namespaceFromResolver: SOLO_NAMESPACE for no resolver or empty namesp
     path: "/ds",
   });
   assertEquals(namespaceFromResolver(solo), SOLO_NAMESPACE);
+});
+
+// ── writeCatalogExport ────────────────────────────────────────────────────────
+
+function makeRow(overrides: Partial<CatalogRow> = {}): CatalogRow {
+  return {
+    namespace: "test-ns",
+    type_normalized: "test-model",
+    model_id: "model-001",
+    data_name: "my-data",
+    id: "data-uuid-001",
+    version: 1,
+    is_latest: 1,
+    model_name: "test-model-name",
+    spec_name: "result",
+    data_type: "resource",
+    content_type: "application/json",
+    lifetime: "infinite",
+    owner_type: "model-method",
+    owner_ref: "",
+    workflow_run_id: "",
+    workflow_name: "",
+    job_name: "",
+    step_name: "",
+    source: "",
+    streaming: 0,
+    size: 256,
+    created_at: "2026-01-01T00:00:00.000Z",
+    tags: '{"type":"resource","specName":"result"}',
+    ...overrides,
+  };
+}
+
+function setupCatalogExportFixture(): {
+  store: CatalogStore;
+  cachePath: string;
+  cleanup: () => void;
+} {
+  const dir = Deno.makeTempDirSync({ prefix: "swamp-export-test-" });
+  const dbPath = join(dir, "_catalog.db");
+  const cachePath = join(dir, "cache");
+  Deno.mkdirSync(join(cachePath, "test-ns"), { recursive: true });
+  const store = new CatalogStore(dbPath);
+  return {
+    store,
+    cachePath,
+    cleanup: () => {
+      store.close();
+      try {
+        Deno.removeSync(dir, { recursive: true });
+      } catch { /* Windows EBUSY */ }
+    },
+  };
+}
+
+Deno.test("writeCatalogExport: empty namespace produces valid empty JSON array", async () => {
+  const { store, cachePath, cleanup } = setupCatalogExportFixture();
+  try {
+    const count = await writeCatalogExport(store, cachePath, "test-ns");
+    assertEquals(count, 0);
+    const content = await Deno.readTextFile(
+      join(cachePath, "test-ns", ".catalog-export.json"),
+    );
+    const parsed = JSON.parse(content);
+    assertEquals(parsed, []);
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("writeCatalogExport: single row produces valid JSON array", async () => {
+  const { store, cachePath, cleanup } = setupCatalogExportFixture();
+  try {
+    const row = makeRow();
+    store.upsert(row);
+    const count = await writeCatalogExport(store, cachePath, "test-ns");
+    assertEquals(count, 1);
+    const content = await Deno.readTextFile(
+      join(cachePath, "test-ns", ".catalog-export.json"),
+    );
+    const parsed = JSON.parse(content) as CatalogRow[];
+    assertEquals(parsed.length, 1);
+    assertEquals(parsed[0].namespace, "test-ns");
+    assertEquals(parsed[0].model_id, "model-001");
+    assertEquals(parsed[0].data_name, "my-data");
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("writeCatalogExport: multi-page namespace produces valid JSON", async () => {
+  const { store, cachePath, cleanup } = setupCatalogExportFixture();
+  try {
+    const totalRows = ITERATE_PAGE_SIZE + 50;
+    for (let i = 0; i < totalRows; i++) {
+      store.upsert(makeRow({
+        data_name: `data-${i}`,
+        version: 1,
+        id: `uuid-${i}`,
+      }));
+    }
+    const count = await writeCatalogExport(store, cachePath, "test-ns");
+    assertEquals(count, totalRows);
+    const content = await Deno.readTextFile(
+      join(cachePath, "test-ns", ".catalog-export.json"),
+    );
+    const parsed = JSON.parse(content) as CatalogRow[];
+    assertEquals(parsed.length, totalRows);
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("writeCatalogExport: round-trip equivalence with direct iteration", async () => {
+  const { store, cachePath, cleanup } = setupCatalogExportFixture();
+  try {
+    for (let i = 0; i < 5; i++) {
+      store.upsert(makeRow({
+        data_name: `item-${i}`,
+        version: 1,
+        id: `uuid-${i}`,
+        size: i * 100,
+      }));
+    }
+    await writeCatalogExport(store, cachePath, "test-ns");
+    const content = await Deno.readTextFile(
+      join(cachePath, "test-ns", ".catalog-export.json"),
+    );
+    const exported = JSON.parse(content) as CatalogRow[];
+    const direct = [...store.iterateNamespace("test-ns")];
+    assertEquals(exported.length, direct.length);
+    for (let i = 0; i < exported.length; i++) {
+      assertEquals(exported[i], direct[i]);
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("writeCatalogExport: yields event loop between pages", async () => {
+  const { store, cachePath, cleanup } = setupCatalogExportFixture();
+  try {
+    const totalRows = ITERATE_PAGE_SIZE * 2 + 1;
+    for (let i = 0; i < totalRows; i++) {
+      store.upsert(makeRow({
+        data_name: `data-${i}`,
+        version: 1,
+        id: `uuid-${i}`,
+      }));
+    }
+    let callbackRanDuringExport = false;
+    const exportPromise = writeCatalogExport(store, cachePath, "test-ns");
+    setTimeout(() => {
+      callbackRanDuringExport = true;
+    }, 0);
+    await exportPromise;
+    assert(
+      callbackRanDuringExport,
+      "setTimeout(0) callback should run during multi-page export",
+    );
+  } finally {
+    cleanup();
+  }
 });


### PR DESCRIPTION
## Summary

- Move `writeCatalogExportIfNeeded` before global lock acquisition in `flushSinglePhasePush`, matching what `flushTwoPhasePush` already does — the export is a full snapshot, safe to write outside the lock
- Rewrite `writeCatalogExport` to stream JSON page-by-page with cooperative yielding (`setTimeout(0)` between pages), so the event loop isn't blocked during synchronous SQLite reads
- Add 5 unit tests for `writeCatalogExport` (empty, single-row, multi-page, round-trip equivalence, event-loop yielding)
- Add ordering test verifying catalog export runs before lock acquisition in single-phase push

## Test plan

- [x] Unit tests: `deno run test src/infrastructure/persistence/repository_factory_test.ts` — 16 passed
- [x] Integration tests: `deno run test src/cli/repo_context_test.ts` — 61 passed
- [x] Full test suite: 10,905 passed, 0 failed
- [x] E2E: compiled binary, configured S3 datastore (MinIO) with namespace, ran model methods through serve, verified `.catalog-export.json` uploaded to S3 with valid JSON (8 rows, correct is_latest flags)
- [x] Verification workflows: build (9/9 passed), reviews (code-review pass, adversarial-review pass, ci-security pass)

Closes swamp-club#1932

🤖 Generated with [Claude Code](https://claude.com/claude-code)