### PR TITLE
feat(datastore): support env and vault expressions in datastore config (swamp-club#1801)

### DIFF
--- a/design/enablers/datastores.md
+++ b/design/enablers/datastores.md
@@ -143,6 +143,57 @@ defined by the extension.
 | `src/domain/extensions/extension_loader.ts` | Generic extension loader (used with kind adapters) |
 | `src/domain/extensions/datastore_kind_adapter.ts` | Datastore-specific kind adapter for ExtensionLoader |
 | `src/domain/datastore/datastore_sync_service.ts` | `DatastoreSyncService` interface |
+| `src/cli/datastore_expression_resolver.ts` | Resolves `${{ env.* }}` and `${{ vault.get() }}` expressions in datastore config values |
+
+### Config Value Interpolation
+
+String values in the datastore `config` object support expression interpolation
+using the same `${{ }}` delimiter syntax as model and workflow definitions.
+Expressions are resolved during config resolution, before the config is passed
+to the extension's schema validation and `createProvider()` factory.
+
+Two expression namespaces are supported:
+
+**Environment variables** — `${{ env.VAR_NAME }}`
+
+Resolves to the value of the named environment variable. Throws a startup error
+if the variable is not set or empty. This is the simplest approach for keeping
+secrets out of `.swamp.yaml` — the token comes from the operator's environment
+(direnv, shell profile, 1Password CLI, etc.).
+
+```yaml
+datastore:
+  type: "@myorg/gitlab-datastore"
+  config:
+    token: "${{ env.GITLAB_TOKEN }}"
+    endpoint: "https://${{ env.GITLAB_HOST }}/api/v4"
+```
+
+**Vault secrets** — `${{ vault.get(vaultName, secretKey) }}`
+
+Resolves to the decrypted value of the named secret from the named vault. All
+installed vault types are supported (native `local_encryption` and extension
+providers like `@swamp/aws-sm`). The vault service is initialized lazily — only
+when a `vault.get()` expression is encountered.
+
+```yaml
+datastore:
+  type: "@myorg/postgres-datastore"
+  config:
+    connectionString: "${{ vault.get(infra, pg-connection-string) }}"
+```
+
+**Limitations:**
+
+- Only `env.*` and `vault.get()` are supported. The full CEL evaluation context
+  (model references, data lookups) is not available at this bootstrap phase.
+- All installed vault types work (native and extension). Extension vault
+  bundles are loaded directly from the `.swamp/vault-bundles/` cache during
+  early boot, bypassing the extension loader. If an extension vault is not
+  installed, install it before referencing it in datastore config.
+- Vault expressions are not supported when `managedConfig: true` — managed
+  config stores vault configurations in the datastore tier, creating a circular
+  dependency. Use environment variable expressions instead.
 
 ## Configuration
 

--- a/src/cli/datastore_expression_resolver.ts
+++ b/src/cli/datastore_expression_resolver.ts
@@ -1,0 +1,248 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join, toFileUrl } from "@std/path";
+import { getLogger } from "@logtape/logtape";
+import { UserError } from "../domain/errors.ts";
+import { VaultService } from "../domain/vaults/vault_service.ts";
+import { YamlVaultConfigRepository } from "../infrastructure/persistence/yaml_vault_config_repository.ts";
+import type { LocalEncryptionConfig } from "../domain/vaults/local_encryption_vault_provider.ts";
+import { RENAMED_VAULT_TYPES } from "../domain/vaults/vault_types.ts";
+import { vaultTypeRegistry } from "../domain/vaults/vault_type_registry.ts";
+import {
+  fixCjsEsmInterop,
+  rewriteZodImports,
+} from "../domain/models/bundle.ts";
+
+const logger = getLogger(["swamp", "datastore", "expressions"]);
+
+const EXPRESSION_PATTERN = /\$\{\{\s*(.+?)\s*\}\}/gs;
+
+const ENV_PATTERN = /^env\.([a-zA-Z_][a-zA-Z0-9_]*)$/;
+
+const VAULT_GET_PATTERN =
+  /^vault\.get\(\s*(?:(['"`])(.+?)\1|([^\s,)]+))\s*,\s*(?:(['"`])(.+?)\4|([^\s,)]+))\s*\)$/;
+
+export interface DatastoreExpressionContext {
+  repoDir: string;
+  managedConfig?: boolean;
+  vaultServiceFactory?: (repoDir: string) => Promise<VaultService>;
+}
+
+async function loadCachedVaultBundles(repoDir: string): Promise<void> {
+  const bundlesDir = join(repoDir, ".swamp", "vault-bundles");
+  try {
+    for await (const fpDir of Deno.readDir(bundlesDir)) {
+      if (!fpDir.isDirectory) continue;
+      for await (const file of Deno.readDir(join(bundlesDir, fpDir.name))) {
+        if (!file.name.endsWith(".js")) continue;
+        try {
+          const bundlePath = join(bundlesDir, fpDir.name, file.name);
+          let js = await Deno.readTextFile(bundlePath);
+          const fixed = fixCjsEsmInterop(rewriteZodImports(js));
+          if (fixed !== js) {
+            js = fixed;
+            await Deno.writeTextFile(bundlePath, js);
+          }
+          const importUrl = toFileUrl(bundlePath).href;
+          const mod = await import(importUrl);
+          if (
+            mod.vault && typeof mod.vault.type === "string" &&
+            typeof mod.vault.createProvider === "function"
+          ) {
+            if (!vaultTypeRegistry.has(mod.vault.type)) {
+              vaultTypeRegistry.register({
+                type: mod.vault.type,
+                name: mod.vault.name ?? mod.vault.type,
+                description: mod.vault.description ?? "",
+                configSchema: mod.vault.configSchema,
+                createProvider: mod.vault.createProvider,
+                isBuiltIn: false,
+              });
+              logger
+                .debug`Loaded vault extension ${mod.vault.type} from cached bundle for datastore config resolution`;
+            }
+          }
+        } catch (err) {
+          logger
+            .debug`Failed to load vault bundle ${file.name}: ${err}`;
+        }
+      }
+    }
+  } catch {
+    // vault-bundles directory doesn't exist — no extension vaults installed
+  }
+}
+
+async function createEarlyVaultService(
+  repoDir: string,
+): Promise<VaultService> {
+  await loadCachedVaultBundles(repoDir);
+
+  const vaultsDir = join(repoDir, "vaults");
+  const vaultService = new VaultService();
+  const vaultRepo = new YamlVaultConfigRepository(
+    repoDir,
+    undefined,
+    vaultsDir,
+  );
+
+  let vaultConfigs;
+  try {
+    vaultConfigs = await vaultRepo.findAll();
+  } catch {
+    return vaultService;
+  }
+
+  for (const vaultConfig of vaultConfigs) {
+    try {
+      let vaultType = vaultConfig.type;
+      const renamedTo = RENAMED_VAULT_TYPES[vaultType.toLowerCase()];
+      if (renamedTo) vaultType = renamedTo;
+
+      let config = vaultConfig.config;
+      if (vaultType === "local_encryption") {
+        const localConfig = config as LocalEncryptionConfig | undefined;
+        if (!localConfig?.base_dir) {
+          config = { ...localConfig, base_dir: repoDir };
+        }
+      }
+
+      vaultService.registerVault({
+        name: vaultConfig.name,
+        type: vaultType,
+        config,
+        auditReads: vaultConfig.auditReads,
+      });
+    } catch (error) {
+      logger
+        .warn`Vault ${vaultConfig.name} not available for datastore config expressions: ${error}`;
+    }
+  }
+
+  return vaultService;
+}
+
+export async function resolveDatastoreExpressions(
+  config: Record<string, unknown>,
+  context: DatastoreExpressionContext,
+): Promise<Record<string, unknown>> {
+  let vaultService: VaultService | null = null;
+
+  async function getVaultService(): Promise<VaultService> {
+    if (vaultService) return vaultService;
+    if (context.managedConfig) {
+      throw new UserError(
+        "Vault expressions in datastore config are not supported when " +
+          "managedConfig is enabled. Managed config stores vault " +
+          "configurations in the datastore tier, which is not available " +
+          "during datastore initialization. Use environment variable " +
+          "expressions instead.",
+      );
+    }
+    const factory = context.vaultServiceFactory ?? createEarlyVaultService;
+    logger
+      .debug`Creating vault service for datastore config expression resolution`;
+    vaultService = await factory(context.repoDir);
+    logger.debug`Vault service created successfully`;
+    return vaultService;
+  }
+
+  async function resolveExpression(expr: string): Promise<string> {
+    const envMatch = expr.match(ENV_PATTERN);
+    if (envMatch) {
+      const varName = envMatch[1];
+      const value = Deno.env.get(varName);
+      if (value === undefined || value === "") {
+        throw new UserError(
+          `Environment variable "${varName}" is not set or empty ` +
+            `(referenced in datastore config expression)`,
+        );
+      }
+      return value;
+    }
+
+    const vaultMatch = expr.match(VAULT_GET_PATTERN);
+    if (vaultMatch) {
+      const vaultName = vaultMatch[2] ?? vaultMatch[3];
+      const secretKey = vaultMatch[5] ?? vaultMatch[6];
+      const service = await getVaultService();
+      try {
+        return await service.get(vaultName, secretKey, "datastore-config");
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : String(error);
+        throw new UserError(
+          `Failed to resolve vault expression in datastore config: ${msg}`,
+        );
+      }
+    }
+
+    throw new UserError(
+      `Unsupported expression in datastore config: "${expr}". ` +
+        `Only env.VAR_NAME and vault.get(vaultName, secretKey) are supported.`,
+    );
+  }
+
+  async function resolveString(str: string): Promise<unknown> {
+    const matches = [...str.matchAll(EXPRESSION_PATTERN)];
+    if (matches.length === 0) return str;
+
+    if (
+      matches.length === 1 &&
+      matches[0].index === 0 &&
+      matches[0][0].length === str.trimEnd().length
+    ) {
+      return await resolveExpression(matches[0][1].trim());
+    }
+
+    let result = str;
+    for (const match of matches) {
+      const rawExpr = match[0];
+      const inner = match[1].trim();
+      const resolved = await resolveExpression(inner);
+      result = result.split(rawExpr).join(String(resolved));
+    }
+    return result;
+  }
+
+  async function resolveValue(value: unknown): Promise<unknown> {
+    if (typeof value === "string") {
+      return await resolveString(value);
+    }
+    if (Array.isArray(value)) {
+      return await Promise.all(value.map(resolveValue));
+    }
+    if (value !== null && typeof value === "object") {
+      return await resolveRecord(value as Record<string, unknown>);
+    }
+    return value;
+  }
+
+  async function resolveRecord(
+    obj: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(obj)) {
+      result[key] = await resolveValue(val);
+    }
+    return result;
+  }
+
+  return await resolveRecord(config);
+}

--- a/src/cli/datastore_expression_resolver_test.ts
+++ b/src/cli/datastore_expression_resolver_test.ts
@@ -1,0 +1,391 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import {
+  type DatastoreExpressionContext,
+  resolveDatastoreExpressions,
+} from "./datastore_expression_resolver.ts";
+import { UserError } from "../domain/errors.ts";
+import type { VaultService } from "../domain/vaults/vault_service.ts";
+
+function baseContext(
+  overrides?: Partial<DatastoreExpressionContext>,
+): DatastoreExpressionContext {
+  return { repoDir: "/tmp/test-repo", ...overrides };
+}
+
+function mockVaultFactory(
+  secrets: Record<string, Record<string, string>>,
+): (repoDir: string) => Promise<VaultService> {
+  return (_repoDir: string) =>
+    Promise.resolve({
+      get: (
+        vaultName: string,
+        secretKey: string,
+        _auditSource: string,
+      ): Promise<string> => {
+        const vault = secrets[vaultName];
+        if (!vault) {
+          return Promise.reject(
+            new Error(
+              `Vault "${vaultName}" not found. Available vaults: ${
+                Object.keys(secrets).join(", ")
+              }`,
+            ),
+          );
+        }
+        const value = vault[secretKey];
+        if (value === undefined) {
+          return Promise.reject(
+            new Error(
+              `Secret "${secretKey}" not found in vault "${vaultName}"`,
+            ),
+          );
+        }
+        return Promise.resolve(value);
+      },
+    } as unknown as VaultService);
+}
+
+// ============================================================================
+// No-op cases
+// ============================================================================
+
+Deno.test("resolveDatastoreExpressions: config with no expressions passes through unchanged", async () => {
+  const config = { host: "localhost", port: 5432, ssl: true };
+  const result = await resolveDatastoreExpressions(config, baseContext());
+  assertEquals(result, { host: "localhost", port: 5432, ssl: true });
+});
+
+Deno.test("resolveDatastoreExpressions: empty config returns empty object", async () => {
+  const result = await resolveDatastoreExpressions({}, baseContext());
+  assertEquals(result, {});
+});
+
+Deno.test("resolveDatastoreExpressions: config with only primitives passes through", async () => {
+  const config = { count: 42, enabled: false, label: null as unknown };
+  const result = await resolveDatastoreExpressions(config, baseContext());
+  assertEquals(result, { count: 42, enabled: false, label: null });
+});
+
+// ============================================================================
+// env.VAR resolution
+// ============================================================================
+
+Deno.test("resolveDatastoreExpressions: resolves env expression in flat config", async () => {
+  const original = Deno.env.get("SWAMP_TEST_DS_EXPR_TOKEN");
+  try {
+    Deno.env.set("SWAMP_TEST_DS_EXPR_TOKEN", "my-secret-token");
+    const config = { token: "${{ env.SWAMP_TEST_DS_EXPR_TOKEN }}" };
+    const result = await resolveDatastoreExpressions(config, baseContext());
+    assertEquals(result, { token: "my-secret-token" });
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_TEST_DS_EXPR_TOKEN", original);
+    } else Deno.env.delete("SWAMP_TEST_DS_EXPR_TOKEN");
+  }
+});
+
+Deno.test("resolveDatastoreExpressions: resolves env expression in nested config", async () => {
+  const original = Deno.env.get("SWAMP_TEST_DS_EXPR_NESTED");
+  try {
+    Deno.env.set("SWAMP_TEST_DS_EXPR_NESTED", "secret-val");
+    const config = {
+      connection: { token: "${{ env.SWAMP_TEST_DS_EXPR_NESTED }}" },
+    };
+    const result = await resolveDatastoreExpressions(config, baseContext());
+    assertEquals(result, { connection: { token: "secret-val" } });
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_TEST_DS_EXPR_NESTED", original);
+    } else Deno.env.delete("SWAMP_TEST_DS_EXPR_NESTED");
+  }
+});
+
+Deno.test("resolveDatastoreExpressions: resolves env expressions in arrays", async () => {
+  const origA = Deno.env.get("SWAMP_TEST_DS_EXPR_A");
+  const origB = Deno.env.get("SWAMP_TEST_DS_EXPR_B");
+  try {
+    Deno.env.set("SWAMP_TEST_DS_EXPR_A", "host-a");
+    Deno.env.set("SWAMP_TEST_DS_EXPR_B", "host-b");
+    const config = {
+      hosts: [
+        "${{ env.SWAMP_TEST_DS_EXPR_A }}",
+        "${{ env.SWAMP_TEST_DS_EXPR_B }}",
+      ],
+    };
+    const result = await resolveDatastoreExpressions(config, baseContext());
+    assertEquals(result, { hosts: ["host-a", "host-b"] });
+  } finally {
+    if (origA !== undefined) Deno.env.set("SWAMP_TEST_DS_EXPR_A", origA);
+    else Deno.env.delete("SWAMP_TEST_DS_EXPR_A");
+    if (origB !== undefined) Deno.env.set("SWAMP_TEST_DS_EXPR_B", origB);
+    else Deno.env.delete("SWAMP_TEST_DS_EXPR_B");
+  }
+});
+
+Deno.test("resolveDatastoreExpressions: interpolates multiple expressions in one string", async () => {
+  const origH = Deno.env.get("SWAMP_TEST_DS_EXPR_HOST");
+  const origP = Deno.env.get("SWAMP_TEST_DS_EXPR_PORT");
+  try {
+    Deno.env.set("SWAMP_TEST_DS_EXPR_HOST", "db.example.com");
+    Deno.env.set("SWAMP_TEST_DS_EXPR_PORT", "5432");
+    const config = {
+      url:
+        "https://${{ env.SWAMP_TEST_DS_EXPR_HOST }}:${{ env.SWAMP_TEST_DS_EXPR_PORT }}/db",
+    };
+    const result = await resolveDatastoreExpressions(config, baseContext());
+    assertEquals(result, { url: "https://db.example.com:5432/db" });
+  } finally {
+    if (origH !== undefined) Deno.env.set("SWAMP_TEST_DS_EXPR_HOST", origH);
+    else Deno.env.delete("SWAMP_TEST_DS_EXPR_HOST");
+    if (origP !== undefined) Deno.env.set("SWAMP_TEST_DS_EXPR_PORT", origP);
+    else Deno.env.delete("SWAMP_TEST_DS_EXPR_PORT");
+  }
+});
+
+Deno.test("resolveDatastoreExpressions: trims whitespace inside expression delimiters", async () => {
+  const original = Deno.env.get("SWAMP_TEST_DS_EXPR_WS");
+  try {
+    Deno.env.set("SWAMP_TEST_DS_EXPR_WS", "trimmed");
+    const config = { val: "${{  env.SWAMP_TEST_DS_EXPR_WS  }}" };
+    const result = await resolveDatastoreExpressions(config, baseContext());
+    assertEquals(result, { val: "trimmed" });
+  } finally {
+    if (original !== undefined) Deno.env.set("SWAMP_TEST_DS_EXPR_WS", original);
+    else Deno.env.delete("SWAMP_TEST_DS_EXPR_WS");
+  }
+});
+
+Deno.test("resolveDatastoreExpressions: throws UserError for missing env var", async () => {
+  Deno.env.delete("SWAMP_TEST_DS_EXPR_MISSING");
+  const config = { token: "${{ env.SWAMP_TEST_DS_EXPR_MISSING }}" };
+  await assertRejects(
+    () => resolveDatastoreExpressions(config, baseContext()),
+    UserError,
+    "SWAMP_TEST_DS_EXPR_MISSING",
+  );
+});
+
+Deno.test("resolveDatastoreExpressions: throws UserError for empty env var", async () => {
+  const original = Deno.env.get("SWAMP_TEST_DS_EXPR_EMPTY");
+  try {
+    Deno.env.set("SWAMP_TEST_DS_EXPR_EMPTY", "");
+    const config = { token: "${{ env.SWAMP_TEST_DS_EXPR_EMPTY }}" };
+    await assertRejects(
+      () => resolveDatastoreExpressions(config, baseContext()),
+      UserError,
+      "not set or empty",
+    );
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_TEST_DS_EXPR_EMPTY", original);
+    } else Deno.env.delete("SWAMP_TEST_DS_EXPR_EMPTY");
+  }
+});
+
+// ============================================================================
+// vault.get() resolution
+// ============================================================================
+
+Deno.test("resolveDatastoreExpressions: resolves vault.get with quoted args", async () => {
+  const ctx = baseContext({
+    vaultServiceFactory: mockVaultFactory({
+      infra: { "db-password": "s3cret" },
+    }),
+  });
+  const config = { password: '${{ vault.get("infra", "db-password") }}' };
+  const result = await resolveDatastoreExpressions(config, ctx);
+  assertEquals(result, { password: "s3cret" });
+});
+
+Deno.test("resolveDatastoreExpressions: resolves vault.get with unquoted args", async () => {
+  const ctx = baseContext({
+    vaultServiceFactory: mockVaultFactory({
+      myVault: { token: "vault-token" },
+    }),
+  });
+  const config = { token: "${{ vault.get(myVault, token) }}" };
+  const result = await resolveDatastoreExpressions(config, ctx);
+  assertEquals(result, { token: "vault-token" });
+});
+
+Deno.test("resolveDatastoreExpressions: resolves vault.get with single-quoted args", async () => {
+  const ctx = baseContext({
+    vaultServiceFactory: mockVaultFactory({
+      v: { k: "single-quoted-val" },
+    }),
+  });
+  const config = { secret: "${{ vault.get('v', 'k') }}" };
+  const result = await resolveDatastoreExpressions(config, ctx);
+  assertEquals(result, { secret: "single-quoted-val" });
+});
+
+Deno.test("resolveDatastoreExpressions: throws UserError when vault not found", async () => {
+  const ctx = baseContext({
+    vaultServiceFactory: mockVaultFactory({}),
+  });
+  const config = { token: '${{ vault.get("missing", "key") }}' };
+  await assertRejects(
+    () => resolveDatastoreExpressions(config, ctx),
+    UserError,
+    "Failed to resolve vault expression",
+  );
+});
+
+Deno.test("resolveDatastoreExpressions: throws UserError when secret not found", async () => {
+  const ctx = baseContext({
+    vaultServiceFactory: mockVaultFactory({
+      infra: { "other-key": "val" },
+    }),
+  });
+  const config = { token: '${{ vault.get("infra", "missing-key") }}' };
+  await assertRejects(
+    () => resolveDatastoreExpressions(config, ctx),
+    UserError,
+    "Failed to resolve vault expression",
+  );
+});
+
+// ============================================================================
+// Mixed expressions
+// ============================================================================
+
+Deno.test("resolveDatastoreExpressions: resolves both env and vault in different fields", async () => {
+  const original = Deno.env.get("SWAMP_TEST_DS_EXPR_MIX");
+  try {
+    Deno.env.set("SWAMP_TEST_DS_EXPR_MIX", "env-val");
+    const ctx = baseContext({
+      vaultServiceFactory: mockVaultFactory({
+        v: { k: "vault-val" },
+      }),
+    });
+    const config = {
+      host: "${{ env.SWAMP_TEST_DS_EXPR_MIX }}",
+      token: "${{ vault.get(v, k) }}",
+    };
+    const result = await resolveDatastoreExpressions(config, ctx);
+    assertEquals(result, { host: "env-val", token: "vault-val" });
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_TEST_DS_EXPR_MIX", original);
+    } else Deno.env.delete("SWAMP_TEST_DS_EXPR_MIX");
+  }
+});
+
+Deno.test("resolveDatastoreExpressions: interpolates env and vault in one string", async () => {
+  const original = Deno.env.get("SWAMP_TEST_DS_EXPR_PREFIX");
+  try {
+    Deno.env.set("SWAMP_TEST_DS_EXPR_PREFIX", "prod");
+    const ctx = baseContext({
+      vaultServiceFactory: mockVaultFactory({
+        v: { k: "abc123" },
+      }),
+    });
+    const config = {
+      url: "${{ env.SWAMP_TEST_DS_EXPR_PREFIX }}-${{ vault.get(v, k) }}",
+    };
+    const result = await resolveDatastoreExpressions(config, ctx);
+    assertEquals(result, { url: "prod-abc123" });
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_TEST_DS_EXPR_PREFIX", original);
+    } else Deno.env.delete("SWAMP_TEST_DS_EXPR_PREFIX");
+  }
+});
+
+// ============================================================================
+// Error cases
+// ============================================================================
+
+Deno.test("resolveDatastoreExpressions: throws UserError for unsupported expression", async () => {
+  const config = { val: "${{ foo.bar }}" };
+  await assertRejects(
+    () => resolveDatastoreExpressions(config, baseContext()),
+    UserError,
+    "Unsupported expression",
+  );
+});
+
+Deno.test("resolveDatastoreExpressions: managedConfig blocks vault expressions", async () => {
+  const ctx = baseContext({
+    managedConfig: true,
+    vaultServiceFactory: mockVaultFactory({ v: { k: "val" } }),
+  });
+  const config = { token: "${{ vault.get(v, k) }}" };
+  await assertRejects(
+    () => resolveDatastoreExpressions(config, ctx),
+    UserError,
+    "managedConfig",
+  );
+});
+
+Deno.test("resolveDatastoreExpressions: managedConfig allows env expressions", async () => {
+  const original = Deno.env.get("SWAMP_TEST_DS_EXPR_MC");
+  try {
+    Deno.env.set("SWAMP_TEST_DS_EXPR_MC", "allowed");
+    const ctx = baseContext({ managedConfig: true });
+    const config = { token: "${{ env.SWAMP_TEST_DS_EXPR_MC }}" };
+    const result = await resolveDatastoreExpressions(config, ctx);
+    assertEquals(result, { token: "allowed" });
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_TEST_DS_EXPR_MC", original);
+    } else Deno.env.delete("SWAMP_TEST_DS_EXPR_MC");
+  }
+});
+
+// ============================================================================
+// Edge cases
+// ============================================================================
+
+Deno.test("resolveDatastoreExpressions: partial expression syntax passes through", async () => {
+  const config = { val: "token-${{ env.X" };
+  const result = await resolveDatastoreExpressions(config, baseContext());
+  assertEquals(result, { val: "token-${{ env.X" });
+});
+
+Deno.test("resolveDatastoreExpressions: non-string config values pass through", async () => {
+  const config = { port: 5432, ssl: true, timeout: null as unknown };
+  const result = await resolveDatastoreExpressions(config, baseContext());
+  assertEquals(result, { port: 5432, ssl: true, timeout: null });
+});
+
+Deno.test("resolveDatastoreExpressions: deeply nested config resolves at all levels", async () => {
+  const original = Deno.env.get("SWAMP_TEST_DS_EXPR_DEEP");
+  try {
+    Deno.env.set("SWAMP_TEST_DS_EXPR_DEEP", "deep-val");
+    const config = {
+      level1: {
+        level2: {
+          level3: { secret: "${{ env.SWAMP_TEST_DS_EXPR_DEEP }}" },
+        },
+      },
+    };
+    const result = await resolveDatastoreExpressions(config, baseContext());
+    assertEquals(result, {
+      level1: { level2: { level3: { secret: "deep-val" } } },
+    });
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_TEST_DS_EXPR_DEEP", original);
+    } else Deno.env.delete("SWAMP_TEST_DS_EXPR_DEEP");
+  }
+});

