### PR TITLE
feat(cli): add token list and revoke subcommands under `swamp auth token`

### DIFF
--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -25,13 +25,17 @@ import { authLogoutCommand } from "./auth_logout.ts";
 import { authWhoamiCommand } from "./auth_whoami.ts";
 import { authServerLoginCommand } from "./auth_server_login.ts";
 import { authTokenCreateCommand } from "./auth_token_create.ts";
+import { authTokenListCommand } from "./auth_token_list.ts";
+import { authTokenRevokeCommand } from "./auth_token_revoke.ts";
 
 export const authTokenCommand = new Command()
   .name("token")
   .description("Manage collective API tokens")
   .error(unknownCommandErrorHandler)
   .action(groupCommandAction)
-  .command("create", authTokenCreateCommand);
+  .command("create", authTokenCreateCommand)
+  .command("list", authTokenListCommand)
+  .command("revoke", authTokenRevokeCommand);
 
 export const authCommand = new Command()
   .name("auth")

--- a/src/cli/commands/auth_token_list.ts
+++ b/src/cli/commands/auth_token_list.ts
@@ -1,0 +1,106 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { isAuthenticated, isCollectiveToken } from "../auth_context.ts";
+import { loadIdentity } from "../load_identity.ts";
+import {
+  authTokenList,
+  type AuthTokenListData,
+  type AuthTokenListEvent,
+  consumeStream,
+  createAuthTokenListDeps,
+  createLibSwampContext,
+  withDefaults,
+} from "../../libswamp/mod.ts";
+import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import { renderAuthTokenList } from "../../presentation/output/auth_token_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const authTokenListCommand = new Command()
+  .name("list")
+  .description("List API tokens for a collective")
+  .option(
+    "--collective <collective:string>",
+    "Collective slug to list tokens for",
+    { required: true },
+  )
+  .example(
+    "List all tokens for a collective",
+    "swamp auth token list --collective myorg",
+  )
+  .example(
+    "List tokens in JSON format",
+    "swamp auth token list --collective myorg --json",
+  )
+  .action(async function (options: AnyOptions) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "auth",
+      "token",
+      "list",
+    ]);
+
+    if (!isAuthenticated()) {
+      throw new UserError(
+        "Listing collective tokens requires a personal swamp-club.com account.\n\n" +
+          "Sign in with:\n\n" +
+          "  swamp auth login\n",
+        "auth_required",
+      );
+    }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const identity = await loadIdentity();
+    const deps = createAuthTokenListDeps({
+      serverUrlOverride: Deno.env.get("SWAMP_CLUB_URL"),
+      identity,
+      isCollectiveToken,
+    });
+
+    let data: AuthTokenListData | undefined;
+
+    await consumeStream(
+      authTokenList(ctx, deps, {
+        collective: options.collective as string,
+      }),
+      withDefaults<AuthTokenListEvent>({
+        listing: (event) => {
+          if (cliCtx.outputMode === "log") {
+            writeOutput(
+              `Listing tokens for collective "${event.collective}"...`,
+            );
+          }
+        },
+        completed: (event) => {
+          data = event.data;
+        },
+        error: (event) => {
+          throw new UserError(event.error.message);
+        },
+      }),
+    );
+
+    if (data) {
+      renderAuthTokenList(data, cliCtx.outputMode);
+    }
+  });

--- a/src/cli/commands/auth_token_revoke.ts
+++ b/src/cli/commands/auth_token_revoke.ts
@@ -1,0 +1,108 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import { isAuthenticated, isCollectiveToken } from "../auth_context.ts";
+import { loadIdentity } from "../load_identity.ts";
+import {
+  authTokenRevoke,
+  type AuthTokenRevokeData,
+  type AuthTokenRevokeEvent,
+  consumeStream,
+  createAuthTokenRevokeDeps,
+  createLibSwampContext,
+  withDefaults,
+} from "../../libswamp/mod.ts";
+import { UserError } from "../../domain/errors.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import { renderAuthTokenRevoke } from "../../presentation/output/auth_token_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const authTokenRevokeCommand = new Command()
+  .name("revoke")
+  .description("Revoke an API token for a collective")
+  .option(
+    "--collective <collective:string>",
+    "Collective slug the token belongs to",
+    { required: true },
+  )
+  .arguments("<token-id:string>")
+  .example(
+    "Revoke a token by ID",
+    "swamp auth token revoke tok-abc123 --collective myorg",
+  )
+  .example(
+    "Revoke a token with JSON output",
+    "swamp auth token revoke tok-abc123 --collective myorg --json",
+  )
+  .action(async function (options: AnyOptions, tokenId: string) {
+    const cliCtx = createContext(options as GlobalOptions, [
+      "auth",
+      "token",
+      "revoke",
+    ]);
+
+    if (!isAuthenticated()) {
+      throw new UserError(
+        "Revoking collective tokens requires a personal swamp-club.com account.\n\n" +
+          "Sign in with:\n\n" +
+          "  swamp auth login\n",
+        "auth_required",
+      );
+    }
+
+    const ctx = createLibSwampContext({ logger: cliCtx.logger });
+    const identity = await loadIdentity();
+    const deps = createAuthTokenRevokeDeps({
+      serverUrlOverride: Deno.env.get("SWAMP_CLUB_URL"),
+      identity,
+      isCollectiveToken,
+    });
+
+    let data: AuthTokenRevokeData | undefined;
+
+    await consumeStream(
+      authTokenRevoke(ctx, deps, {
+        collective: options.collective as string,
+        tokenId,
+      }),
+      withDefaults<AuthTokenRevokeEvent>({
+        revoking: (event) => {
+          if (cliCtx.outputMode === "log") {
+            writeOutput(
+              `Revoking token "${event.tokenId}" from collective "${event.collective}"...`,
+            );
+          }
+        },
+        completed: (event) => {
+          data = event.data;
+        },
+        error: (event) => {
+          throw new UserError(event.error.message);
+        },
+      }),
+    );
+
+    if (data) {
+      renderAuthTokenRevoke(data, cliCtx.outputMode);
+    }
+  });

