### PR TITLE
fix(update): replace LogTape output with writeOutput and add hourly cadence (swamp-club#1937)

### DIFF
--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -40,7 +40,7 @@ const CONFIG_KEYS: Record<string, { description: string; values?: string[] }> =
     },
     "update.cadence": {
       description: "How often to check for updates",
-      values: ["daily", "weekly"],
+      values: ["hourly", "daily", "weekly"],
     },
   };
 

--- a/src/cli/commands/config_test.ts
+++ b/src/cli/commands/config_test.ts
@@ -61,7 +61,7 @@ Deno.test("config set: rejects invalid cadence", async () => {
       "config",
       "set",
       "update.cadence",
-      "hourly",
+      "monthly",
     ],
     stdout: "piped",
     stderr: "piped",

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -49,7 +49,10 @@ import {
   AUTOUPDATE_LOG_RETENTION_DAYS,
   type AutoupdateLogEntry,
 } from "../../domain/update/autoupdate_log.ts";
-import type { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import {
+  type getSwampLogger,
+  writeOutput,
+} from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
 import { SkillAssets } from "../../infrastructure/assets/skill_assets.ts";
 import {
@@ -78,6 +81,7 @@ async function dirExists(path: string): Promise<boolean> {
 
 async function syncGlobalSkills(
   logger: ReturnType<typeof getSwampLogger>,
+  outputMode: "log" | "json" = "log",
 ): Promise<void> {
   if (isRunningAsRoot()) {
     logger
@@ -119,7 +123,9 @@ async function syncGlobalSkills(
     }
     await skillAssets.copySkillsTo(resolved);
     await removeSupersededSkills(resolved);
-    logger.info`Synced global skills to ${resolved}`;
+    if (outputMode === "log") {
+      writeOutput(`Synced global skills to ${resolved}`);
+    }
   }
 
   if (customDirs.length === 0) return;
@@ -139,7 +145,9 @@ async function syncGlobalSkills(
     }
     await skillAssets.copySkillsTo(resolved);
     await removeSupersededSkills(resolved);
-    logger.info`Synced global skills to ${resolved}`;
+    if (outputMode === "log") {
+      writeOutput(`Synced global skills to ${resolved}`);
+    }
     survivingCustomDirs.push(dir);
   }
 
@@ -323,18 +331,20 @@ async function runBackgroundUpdate(
 function promptCadence(defaultCadence: UpdateCadence): UpdateCadence {
   while (true) {
     const input = prompt(
-      "How often should swamp check for updates? (daily/weekly)",
+      "How often should swamp check for updates? (hourly/daily/weekly)",
       defaultCadence,
     );
     if (input === null) {
       throw new UserError(
-        "No input received. Use `swamp config set update.cadence <daily|weekly>` instead.",
+        "No input received. Use `swamp config set update.cadence <hourly|daily|weekly>` instead.",
       );
     }
     if (isValidCadence(input)) {
       return input;
     }
-    console.error(`Invalid cadence: ${input}. Must be "daily" or "weekly".`);
+    console.error(
+      `Invalid cadence: ${input}. Must be "hourly", "daily", or "weekly".`,
+    );
   }
 }
 
@@ -394,7 +404,6 @@ async function runSetupAuto(
 
   const prefsRepo = new UpdatePreferencesFileRepository();
   const prefs = await prefsRepo.read();
-  const logger = ctx.logger;
 
   const cadence = promptCadence(prefs.cadence);
 
@@ -412,16 +421,16 @@ async function runSetupAuto(
       }),
     );
   } else {
-    logger.info`Autoupdate enabled with ${cadence} checks`;
+    writeOutput(`Autoupdate enabled with ${cadence} checks`);
 
     if (launchdMode === "daemon") {
       const desc = privilegedSchedulerDescription();
-      logger.info`Installed as ${desc} (root-owned binary)`;
+      writeOutput(`Installed as ${desc} (root-owned binary)`);
     }
 
     const status = await scheduler.status();
     if (status.installed) {
-      logger.info("Background scheduler installed successfully");
+      writeOutput("Background scheduler installed successfully");
     }
   }
 }
@@ -452,7 +461,7 @@ async function runDisableAuto(
       JSON.stringify({ key: "update.auto", value: "disabled" }),
     );
   } else {
-    ctx.logger.info("Autoupdate disabled and scheduler removed");
+    writeOutput("Autoupdate disabled and scheduler removed");
   }
 }
 