--- a/src/cli/resolve_datastore.ts
+++ b/src/cli/resolve_datastore.ts
@@ -46,6 +46,7 @@ import { datastoreTypeRegistry } from "../domain/datastore/datastore_type_regist
 import { UserError } from "../domain/errors.ts";
 import { resolveDatastoreType } from "../domain/extensions/extension_auto_resolver.ts";
 import { getAutoResolver } from "../domain/extensions/auto_resolver_context.ts";
+import { resolveDatastoreExpressions } from "./datastore_expression_resolver.ts";
 
 const logger = getLogger(["swamp", "datastore", "resolve"]);
 
@@ -114,8 +115,11 @@ export async function parseDatastoreEnvVar(
       await datastoreTypeRegistry.ensureTypeLoaded(renamedTo);
       const typeInfo = datastoreTypeRegistry.get(renamedTo);
       if (typeInfo?.createProvider) {
-        const config: Record<string, unknown> = { bucket };
+        let config: Record<string, unknown> = { bucket };
         if (prefix) config.prefix = prefix;
+
+        const envCtx = { repoDir: repoDir ?? Deno.cwd() };
+        config = await resolveDatastoreExpressions(config, envCtx);
 
         if (typeInfo.configSchema) {
           const result = typeInfo.configSchema.safeParse(config);
@@ -188,6 +192,9 @@ export async function parseDatastoreEnvVar(
       );
     }
   }
+
+  const envCtx = { repoDir: repoDir ?? Deno.cwd() };
+  config = await resolveDatastoreExpressions(config, envCtx);
 
   if (typeInfo.configSchema) {
     const result = typeInfo.configSchema.safeParse(config);
@@ -269,7 +276,7 @@ export async function resolveDatastoreConfig(
       const typeInfo = datastoreTypeRegistry.get(renamedTo);
       if (typeInfo?.createProvider) {
         // Build config from the S3-specific YAML fields
-        const config: Record<string, unknown> = {};
+        let config: Record<string, unknown> = {};
         if (ds.bucket) config.bucket = ds.bucket;
         if (ds.prefix) config.prefix = ds.prefix;
         if (ds.region) config.region = ds.region;
@@ -277,6 +284,12 @@ export async function resolveDatastoreConfig(
         if (ds.forcePathStyle != null) {
           config.forcePathStyle = ds.forcePathStyle;
         }
+
+        const exprCtx = {
+          repoDir: repoDir ?? Deno.cwd(),
+          managedConfig: ds.managedConfig,
+        };
+        config = await resolveDatastoreExpressions(config, exprCtx);
 
         if (typeInfo.configSchema) {
           const result = typeInfo.configSchema.safeParse(config);
@@ -358,7 +371,13 @@ export async function resolveDatastoreConfig(
       );
     }
 
-    const customConfig = ds.config ?? {};
+    let customConfig = ds.config ?? {};
+
+    const exprCtx = {
+      repoDir: repoDir ?? Deno.cwd(),
+      managedConfig: ds.managedConfig,
+    };
+    customConfig = await resolveDatastoreExpressions(customConfig, exprCtx);
 
     if (typeInfo.configSchema) {
       const result = typeInfo.configSchema.safeParse(customConfig);

--- a/src/cli/resolve_datastore_test.ts
+++ b/src/cli/resolve_datastore_test.ts
@@ -464,3 +464,84 @@ Deno.test("isCustomDatastoreConfig: returns true for custom type", () => {
     true,
   );
 });
+
+// ============================================================================
+// Expression resolution integration tests
+// ============================================================================
+
+Deno.test("resolveDatastoreConfig: resolves env expression in custom type YAML config", async () => {
+  ensureTestType("@test/ds-expr", {
+    configSchema: z.object({ token: z.string() }),
+  });
+  const original = Deno.env.get("SWAMP_TEST_DS_INTEG_TOKEN");
+  try {
+    Deno.env.set("SWAMP_TEST_DS_INTEG_TOKEN", "my-secret-token");
+    const marker: RepoMarkerData = {
+      swampVersion: "0.1.0",
+      initializedAt: "2024-01-01",
+      repoId: "test-id",
+      datastore: {
+        type: "@test/ds-expr",
+        config: { token: "${{ env.SWAMP_TEST_DS_INTEG_TOKEN }}" },
+      },
+    };
+    const config = await resolveDatastoreConfig(marker, undefined, "/tmp/test");
+    assertEquals(isCustomDatastoreConfig(config), true);
+    assertEquals(
+      (config as CustomDatastoreConfig).config.token,
+      "my-secret-token",
+    );
+  } finally {
+    if (original !== undefined) {
+      Deno.env.set("SWAMP_TEST_DS_INTEG_TOKEN", original);
+    } else Deno.env.delete("SWAMP_TEST_DS_INTEG_TOKEN");
+  }
+});
+
+Deno.test("resolveDatastoreConfig: resolves env expression in SWAMP_DATASTORE env var", async () => {
+  ensureTestType("@test/ds-expr-env", {
+    configSchema: z.object({ token: z.string() }),
+  });
+  const origDs = Deno.env.get("SWAMP_DATASTORE");
+  const origToken = Deno.env.get("SWAMP_TEST_DS_INTEG_TOKEN2");
+  try {
+    Deno.env.set("SWAMP_TEST_DS_INTEG_TOKEN2", "env-secret");
+    Deno.env.set(
+      "SWAMP_DATASTORE",
+      '@test/ds-expr-env:{"token":"${{ env.SWAMP_TEST_DS_INTEG_TOKEN2 }}"}',
+    );
+    const config = await resolveDatastoreConfig(null, undefined, "/tmp/test");
+    assertEquals(isCustomDatastoreConfig(config), true);
+    assertEquals(
+      (config as CustomDatastoreConfig).config.token,
+      "env-secret",
+    );
+  } finally {
+    if (origDs !== undefined) Deno.env.set("SWAMP_DATASTORE", origDs);
+    else Deno.env.delete("SWAMP_DATASTORE");
+    if (origToken !== undefined) {
+      Deno.env.set("SWAMP_TEST_DS_INTEG_TOKEN2", origToken);
+    } else Deno.env.delete("SWAMP_TEST_DS_INTEG_TOKEN2");
+  }
+});
+
+Deno.test("resolveDatastoreConfig: missing env expression in config throws UserError", async () => {
+  ensureTestType("@test/ds-expr-miss", {
+    configSchema: z.object({ token: z.string() }),
+  });
+  Deno.env.delete("SWAMP_TEST_DS_INTEG_NONEXISTENT");
+  const marker: RepoMarkerData = {
+    swampVersion: "0.1.0",
+    initializedAt: "2024-01-01",
+    repoId: "test-id",
+    datastore: {
+      type: "@test/ds-expr-miss",
+      config: { token: "${{ env.SWAMP_TEST_DS_INTEG_NONEXISTENT }}" },
+    },
+  };
+  await assertRejects(
+    () => resolveDatastoreConfig(marker, undefined, "/tmp/test"),
+    Error,
+    "SWAMP_TEST_DS_INTEG_NONEXISTENT",
+  );
+});


### PR DESCRIPTION
## Summary

- Add `${{ env.VAR }}` and `${{ vault.get(name, key) }}` expression resolution to datastore config values in `.swamp.yaml`
- Uses the same expression delimiter syntax as model/workflow definitions for consistency
- VaultService is lazily created via a lightweight early-boot factory that reads local vault configs without triggering the full vault type registry loading
- All installed vault types work (native `local_encryption` and extension providers like `@swamp/aws-sm`)

## Details

Datastore config in `.swamp.yaml` previously required literal token values. This forced operators to choose between committing secrets, gitignoring `.swamp.yaml`, or using `git skip-worktree` hacks. This change adds expression resolution at the datastore config layer, applied during `resolveDatastoreConfig()` before schema validation and `createProvider()`.

The resolver (`src/cli/datastore_expression_resolver.ts`) recursively walks config objects and resolves:
- `${{ env.VAR_NAME }}` — via `Deno.env.get()`
- `${{ vault.get(vaultName, secretKey) }}` — via a lazy VaultService

Four integration points in `resolve_datastore.ts` cover both `.swamp.yaml` and `SWAMP_DATASTORE` env var paths. The `managedConfig` circular dependency is detected and produces a clear error.

## Test plan

- [x] 23 unit tests for the expression resolver (env, vault, mixed, errors, edge cases)
- [x] 3 integration tests in `resolve_datastore_test.ts` (YAML config, env var, missing var)
- [x] E2E tested with minio: env expressions, vault expressions, mixed expressions, missing var error, full model run with data sync
- [x] All 52 tests pass, type check clean, lint clean, fmt clean
- [x] Verification workflow: build 9/9 passed, code review pass, adversarial review pass

Closes swamp-club#1801

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1Kd2EvJthEEPzL4mRAXu5