--- a/src/infrastructure/http/swamp_club_client.ts
+++ b/src/infrastructure/http/swamp_club_client.ts
@@ -27,19 +27,32 @@ import type { GenesisPass } from "../../domain/quest/genesis_pass.ts";
 
 export type { ClientIdentity };
 
+/** Metadata fields shared by all collective token responses (never includes the secret key). */
+export interface CollectiveTokenMetadata {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  enabled: boolean;
+  expiresAt: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+  scopes: string[];
+}
+
 /** Response from creating a collective API token. */
 export interface CreateCollectiveTokenResponse {
-  token: {
-    id: string;
-    name: string;
-    keyPrefix: string;
-    enabled: boolean;
-    expiresAt: string | null;
-    createdAt: string;
-    lastUsedAt: string | null;
-    scopes: string[];
-  };
+  token: CollectiveTokenMetadata;
   key: string;
+}
+
+/** Response from listing collective API tokens — metadata only, no secrets. */
+export interface ListCollectiveTokensResponse {
+  tokens: CollectiveTokenMetadata[];
+}
+
+/** Response from revoking a collective API token — metadata only, no secrets. */
+export interface RevokeCollectiveTokenResponse {
+  token: CollectiveTokenMetadata;
 }
 
 /** Response from BetterAuth sign-in endpoint. */