@@ -487,38 +496,35 @@ async function runSetupAutoStatus(
     return;
   }
 
-  const logger = ctx.logger;
-
   if (!prefs.enabled) {
-    logger.info(
+    writeOutput(
       "Autoupdate is disabled. Run `swamp update --setup-auto` to enable.",
     );
     return;
   }
 
-  logger.info`Autoupdate: enabled`;
-  logger.info`Cadence: ${prefs.cadence}`;
+  writeOutput("Autoupdate: enabled");
+  writeOutput(`Cadence: ${prefs.cadence}`);
 
   const typeLabel = schedulerTypeDisplayLabel(launchdMode);
   if (typeLabel) {
-    logger.info`Scheduler type: ${typeLabel}`;
+    writeOutput(`Scheduler type: ${typeLabel}`);
   }
 
   const scheduler = await createScheduler({ launchdMode });
   const scheduleStatus = await scheduler.status();
-  logger.info`Scheduler installed: ${scheduleStatus.installed}`;
+  writeOutput(`Scheduler installed: ${scheduleStatus.installed}`);
 
   const logRepo = new AutoupdateLogFileRepository(logPath);
   const entries = await logRepo.readAll();
   if (entries.length > 0) {
     const last = entries[entries.length - 1];
-    logger.info`Last check: ${last.timestamp} (${last.outcome})`;
+    writeOutput(`Last check: ${last.timestamp} (${last.outcome})`);
     if (last.versionAfter) {
-      logger
-        .info`Last update: ${last.versionBefore} → ${last.versionAfter}`;
+      writeOutput(`Last update: ${last.versionBefore} → ${last.versionAfter}`);
     }
   } else {
-    logger.info("No autoupdate history yet");
+    writeOutput("No autoupdate history yet");
   }
 }
 