@@ -725,6 +738,91 @@ export class SwampClubClient {
       }
       throw new UserError(
         `Failed to create collective token (HTTP ${res.status}): ${text}`,
+      );
+    }
+
+    return await res.json();
+  }
+
+  async listCollectiveTokens(
+    apiKey: string,
+    collectiveSlug: string,
+    signal?: AbortSignal,
+  ): Promise<ListCollectiveTokensResponse> {
+    const res = await this.fetch(
+      `/api/v1/collectives/${encodeURIComponent(collectiveSlug)}/api-tokens`,
+      {
+        method: "GET",
+        headers: {
+          "x-api-key": apiKey,
+        },
+      },
+      signal,
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      if (res.status === 401) {
+        throw new UserError(
+          "Not authenticated. Sign in with `swamp auth login`.",
+        );
+      }
+      if (res.status === 403) {
+        throw new UserError(
+          `You do not have permission to list tokens for collective "${collectiveSlug}". Only owners and admins can manage collective API tokens.`,
+        );
+      }
+      if (res.status === 404) {
+        throw new UserError(
+          `Collective "${collectiveSlug}" not found.`,
+        );
+      }
+      throw new UserError(
+        `Failed to list collective tokens (HTTP ${res.status}): ${text}`,
+      );
+    }
+
+    return await res.json();
+  }
+
+  async revokeCollectiveToken(
+    apiKey: string,
+    collectiveSlug: string,
+    tokenId: string,
+    signal?: AbortSignal,
+  ): Promise<RevokeCollectiveTokenResponse> {
+    const res = await this.fetch(
+      `/api/v1/collectives/${encodeURIComponent(collectiveSlug)}/api-tokens/${
+        encodeURIComponent(tokenId)
+      }`,
+      {
+        method: "DELETE",
+        headers: {
+          "x-api-key": apiKey,
+        },
+      },
+      signal,
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      if (res.status === 401) {
+        throw new UserError(
+          "Not authenticated. Sign in with `swamp auth login`.",
+        );
+      }
+      if (res.status === 403) {
+        throw new UserError(
+          `You do not have permission to revoke tokens for collective "${collectiveSlug}". Only owners and admins can manage collective API tokens.`,
+        );
+      }
+      if (res.status === 404) {
+        throw new UserError(
+          `Token "${tokenId}" not found in collective "${collectiveSlug}".`,
+        );
+      }
+      throw new UserError(
+        `Failed to revoke collective token (HTTP ${res.status}): ${text}`,
       );
     }
 

--- a/src/libswamp/auth/token_list.ts
+++ b/src/libswamp/auth/token_list.ts
@@ -1,0 +1,160 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AuthCredentials } from "../../domain/auth/auth_credentials.ts";
+import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
+import type {
+  CollectiveTokenMetadata,
+  ListCollectiveTokensResponse,
+} from "../../infrastructure/http/swamp_club_client.ts";
+import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
+import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
+import {
+  AuthRepository,
+  type AuthRepositoryOptions,
+} from "../../infrastructure/persistence/auth_repository.ts";
+import type { LibSwampContext } from "../context.ts";
+import {
+  cancelled,
+  notAuthenticated,
+  type SwampError,
+  validationFailed,
+} from "../errors.ts";
+
+export interface AuthTokenListItem {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  enabled: boolean;
+  expiresAt: string | null;
+  createdAt: string;
+  lastUsedAt: string | null;
+  scopes: string[];
+}
+
+export interface AuthTokenListData {
+  collective: string;
+  tokens: AuthTokenListItem[];
+}
+
+export type AuthTokenListEvent =
+  | { kind: "listing"; collective: string }
+  | { kind: "completed"; data: AuthTokenListData }
+  | { kind: "error"; error: SwampError };
+
+export interface AuthTokenListInput {
+  collective: string;
+}
+
+export interface AuthTokenListDeps {
+  loadCredentials: () => Promise<AuthCredentials | null>;
+  listTokens: (
+    serverUrl: string,
+    apiKey: string,
+    collective: string,
+    signal: AbortSignal,
+  ) => Promise<ListCollectiveTokensResponse>;
+  isCollectiveToken: () => boolean;
+  serverUrlOverride?: string;
+}
+
+export interface CreateAuthTokenListDepsOptions {
+  serverUrlOverride?: string;
+  identity?: ClientIdentity;
+  repo?: AuthRepositoryOptions;
+  isCollectiveToken: () => boolean;
+}
+
+export function createAuthTokenListDeps(
+  options: CreateAuthTokenListDepsOptions,
+): AuthTokenListDeps {
+  const repo = new AuthRepository(options.repo);
+  return {
+    loadCredentials: () => repo.load(),
+    listTokens: (serverUrl, apiKey, collective, signal) => {
+      const client = new SwampClubClient(serverUrl, options.identity);
+      return client.listCollectiveTokens(apiKey, collective, signal);
+    },
+    isCollectiveToken: options.isCollectiveToken,
+    serverUrlOverride: options.serverUrlOverride,
+  };
+}
+
+function toListItem(token: CollectiveTokenMetadata): AuthTokenListItem {
+  return {
+    id: token.id,
+    name: token.name,
+    keyPrefix: token.keyPrefix,
+    enabled: token.enabled,
+    expiresAt: token.expiresAt,
+    createdAt: token.createdAt,
+    lastUsedAt: token.lastUsedAt,
+    scopes: token.scopes,
+  };
+}
+
+export async function* authTokenList(
+  ctx: LibSwampContext,
+  deps: AuthTokenListDeps,
+  input: AuthTokenListInput,
+): AsyncIterable<AuthTokenListEvent> {
+  if (deps.isCollectiveToken()) {
+    yield {
+      kind: "error",
+      error: validationFailed(
+        "Collective tokens cannot list other collective tokens. Sign in with a personal account using `swamp auth login`.",
+      ),
+    };
+    return;
+  }
+
+  const credentials = await deps.loadCredentials();
+  if (!credentials) {
+    yield { kind: "error", error: notAuthenticated() };
+    return;
+  }
+
+  const serverUrl = deps.serverUrlOverride ?? credentials.serverUrl ??
+    DEFAULT_SWAMP_CLUB_URL;
+
+  yield { kind: "listing", collective: input.collective };
+
+  try {
+    const response = await deps.listTokens(
+      serverUrl,
+      credentials.apiKey,
+      input.collective,
+      ctx.signal,
+    );
+
+    yield {
+      kind: "completed",
+      data: {
+        collective: input.collective,
+        tokens: response.tokens.map(toListItem),
+      },
+    };
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      yield { kind: "error", error: cancelled(error) };
+      return;
+    }
+    throw error;
+  }
+}