@@ -587,7 +593,7 @@ export const updateCommand = new Command()
       if (renderer.updated) {
         spinner?.update("Syncing global skills...");
         try {
-          await syncGlobalSkills(ctx.logger);
+          await syncGlobalSkills(ctx.logger, ctx.outputMode);
         } catch (err) {
           ctx.logger
             .warn`Failed to sync global skills: ${

--- a/src/domain/update/update_preferences.ts
+++ b/src/domain/update/update_preferences.ts
@@ -17,9 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-export type UpdateCadence = "daily" | "weekly";
+export type UpdateCadence = "hourly" | "daily" | "weekly";
 
 export const VALID_CADENCES: readonly UpdateCadence[] = [
+  "hourly",
   "daily",
   "weekly",
 ] as const;

--- a/src/domain/update/update_preferences_test.ts
+++ b/src/domain/update/update_preferences_test.ts
@@ -31,8 +31,11 @@ Deno.test("isValidCadence: accepts weekly", () => {
   assertEquals(isValidCadence("weekly"), true);
 });
 
+Deno.test("isValidCadence: accepts hourly", () => {
+  assertEquals(isValidCadence("hourly"), true);
+});
+
 Deno.test("isValidCadence: rejects invalid values", () => {
-  assertEquals(isValidCadence("hourly"), false);
   assertEquals(isValidCadence(""), false);
   assertEquals(isValidCadence("monthly"), false);
 });

--- a/src/infrastructure/update/cron_scheduler.ts
+++ b/src/infrastructure/update/cron_scheduler.ts
@@ -29,11 +29,21 @@ import { getSwampDataDir } from "../persistence/paths.ts";
 const CRON_MARKER = "# swamp-autoupdate";
 
 export function cronSchedule(cadence: UpdateCadence): string {
-  return cadence === "daily" ? "0 9 * * *" : "0 9 * * 1";
+  switch (cadence) {
+    case "hourly":
+      return "0 * * * *";
+    case "daily":
+      return "0 9 * * *";
+    case "weekly":
+      return "0 9 * * 1";
+  }
 }
 
 export function cadenceFromSchedule(schedule: string): UpdateCadence {
-  return schedule.trim().endsWith("* * 1") ? "weekly" : "daily";
+  const trimmed = schedule.trim();
+  if (trimmed === "0 * * * *") return "hourly";
+  if (trimmed.endsWith("* * 1")) return "weekly";
+  return "daily";
 }
 
 export function escapeShellPath(s: string): string {

--- a/src/infrastructure/update/launchd_scheduler.ts
+++ b/src/infrastructure/update/launchd_scheduler.ts
@@ -91,7 +91,11 @@ export function buildPlist(
   cadence: UpdateCadence,
   mode: LaunchdMode = "agent",
 ): string {
-  const interval = cadence === "daily" ? 86400 : 604800;
+  const interval = cadence === "hourly"
+    ? 3600
+    : cadence === "daily"
+    ? 86400
+    : 604800;
   const escapedPath = escapeXml(binaryPath);
   const logDir = autoupdateLogDir(mode);
   const stdoutLog = escapeXml(join(logDir, "autoupdate.stdout.log"));
@@ -127,7 +131,7 @@ export function buildPlist(
 }
 
 export function cadenceFromInterval(interval: number): UpdateCadence {
-  return interval <= 86400 ? "daily" : "weekly";
+  return interval <= 3600 ? "hourly" : interval <= 86400 ? "daily" : "weekly";
 }
 
 async function getUid(): Promise<string> {

--- a/src/infrastructure/update/scheduler_helpers_test.ts
+++ b/src/infrastructure/update/scheduler_helpers_test.ts
@@ -64,9 +64,18 @@ Deno.test("buildPlist: contains weekly interval", () => {
   assertStringIncludes(plist, "<integer>604800</integer>");
 });
 
+Deno.test("buildPlist: contains hourly interval", () => {
+  const plist = buildPlist("/usr/local/bin/swamp", "hourly");
+  assertStringIncludes(plist, "<integer>3600</integer>");
+});
+
 Deno.test("buildPlist: escapes special chars in path", () => {
   const plist = buildPlist('/opt/my "app/swamp', "daily");
   assertStringIncludes(plist, "&quot;");
+});
+
+Deno.test("cadenceFromInterval: hourly for 3600", () => {
+  assertEquals(cadenceFromInterval(3600), "hourly");
 });
 
 Deno.test("cadenceFromInterval: daily for 86400", () => {
@@ -108,6 +117,12 @@ Deno.test("buildService: escapes quotes in path", () => {
   assertStringIncludes(service, 'ExecStart="/opt/my \\"app/swamp"');
 });
 
+Deno.test("buildTimer: hourly calendar", () => {
+  const timer = buildTimer("hourly");
+  assertStringIncludes(timer, "OnCalendar=hourly");
+  assertStringIncludes(timer, "RandomizedDelaySec=300");
+});
+
 Deno.test("buildTimer: daily calendar", () => {
   const timer = buildTimer("daily");
   assertStringIncludes(timer, "OnCalendar=daily");
@@ -118,12 +133,20 @@ Deno.test("buildTimer: weekly calendar", () => {
   assertStringIncludes(timer, "OnCalendar=weekly");
 });
 
+Deno.test("cronSchedule: hourly schedule", () => {
+  assertEquals(cronSchedule("hourly"), "0 * * * *");
+});
+
 Deno.test("cronSchedule: daily schedule", () => {
   assertEquals(cronSchedule("daily"), "0 9 * * *");
 });
 
 Deno.test("cronSchedule: weekly schedule", () => {
   assertEquals(cronSchedule("weekly"), "0 9 * * 1");
+});
+
+Deno.test("cadenceFromSchedule: detects hourly", () => {
+  assertEquals(cadenceFromSchedule("0 * * * *"), "hourly");
 });
 
 Deno.test("cadenceFromSchedule: detects daily", () => {

--- a/src/infrastructure/update/systemd_scheduler.ts
+++ b/src/infrastructure/update/systemd_scheduler.ts
@@ -92,14 +92,19 @@ ExecStart="${escaped}" update --background
 }
 
 export function buildTimer(cadence: UpdateCadence): string {
-  const onCalendar = cadence === "daily" ? "daily" : "weekly";
+  const onCalendar = cadence === "hourly"
+    ? "hourly"
+    : cadence === "daily"
+    ? "daily"
+    : "weekly";
+  const jitter = cadence === "hourly" ? 300 : 3600;
   return `[Unit]
 Description=Swamp autoupdate timer
 
 [Timer]
 OnCalendar=${onCalendar}
 Persistent=true
-RandomizedDelaySec=3600
+RandomizedDelaySec=${jitter}
 
 [Install]
 WantedBy=timers.target
@@ -172,7 +177,10 @@ export class SystemdScheduler implements AutoupdateScheduler {
     try {
       const content = await Deno.readTextFile(timerPath(this.mode));
       const calendarMatch = content.match(/OnCalendar=(\w+)/);
-      const cadence: UpdateCadence = calendarMatch?.[1] === "weekly"
+      const cal = calendarMatch?.[1];
+      const cadence: UpdateCadence = cal === "hourly"
+        ? "hourly"
+        : cal === "weekly"
         ? "weekly"
         : "daily";
 

--- a/src/infrastructure/update/update_preferences_file_repository_test.ts
+++ b/src/infrastructure/update/update_preferences_file_repository_test.ts
@@ -86,7 +86,7 @@ Deno.test("UpdatePreferencesFileRepository: fills missing fields with defaults",
 Deno.test("UpdatePreferencesFileRepository: rejects invalid cadence", async () => {
   await withTempDir(async (dir) => {
     const filePath = join(dir, "update.yaml");
-    await Deno.writeTextFile(filePath, "enabled: true\ncadence: hourly\n");
+    await Deno.writeTextFile(filePath, "enabled: true\ncadence: monthly\n");
 
     const repo = new UpdatePreferencesFileRepository(filePath);
     const prefs = await repo.read();

--- a/src/presentation/renderers/update_check.ts
+++ b/src/presentation/renderers/update_check.ts
@@ -20,7 +20,10 @@
 import type { EventHandlers, UpdateCheckEvent } from "../../libswamp/mod.ts";
 import type { Renderer } from "../renderer.ts";
 import type { OutputMode } from "../output/output.ts";
-import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import {
+  getSwampLogger,
+  writeOutput,
+} from "../../infrastructure/logging/logger.ts";
 import { UserError } from "../../domain/errors.ts";
 
 export interface UpdateCheckRenderer extends Renderer<UpdateCheckEvent> {
@@ -38,20 +41,23 @@ class LogUpdateCheckRenderer implements UpdateCheckRenderer {
         const data = e.data;
         switch (data.status) {
           case "up_to_date":
-            logger.info`swamp is up to date (${data.currentVersion})`;
+            writeOutput(`swamp is up to date (${data.currentVersion})`);
             break;
           case "update_available":
-            logger
-              .info`Update available: ${data.currentVersion} \u2192 ${data.latestVersion}`;
-            logger.info("Run `swamp update` to install");
+            writeOutput(
+              `Update available: ${data.currentVersion} \u2192 ${data.latestVersion}`,
+            );
+            writeOutput("Run `swamp update` to install");
             break;
           case "updated":
             this.updated = true;
-            logger.info("swamp updated successfully!");
-            logger.info`${data.previousVersion} \u2192 ${data.newVersion}`;
-            logger.info("SHA-256 integrity check passed");
-            logger.info("The swamp binary has been updated globally.");
-            logger.info(
+            writeOutput("swamp updated successfully!");
+            writeOutput(
+              `${data.previousVersion} \u2192 ${data.newVersion}`,
+            );
+            writeOutput("SHA-256 integrity check passed");
+            writeOutput("The swamp binary has been updated globally.");
+            writeOutput(
               "Run `swamp repo upgrade` in your repositories to update settings and instructions.",
             );
             break;


### PR DESCRIPTION
## Summary

- Replaces raw LogTape `logger.info` calls with `writeOutput()` across the
  update command's log-mode output path (renderer, skill sync, `--setup-auto`
  subcommands), matching the clean output pattern used by `swamp repo init`
- Adds `"hourly"` as a valid update cadence alongside `"daily"` and `"weekly"`,
  updating all three scheduler implementations (launchd, systemd, cron), domain
  type, config validation, and tests
- Gates `writeOutput` in `syncGlobalSkills` on `outputMode === "log"` to avoid
  corrupting `--json` stdout
- Scales systemd `RandomizedDelaySec` to 300s for hourly cadence (vs 3600s for
  daily/weekly) so jitter doesn't exceed the interval

Closes swamp-club#1937

## Test plan

- [x] `deno run test src/domain/update/update_preferences_test.ts` — hourly accepted
- [x] `deno run test src/infrastructure/update/scheduler_helpers_test.ts` — all scheduler mappings
- [x] `deno run test src/cli/commands/update_test.ts` — renderer uses writeOutput
- [x] `deno run test src/cli/commands/config_test.ts` — invalid cadence rejection
- [x] `deno run test src/infrastructure/update/update_preferences_file_repository_test.ts`
- [x] Full verification workflow: lint, fmt, type-check, tests, compile, agent reviews (3x pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>