--- a/src/libswamp/auth/token_list_test.ts
+++ b/src/libswamp/auth/token_list_test.ts
@@ -1,0 +1,214 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { AuthCredentials } from "../../domain/auth/auth_credentials.ts";
+import type { ListCollectiveTokensResponse } from "../../infrastructure/http/swamp_club_client.ts";
+import { createLibSwampContext } from "../context.ts";
+import { collect } from "../testing.ts";
+import {
+  authTokenList,
+  type AuthTokenListDeps,
+  type AuthTokenListEvent,
+} from "./token_list.ts";
+
+const testCredentials: AuthCredentials = {
+  serverUrl: "https://swamp-club.com",
+  apiKey: "swamp_test_key",
+  apiKeyId: "key-1",
+  username: "adam",
+};
+
+const testListResponse: ListCollectiveTokensResponse = {
+  tokens: [
+    {
+      id: "tok-1",
+      name: "ci-deploy",
+      keyPrefix: "swamp_org_ab",
+      enabled: true,
+      expiresAt: null,
+      createdAt: "2026-07-23T00:00:00Z",
+      lastUsedAt: "2026-08-15T12:00:00Z",
+      scopes: ["extensions:push"],
+    },
+    {
+      id: "tok-2",
+      name: "staging-runner",
+      keyPrefix: "swamp_org_cd",
+      enabled: true,
+      expiresAt: "2027-01-01T00:00:00Z",
+      createdAt: "2026-08-01T00:00:00Z",
+      lastUsedAt: null,
+      scopes: ["serve:*"],
+    },
+  ],
+};
+
+function makeDeps(
+  overrides: Partial<AuthTokenListDeps> = {},
+): AuthTokenListDeps {
+  return {
+    loadCredentials: () => Promise.resolve(testCredentials),
+    listTokens: () => Promise.resolve(testListResponse),
+    isCollectiveToken: () => false,
+    ...overrides,
+  };
+}
+
+Deno.test("authTokenList: yields listing -> completed on success", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps();
+
+  const events = await collect<AuthTokenListEvent>(
+    authTokenList(ctx, deps, { collective: "myorg" }),
+  );
+
+  assertEquals(events.length, 2);
+  assertEquals(events[0], { kind: "listing", collective: "myorg" });
+  const completed = events[1] as Extract<
+    AuthTokenListEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+  assertEquals(completed.data.collective, "myorg");
+  assertEquals(completed.data.tokens.length, 2);
+  assertEquals(completed.data.tokens[0].name, "ci-deploy");
+  assertEquals(completed.data.tokens[1].name, "staging-runner");
+});
+
+Deno.test("authTokenList: completed data has no key field", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps();
+
+  const events = await collect<AuthTokenListEvent>(
+    authTokenList(ctx, deps, { collective: "myorg" }),
+  );
+
+  const completed = events[1] as Extract<
+    AuthTokenListEvent,
+    { kind: "completed" }
+  >;
+  for (const token of completed.data.tokens) {
+    assertEquals("key" in token, false);
+    assertEquals("secret" in token, false);
+  }
+});
+
+Deno.test("authTokenList: rejects collective tokens", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({ isCollectiveToken: () => true });
+
+  const events = await collect<AuthTokenListEvent>(
+    authTokenList(ctx, deps, { collective: "myorg" }),
+  );
+
+  assertEquals(events.length, 1);
+  const err = events[0] as Extract<AuthTokenListEvent, { kind: "error" }>;
+  assertEquals(err.kind, "error");
+  assertEquals(err.error.code, "validation_failed");
+});
+
+Deno.test("authTokenList: yields not_authenticated when no credentials", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({ loadCredentials: () => Promise.resolve(null) });
+
+  const events = await collect<AuthTokenListEvent>(
+    authTokenList(ctx, deps, { collective: "myorg" }),
+  );
+
+  assertEquals(events.length, 1);
+  const err = events[0] as Extract<AuthTokenListEvent, { kind: "error" }>;
+  assertEquals(err.kind, "error");
+  assertEquals(err.error.code, "not_authenticated");
+});
+
+Deno.test("authTokenList: uses serverUrlOverride when provided", async () => {
+  const ctx = createLibSwampContext();
+  const calledUrls: string[] = [];
+  const deps = makeDeps({
+    listTokens: (serverUrl, _apiKey, _collective, _signal) => {
+      calledUrls.push(serverUrl);
+      return Promise.resolve(testListResponse);
+    },
+    serverUrlOverride: "https://custom.server",
+  });
+
+  await collect<AuthTokenListEvent>(
+    authTokenList(ctx, deps, { collective: "myorg" }),
+  );
+
+  assertEquals(calledUrls, ["https://custom.server"]);
+});
+
+Deno.test("authTokenList: passes correct collective to listTokens", async () => {
+  const ctx = createLibSwampContext();
+  let capturedCollective: string | undefined;
+  const deps = makeDeps({
+    listTokens: (_serverUrl, _apiKey, collective, _signal) => {
+      capturedCollective = collective;
+      return Promise.resolve(testListResponse);
+    },
+  });
+
+  await collect<AuthTokenListEvent>(
+    authTokenList(ctx, deps, { collective: "myorg" }),
+  );
+
+  assertEquals(capturedCollective, "myorg");
+});
+
+Deno.test("authTokenList: yields cancelled error on abort", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const ctx = createLibSwampContext({ signal: controller.signal });
+  const deps = makeDeps({
+    listTokens: (_serverUrl, _apiKey, _collective, signal) => {
+      signal.throwIfAborted();
+      return Promise.resolve(testListResponse);
+    },
+  });
+
+  const events = await collect<AuthTokenListEvent>(
+    authTokenList(ctx, deps, { collective: "myorg" }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    AuthTokenListEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "cancelled");
+});
+
+Deno.test("authTokenList: handles empty token list", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({
+    listTokens: () => Promise.resolve({ tokens: [] }),
+  });
+
+  const events = await collect<AuthTokenListEvent>(
+    authTokenList(ctx, deps, { collective: "myorg" }),
+  );
+
+  const completed = events[1] as Extract<
+    AuthTokenListEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.data.tokens, []);
+});

--- a/src/libswamp/auth/token_revoke.ts
+++ b/src/libswamp/auth/token_revoke.ts
@@ -1,0 +1,142 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AuthCredentials } from "../../domain/auth/auth_credentials.ts";
+import { DEFAULT_SWAMP_CLUB_URL } from "../../domain/auth/auth_credentials.ts";
+import type { RevokeCollectiveTokenResponse } from "../../infrastructure/http/swamp_club_client.ts";
+import { SwampClubClient } from "../../infrastructure/http/swamp_club_client.ts";
+import type { ClientIdentity } from "../../infrastructure/http/client_identity.ts";
+import {
+  AuthRepository,
+  type AuthRepositoryOptions,
+} from "../../infrastructure/persistence/auth_repository.ts";
+import type { LibSwampContext } from "../context.ts";
+import {
+  cancelled,
+  notAuthenticated,
+  type SwampError,
+  validationFailed,
+} from "../errors.ts";
+
+export interface AuthTokenRevokeData {
+  id: string;
+  name: string;
+  collective: string;
+}
+
+export type AuthTokenRevokeEvent =
+  | { kind: "revoking"; collective: string; tokenId: string }
+  | { kind: "completed"; data: AuthTokenRevokeData }
+  | { kind: "error"; error: SwampError };
+
+export interface AuthTokenRevokeInput {
+  collective: string;
+  tokenId: string;
+}
+
+export interface AuthTokenRevokeDeps {
+  loadCredentials: () => Promise<AuthCredentials | null>;
+  revokeToken: (
+    serverUrl: string,
+    apiKey: string,
+    collective: string,
+    tokenId: string,
+    signal: AbortSignal,
+  ) => Promise<RevokeCollectiveTokenResponse>;
+  isCollectiveToken: () => boolean;
+  serverUrlOverride?: string;
+}
+
+export interface CreateAuthTokenRevokeDepsOptions {
+  serverUrlOverride?: string;
+  identity?: ClientIdentity;
+  repo?: AuthRepositoryOptions;
+  isCollectiveToken: () => boolean;
+}
+
+export function createAuthTokenRevokeDeps(
+  options: CreateAuthTokenRevokeDepsOptions,
+): AuthTokenRevokeDeps {
+  const repo = new AuthRepository(options.repo);
+  return {
+    loadCredentials: () => repo.load(),
+    revokeToken: (serverUrl, apiKey, collective, tokenId, signal) => {
+      const client = new SwampClubClient(serverUrl, options.identity);
+      return client.revokeCollectiveToken(apiKey, collective, tokenId, signal);
+    },
+    isCollectiveToken: options.isCollectiveToken,
+    serverUrlOverride: options.serverUrlOverride,
+  };
+}
+
+export async function* authTokenRevoke(
+  ctx: LibSwampContext,
+  deps: AuthTokenRevokeDeps,
+  input: AuthTokenRevokeInput,
+): AsyncIterable<AuthTokenRevokeEvent> {
+  if (deps.isCollectiveToken()) {
+    yield {
+      kind: "error",
+      error: validationFailed(
+        "Collective tokens cannot revoke other collective tokens. Sign in with a personal account using `swamp auth login`.",
+      ),
+    };
+    return;
+  }
+
+  const credentials = await deps.loadCredentials();
+  if (!credentials) {
+    yield { kind: "error", error: notAuthenticated() };
+    return;
+  }
+
+  const serverUrl = deps.serverUrlOverride ?? credentials.serverUrl ??
+    DEFAULT_SWAMP_CLUB_URL;
+
+  yield {
+    kind: "revoking",
+    collective: input.collective,
+    tokenId: input.tokenId,
+  };
+
+  try {
+    const response = await deps.revokeToken(
+      serverUrl,
+      credentials.apiKey,
+      input.collective,
+      input.tokenId,
+      ctx.signal,
+    );
+
+    yield {
+      kind: "completed",
+      data: {
+        id: response.token.id,
+        name: response.token.name,
+        collective: input.collective,
+      },
+    };
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      yield { kind: "error", error: cancelled(error) };
+      return;
+    }
+    throw error;
+  }
+}

--- a/src/libswamp/auth/token_revoke_test.ts
+++ b/src/libswamp/auth/token_revoke_test.ts
@@ -1,0 +1,187 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { AuthCredentials } from "../../domain/auth/auth_credentials.ts";
+import type { RevokeCollectiveTokenResponse } from "../../infrastructure/http/swamp_club_client.ts";
+import { createLibSwampContext } from "../context.ts";
+import { collect } from "../testing.ts";
+import {
+  authTokenRevoke,
+  type AuthTokenRevokeDeps,
+  type AuthTokenRevokeEvent,
+} from "./token_revoke.ts";
+
+const testCredentials: AuthCredentials = {
+  serverUrl: "https://swamp-club.com",
+  apiKey: "swamp_test_key",
+  apiKeyId: "key-1",
+  username: "adam",
+};
+
+const testRevokeResponse: RevokeCollectiveTokenResponse = {
+  token: {
+    id: "tok-1",
+    name: "ci-deploy",
+    keyPrefix: "swamp_org_ab",
+    enabled: false,
+    expiresAt: null,
+    createdAt: "2026-07-23T00:00:00Z",
+    lastUsedAt: "2026-08-15T12:00:00Z",
+    scopes: ["extensions:push"],
+  },
+};
+
+function makeDeps(
+  overrides: Partial<AuthTokenRevokeDeps> = {},
+): AuthTokenRevokeDeps {
+  return {
+    loadCredentials: () => Promise.resolve(testCredentials),
+    revokeToken: () => Promise.resolve(testRevokeResponse),
+    isCollectiveToken: () => false,
+    ...overrides,
+  };
+}
+
+Deno.test("authTokenRevoke: yields revoking -> completed on success", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps();
+
+  const events = await collect<AuthTokenRevokeEvent>(
+    authTokenRevoke(ctx, deps, { collective: "myorg", tokenId: "tok-1" }),
+  );
+
+  assertEquals(events, [
+    { kind: "revoking", collective: "myorg", tokenId: "tok-1" },
+    {
+      kind: "completed",
+      data: {
+        id: "tok-1",
+        name: "ci-deploy",
+        collective: "myorg",
+      },
+    },
+  ]);
+});
+
+Deno.test("authTokenRevoke: completed data has no key field", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps();
+
+  const events = await collect<AuthTokenRevokeEvent>(
+    authTokenRevoke(ctx, deps, { collective: "myorg", tokenId: "tok-1" }),
+  );
+
+  const completed = events[1] as Extract<
+    AuthTokenRevokeEvent,
+    { kind: "completed" }
+  >;
+  assertEquals("key" in completed.data, false);
+  assertEquals("secret" in completed.data, false);
+  assertEquals("keyPrefix" in completed.data, false);
+});
+
+Deno.test("authTokenRevoke: rejects collective tokens", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({ isCollectiveToken: () => true });
+
+  const events = await collect<AuthTokenRevokeEvent>(
+    authTokenRevoke(ctx, deps, { collective: "myorg", tokenId: "tok-1" }),
+  );
+
+  assertEquals(events.length, 1);
+  const err = events[0] as Extract<AuthTokenRevokeEvent, { kind: "error" }>;
+  assertEquals(err.kind, "error");
+  assertEquals(err.error.code, "validation_failed");
+});
+
+Deno.test("authTokenRevoke: yields not_authenticated when no credentials", async () => {
+  const ctx = createLibSwampContext();
+  const deps = makeDeps({ loadCredentials: () => Promise.resolve(null) });
+
+  const events = await collect<AuthTokenRevokeEvent>(
+    authTokenRevoke(ctx, deps, { collective: "myorg", tokenId: "tok-1" }),
+  );
+
+  assertEquals(events.length, 1);
+  const err = events[0] as Extract<AuthTokenRevokeEvent, { kind: "error" }>;
+  assertEquals(err.kind, "error");
+  assertEquals(err.error.code, "not_authenticated");
+});
+
+Deno.test("authTokenRevoke: uses serverUrlOverride when provided", async () => {
+  const ctx = createLibSwampContext();
+  const calledUrls: string[] = [];
+  const deps = makeDeps({
+    revokeToken: (serverUrl, _apiKey, _collective, _tokenId, _signal) => {
+      calledUrls.push(serverUrl);
+      return Promise.resolve(testRevokeResponse);
+    },
+    serverUrlOverride: "https://custom.server",
+  });
+
+  await collect<AuthTokenRevokeEvent>(
+    authTokenRevoke(ctx, deps, { collective: "myorg", tokenId: "tok-1" }),
+  );
+
+  assertEquals(calledUrls, ["https://custom.server"]);
+});
+
+Deno.test("authTokenRevoke: passes correct args to revokeToken", async () => {
+  const ctx = createLibSwampContext();
+  let capturedCollective: string | undefined;
+  let capturedTokenId: string | undefined;
+  const deps = makeDeps({
+    revokeToken: (_serverUrl, _apiKey, collective, tokenId, _signal) => {
+      capturedCollective = collective;
+      capturedTokenId = tokenId;
+      return Promise.resolve(testRevokeResponse);
+    },
+  });
+
+  await collect<AuthTokenRevokeEvent>(
+    authTokenRevoke(ctx, deps, { collective: "myorg", tokenId: "tok-1" }),
+  );
+
+  assertEquals(capturedCollective, "myorg");
+  assertEquals(capturedTokenId, "tok-1");
+});
+
+Deno.test("authTokenRevoke: yields cancelled error on abort", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const ctx = createLibSwampContext({ signal: controller.signal });
+  const deps = makeDeps({
+    revokeToken: (_serverUrl, _apiKey, _collective, _tokenId, signal) => {
+      signal.throwIfAborted();
+      return Promise.resolve(testRevokeResponse);
+    },
+  });
+
+  const events = await collect<AuthTokenRevokeEvent>(
+    authTokenRevoke(ctx, deps, { collective: "myorg", tokenId: "tok-1" }),
+  );
+
+  const last = events[events.length - 1] as Extract<
+    AuthTokenRevokeEvent,
+    { kind: "error" }
+  >;
+  assertEquals(last.kind, "error");
+  assertEquals(last.error.code, "cancelled");
+});

--- a/src/libswamp/mod.ts
+++ b/src/libswamp/mod.ts
@@ -1299,6 +1299,29 @@ export {
   type CreateAuthTokenCreateDepsOptions,
 } from "./auth/token_create.ts";
 
+// Auth token list operations
+export {
+  authTokenList,
+  type AuthTokenListData,
+  type AuthTokenListDeps,
+  type AuthTokenListEvent,
+  type AuthTokenListInput,
+  type AuthTokenListItem,
+  createAuthTokenListDeps,
+  type CreateAuthTokenListDepsOptions,
+} from "./auth/token_list.ts";
+
+// Auth token revoke operations
+export {
+  authTokenRevoke,
+  type AuthTokenRevokeData,
+  type AuthTokenRevokeDeps,
+  type AuthTokenRevokeEvent,
+  type AuthTokenRevokeInput,
+  createAuthTokenRevokeDeps,
+  type CreateAuthTokenRevokeDepsOptions,
+} from "./auth/token_revoke.ts";
+
 // Auth logout operations
 export {
   authLogout,

--- a/src/presentation/output/auth_token_output.ts
+++ b/src/presentation/output/auth_token_output.ts
@@ -17,9 +17,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { bold, cyan, yellow } from "@std/fmt/colors";
+import { bold, cyan, dim, green, yellow } from "@std/fmt/colors";
 import { writeOutput } from "../../infrastructure/logging/logger.ts";
-import type { AuthTokenCreateData } from "../../libswamp/mod.ts";
+import type {
+  AuthTokenCreateData,
+  AuthTokenListData,
+  AuthTokenRevokeData,
+} from "../../libswamp/mod.ts";
 import type { OutputMode } from "./output.ts";
 
 export function renderAuthTokenCreate(
@@ -43,4 +47,74 @@ export function renderAuthTokenCreate(
     ),
   ];
   writeOutput(lines.join("\n"));
+}
+
+export function renderAuthTokenList(
+  data: AuthTokenListData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data.tokens, null, 2));
+    return;
+  }
+
+  if (data.tokens.length === 0) {
+    writeOutput(
+      [
+        `No API tokens found for collective ${bold(data.collective)}.`,
+        dim(
+          "Create one with: swamp auth token create --collective " +
+            data.collective + " --scopes <scopes>",
+        ),
+      ].join("\n"),
+    );
+    return;
+  }
+
+  const headers = ["NAME", "ID", "PREFIX", "SCOPES", "CREATED", "LAST USED"];
+  const rows = data.tokens.map((token) => [
+    token.name,
+    token.id,
+    token.keyPrefix,
+    token.scopes.join(", "),
+    token.createdAt,
+    token.lastUsedAt ?? dim("-"),
+  ]);
+
+  const widths = headers.map((header, i) =>
+    Math.max(header.length, ...rows.map((row) => row[i].length))
+  );
+
+  const headerLine = dim(
+    headers.map((h, i) => h.padEnd(widths[i])).join("  "),
+  );
+  const dataLines = rows.map((row) =>
+    row
+      .map((cell, i) => {
+        const padded = cell.padEnd(widths[i]);
+        return i === 0 ? bold(padded) : padded;
+      })
+      .join("  ")
+      .trimEnd()
+  );
+
+  writeOutput([headerLine, ...dataLines].join("\n"));
+}
+
+const checkmark = "✓";
+
+export function renderAuthTokenRevoke(
+  data: AuthTokenRevokeData,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  writeOutput(
+    `${green(checkmark)} Token ${bold(data.name)} revoked from collective ${
+      bold(data.collective)
+    }.`,
+  );
 }

--- a/src/presentation/output/auth_token_output_test.ts
+++ b/src/presentation/output/auth_token_output_test.ts
@@ -1,0 +1,118 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { stripAnsiCode } from "@std/fmt/colors";
+import type {
+  AuthTokenListData,
+  AuthTokenRevokeData,
+} from "../../libswamp/mod.ts";
+import {
+  renderAuthTokenList,
+  renderAuthTokenRevoke,
+} from "./auth_token_output.ts";
+
+function captureLogs(fn: () => void): string {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return stripAnsiCode(logs.join("\n"));
+}
+
+const listData: AuthTokenListData = {
+  collective: "myorg",
+  tokens: [
+    {
+      id: "tok-1",
+      name: "ci-deploy",
+      keyPrefix: "swamp_org_ab",
+      enabled: true,
+      expiresAt: null,
+      createdAt: "2026-07-23T00:00:00Z",
+      lastUsedAt: "2026-08-15T12:00:00Z",
+      scopes: ["extensions:push"],
+    },
+    {
+      id: "tok-2",
+      name: "staging-runner",
+      keyPrefix: "swamp_org_cd",
+      enabled: true,
+      expiresAt: "2027-01-01T00:00:00Z",
+      createdAt: "2026-08-01T00:00:00Z",
+      lastUsedAt: null,
+      scopes: ["serve:*"],
+    },
+  ],
+};
+
+const revokeData: AuthTokenRevokeData = {
+  id: "tok-1",
+  name: "ci-deploy",
+  collective: "myorg",
+};
+
+Deno.test("renderAuthTokenList: log mode shows table with token metadata", () => {
+  const output = captureLogs(() => renderAuthTokenList(listData, "log"));
+  assertStringIncludes(output, "ci-deploy");
+  assertStringIncludes(output, "staging-runner");
+  assertStringIncludes(output, "swamp_org_ab");
+  assertStringIncludes(output, "extensions:push");
+});
+
+Deno.test("renderAuthTokenList: log mode never includes secret key", () => {
+  const output = captureLogs(() => renderAuthTokenList(listData, "log"));
+  assertEquals(output.includes("swamp_org_abcdef"), false);
+});
+
+Deno.test("renderAuthTokenList: json mode outputs tokens array", () => {
+  const output = captureLogs(() => renderAuthTokenList(listData, "json"));
+  const parsed = JSON.parse(output);
+  assertEquals(Array.isArray(parsed), true);
+  assertEquals(parsed.length, 2);
+  assertEquals(parsed[0].name, "ci-deploy");
+  assertEquals("key" in parsed[0], false);
+});
+
+Deno.test("renderAuthTokenList: empty list shows hint", () => {
+  const emptyData: AuthTokenListData = { collective: "myorg", tokens: [] };
+  const output = captureLogs(() => renderAuthTokenList(emptyData, "log"));
+  assertStringIncludes(output, "No API tokens found");
+  assertStringIncludes(output, "swamp auth token create");
+});
+
+Deno.test("renderAuthTokenRevoke: log mode shows confirmation", () => {
+  const output = captureLogs(() => renderAuthTokenRevoke(revokeData, "log"));
+  assertStringIncludes(output, "ci-deploy");
+  assertStringIncludes(output, "revoked");
+  assertStringIncludes(output, "myorg");
+});
+
+Deno.test("renderAuthTokenRevoke: json mode outputs structured data", () => {
+  const output = captureLogs(() => renderAuthTokenRevoke(revokeData, "json"));
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.id, "tok-1");
+  assertEquals(parsed.name, "ci-deploy");
+  assertEquals(parsed.collective, "myorg");
+  assertEquals("key" in parsed, false);
+});


### PR DESCRIPTION
## Summary

- Add `swamp auth token list --collective <slug>` and `swamp auth token revoke <id> --collective <slug>` to close the collective API token lifecycle from the CLI
- Both commands call the swamp-club REST API (GET and DELETE on `/api/v1/collectives/{slug}/api-tokens`) following the same libswamp async-generator + deps-injection architecture as `auth token create`
- Response types (`ListCollectiveTokensResponse`, `RevokeCollectiveTokenResponse`) are structurally separate from `CreateCollectiveTokenResponse` and **never carry the secret key** — only token metadata flows through list and revoke

Closes swamp-club#1680

Co-authored-by: Blake Irvin <blakeirvin@me.com>

## Test plan

- [x] 8 unit tests for `authTokenList` generator (success, empty list, secret exclusion, collective token rejection, auth guard, abort, server URL override, collective passthrough)
- [x] 7 unit tests for `authTokenRevoke` generator (success, secret exclusion, collective token rejection, auth guard, abort, server URL override, arg passthrough)
- [x] 6 output renderer tests (list log/json modes, empty list hint, revoke log/json modes, no-key assertions)
- [x] All existing `auth_token_create` tests still pass
- [x] `deno check`, `deno lint`, `deno fmt` clean
- [x] Full verification workflow passed (build + reviews + skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)