### PR TITLE
feat(repo): add AntiGravity as a built-in AI tool with full audit integration

### DIFF
--- a/design/surfaces/agent-interface.md
+++ b/design/surfaces/agent-interface.md
@@ -36,11 +36,12 @@ Each AI tool has a native global skills path that it reads at runtime:
 | copilot  | reads from `~/.agents/skills/` directly  | Yes                        |
 | kiro     | `~/.kiro/skills/`                        | No                         |
 | pi       | `~/.pi/agent/skills/`                    | Yes                        |
+| antigravity | reads from `~/.agents/skills/` directly | Yes                     |
 
 Tools that read from `~/.agents/skills/` natively (Amp, Cursor, OpenCode, Codex,
-Copilot, Pi) share a single copy. Claude Code and Kiro require their own copies
-at their vendor-specific global paths. Pi also reads from its own
-`~/.pi/agent/skills/` directory.
+Copilot, Pi, AntiGravity) share a single copy. Claude Code and Kiro require
+their own copies at their vendor-specific global paths. Pi also reads from its
+own `~/.pi/agent/skills/` directory.
 
 The `GLOBAL_SKILL_DIRS` mapping in `src/domain/repo/skill_dirs.ts` defines
 the home-relative path per built-in tool:
@@ -55,6 +56,7 @@ export const GLOBAL_SKILL_DIRS: Record<string, string> = {
   copilot: ".agents/skills",
   kiro: ".kiro/skills",
   pi: ".pi/agent/skills",
+  antigravity: ".agents/skills",
 };
 ```
 

--- a/src/cli/ai_tool_parser.ts
+++ b/src/cli/ai_tool_parser.ts
@@ -30,6 +30,7 @@ export const VALID_AI_TOOLS: readonly AiTool[] = [
   "codex",
   "copilot",
   "pi",
+  "antigravity",
   "none",
 ] as const;
 

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -90,6 +90,8 @@ const VALID_HOOK_TOOLS: HookTool[] = [
   "kiro",
   "opencode",
   "copilot",
+  "pi",
+  "antigravity",
 ];
 
 /**

--- a/src/cli/commands/repo_init.ts
+++ b/src/cli/commands/repo_init.ts
@@ -54,6 +54,8 @@ class ToolNameType extends StringType {
       "codex",
       "copilot",
       "kiro",
+      "pi",
+      "antigravity",
       "none",
     ];
   }

--- a/src/cli/resolve_extension_files.ts
+++ b/src/cli/resolve_extension_files.ts
@@ -468,7 +468,7 @@ export async function resolveExtensionFiles(
 
     if (candidateBases.length === 0) {
       throw new UserError(
-        `Cannot package skills: no enrolled tools have skill directories. Set a tool with: swamp repo upgrade --tool <claude|cursor|kiro|opencode|codex|pi>`,
+        `Cannot package skills: no enrolled tools have skill directories. Set a tool with: swamp repo upgrade --tool <claude|cursor|kiro|opencode|codex|pi|antigravity>`,
       );
     }
 

--- a/src/domain/audit/doctor/checks/agent_config_loadable.ts
+++ b/src/domain/audit/doctor/checks/agent_config_loadable.ts
@@ -33,6 +33,7 @@ const CONFIG_FILES: Record<string, string[]> = {
   opencode: [".opencode/plugins/swamp-audit.ts"],
   copilot: [".github/hooks/swamp-audit.json"],
   pi: [".pi/extensions/swamp-audit.ts"],
+  antigravity: [".agents/hooks.json"],
 };
 
 async function readJsonFile(path: string): Promise<unknown> {
@@ -324,6 +325,40 @@ async function checkPi(ctx: CheckContext): Promise<CheckResult> {
   };
 }
 
+async function checkAntiGravity(ctx: CheckContext): Promise<CheckResult> {
+  const hooksPath = join(ctx.repoPath, ".agents/hooks.json");
+  let content: string;
+  try {
+    content = await Deno.readTextFile(hooksPath);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return {
+        name: "agent-config-loadable",
+        status: "fail",
+        message: `${hooksPath} is missing`,
+        hint: "Run `swamp init --tool antigravity --force` to install hooks.",
+      };
+    }
+    throw error;
+  }
+  if (
+    !(content.includes("swamp") && content.includes("audit") &&
+      content.includes("record"))
+  ) {
+    return {
+      name: "agent-config-loadable",
+      status: "fail",
+      message: "AntiGravity hooks.json does not reference `swamp audit record`",
+      hint: "Run `swamp init --tool antigravity --force` to rewrite the hooks.",
+    };
+  }
+  return {
+    name: "agent-config-loadable",
+    status: "pass",
+    message: `${hooksPath} is present and references \`swamp audit record\``,
+  };
+}
+
 function appliesTo(tool: string): boolean {
   return tool in CONFIG_FILES;
 }
@@ -346,6 +381,8 @@ export const agentConfigLoadableCheck: PreflightCheck = {
         return await checkCopilot(ctx);
       case "pi":
         return await checkPi(ctx);
+      case "antigravity":
+        return await checkAntiGravity(ctx);
       default:
         return {
           name: "agent-config-loadable",

--- a/src/domain/audit/doctor/checks/agent_config_loadable_test.ts
+++ b/src/domain/audit/doctor/checks/agent_config_loadable_test.ts
@@ -300,3 +300,52 @@ Deno.test("agentConfigLoadable: pi fails when extension does not reference swamp
     assertStringIncludes(result.message, "swamp audit record");
   });
 });
+
+Deno.test("agentConfigLoadable: antigravity passes when hooks.json references swamp audit record", async () => {
+  await withTempRepo(async (repo) => {
+    const path = join(repo, ".agents/hooks.json");
+    await ensureDir(join(path, ".."));
+    await Deno.writeTextFile(
+      path,
+      JSON.stringify({
+        "swamp-audit": {
+          enabled: true,
+          PostToolUse: [{
+            matcher: "run_command",
+            hooks: [{
+              type: "command",
+              command: "swamp audit record --from-hook --tool antigravity",
+            }],
+          }],
+        },
+      }),
+    );
+    const result = await agentConfigLoadableCheck.run(
+      makeCtx(repo, "antigravity"),
+    );
+    assertEquals(result.status, "pass");
+  });
+});
+
+Deno.test("agentConfigLoadable: antigravity fails when hooks.json is missing", async () => {
+  await withTempRepo(async (repo) => {
+    const result = await agentConfigLoadableCheck.run(
+      makeCtx(repo, "antigravity"),
+    );
+    assertEquals(result.status, "fail");
+    assertStringIncludes(result.message, "missing");
+  });
+});
+
+Deno.test("agentConfigLoadable: antigravity fails when hooks.json does not reference swamp", async () => {
+  await withTempRepo(async (repo) => {
+    const path = join(repo, ".agents/hooks.json");
+    await ensureDir(join(path, ".."));
+    await Deno.writeTextFile(path, JSON.stringify({ other: {} }));
+    const result = await agentConfigLoadableCheck.run(
+      makeCtx(repo, "antigravity"),
+    );
+    assertEquals(result.status, "fail");
+    assertStringIncludes(result.message, "swamp audit record");
+  });
+});

--- a/src/domain/audit/doctor/checks/binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path.ts
@@ -29,11 +29,14 @@ const INSTALL_HINTS: Record<string, string> = {
   copilot:
     "Install GitHub Copilot CLI: https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli",
   pi: "Install Pi: https://pi.dev/docs/latest",
+  antigravity:
+    "Install AntiGravity CLI: https://antigravity.google/docs/cli/install/",
 };
 
 function appliesTo(tool: string): boolean {
   return tool === "claude" || tool === "cursor" || tool === "kiro" ||
-    tool === "opencode" || tool === "copilot" || tool === "pi";
+    tool === "opencode" || tool === "copilot" || tool === "pi" ||
+    tool === "antigravity";
 }
 
 /**

--- a/src/domain/audit/doctor/checks/binary_on_path_test.ts
+++ b/src/domain/audit/doctor/checks/binary_on_path_test.ts
@@ -69,7 +69,7 @@ Deno.test("binaryOnPath: uses tool-specific binary name", async () => {
   assertEquals(seen, ["kiro-cli", "claude", "cursor", "opencode", "copilot"]);
 });
 
-Deno.test("binaryOnPath: appliesTo returns true for all five audit tools, false otherwise", () => {
+Deno.test("binaryOnPath: appliesTo returns true for all audit tools, false otherwise", () => {
   const check = makeBinaryOnPathCheck({
     resolveBinary: () => Promise.resolve(null),
   });
@@ -78,6 +78,8 @@ Deno.test("binaryOnPath: appliesTo returns true for all five audit tools, false 
   assertEquals(check.appliesTo("kiro"), true);
   assertEquals(check.appliesTo("opencode"), true);
   assertEquals(check.appliesTo("copilot"), true);
+  assertEquals(check.appliesTo("pi"), true);
+  assertEquals(check.appliesTo("antigravity"), true);
   assertEquals(check.appliesTo("amp"), false);
   assertEquals(check.appliesTo("codex"), false);
   assertEquals(check.appliesTo("none"), false);

--- a/src/domain/audit/doctor/checks/recording_smoke.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke.ts
@@ -36,7 +36,8 @@ import { syntheticPayloadFor } from "../synthetic_payloads.ts";
 
 function appliesTo(tool: string): boolean {
   return tool === "claude" || tool === "cursor" || tool === "kiro" ||
-    tool === "opencode" || tool === "copilot" || tool === "pi";
+    tool === "opencode" || tool === "copilot" || tool === "pi" ||
+    tool === "antigravity";
 }
 
 function randomNonce(): string {

--- a/src/domain/audit/doctor/checks/recording_smoke_test.ts
+++ b/src/domain/audit/doctor/checks/recording_smoke_test.ts
@@ -129,6 +129,9 @@ Deno.test("recordingSmokeTest: appliesTo returns true only for audit-hook tools"
   assertEquals(recordingSmokeTestCheck.appliesTo("claude"), true);
   assertEquals(recordingSmokeTestCheck.appliesTo("kiro"), true);
   assertEquals(recordingSmokeTestCheck.appliesTo("copilot"), true);
+  assertEquals(recordingSmokeTestCheck.appliesTo("opencode"), true);
+  assertEquals(recordingSmokeTestCheck.appliesTo("pi"), true);
+  assertEquals(recordingSmokeTestCheck.appliesTo("antigravity"), true);
   assertEquals(recordingSmokeTestCheck.appliesTo("amp"), false);
   assertEquals(recordingSmokeTestCheck.appliesTo("codex"), false);
   assertEquals(recordingSmokeTestCheck.appliesTo("none"), false);

--- a/src/domain/audit/doctor/checks/resolve_binary.ts
+++ b/src/domain/audit/doctor/checks/resolve_binary.ts
@@ -39,6 +39,10 @@ export function binaryNameFor(tool: string): string {
       return "opencode";
     case "copilot":
       return "copilot";
+    case "pi":
+      return "pi";
+    case "antigravity":
+      return "agy";
     default:
       return tool;
   }

--- a/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
@@ -35,7 +35,8 @@ import type { ResolveBinary } from "./resolve_binary.ts";
 
 function appliesTo(tool: string): boolean {
   return tool === "claude" || tool === "cursor" || tool === "kiro" ||
-    tool === "opencode" || tool === "copilot" || tool === "pi";
+    tool === "opencode" || tool === "copilot" || tool === "pi" ||
+    tool === "antigravity";
 }
 
 async function checkKiroBakedPath(ctx: CheckContext): Promise<{

--- a/src/domain/audit/doctor/synthetic_payloads.ts
+++ b/src/domain/audit/doctor/synthetic_payloads.ts
@@ -144,6 +144,16 @@ export function syntheticPayloadFor(
       };
       return { stdin: JSON.stringify(raw), env: {}, expectedCommand };
     }
+    case "antigravity": {
+      const raw = {
+        toolCall: {
+          name: "run_command",
+          args: { CommandLine: expectedCommand, Cwd: cwd },
+        },
+        conversationId: DOCTOR_SMOKE_TEST_SESSION_ID,
+      };
+      return { stdin: JSON.stringify(raw), env: {}, expectedCommand };
+    }
     case "amp":
     case "codex":
     case "none":

--- a/src/domain/audit/doctor/synthetic_payloads_test.ts
+++ b/src/domain/audit/doctor/synthetic_payloads_test.ts
@@ -38,6 +38,7 @@ const SUPPORTED_TOOLS: HookTool[] = [
   "opencode",
   "copilot",
   "pi",
+  "antigravity",
 ];
 
 for (const tool of SUPPORTED_TOOLS) {

--- a/src/domain/audit/hook_input.ts
+++ b/src/domain/audit/hook_input.ts
@@ -26,7 +26,8 @@ export type HookTool =
   | "kiro"
   | "opencode"
   | "copilot"
-  | "pi";
+  | "pi"
+  | "antigravity";
 
 /**
  * Normalized hook input from any supported tool.
@@ -88,6 +89,8 @@ export function normalizeHookInput(
       return normalizeOpenCode(raw);
     case "pi":
       return normalizePi(raw);
+    case "antigravity":
+      return normalizeAntiGravity(raw);
     case "copilot":
       return normalizeCopilot(raw);
   }
@@ -254,6 +257,34 @@ function normalizePi(
     command,
     cwd: (raw.cwd as string) || ".",
     sessionId: raw.session_id as string | undefined,
+    isFailure,
+    ...(isFailure && errorStr ? { errorMessage: errorStr } : {}),
+  };
+}
+
+/**
+ * AntiGravity: PostToolUse hooks via .agents/hooks.json.
+ * toolCall.name === "run_command", command from toolCall.args.CommandLine,
+ * cwd from toolCall.args.Cwd, session from conversationId.
+ */
+function normalizeAntiGravity(
+  raw: Record<string, unknown>,
+): NormalizedHookInput | null {
+  const toolCall = raw.toolCall as
+    | { name?: string; args?: { CommandLine?: string; Cwd?: string } }
+    | undefined;
+  if (toolCall?.name !== "run_command") return null;
+
+  const command = toolCall.args?.CommandLine;
+  if (!command) return null;
+
+  const errorStr = raw.error as string | undefined;
+  const isFailure = !!errorStr;
+
+  return {
+    command,
+    cwd: toolCall.args?.Cwd || (raw.cwd as string) || ".",
+    sessionId: raw.conversationId as string | undefined,
     isFailure,
     ...(isFailure && errorStr ? { errorMessage: errorStr } : {}),
   };

--- a/src/domain/audit/hook_input_test.ts
+++ b/src/domain/audit/hook_input_test.ts
@@ -362,6 +362,51 @@ Deno.test("normalizeHookInput pi: skips non-bash tools", () => {
   assertEquals(result, null);
 });
 
+// ---- AntiGravity normalization ----
+
+Deno.test("normalizeHookInput antigravity: normalizes successful run_command", () => {
+  const result = normalizeHookInput("antigravity", {
+    conversationId: "agy-session-1",
+    toolCall: {
+      name: "run_command",
+      args: { CommandLine: "ls -la", Cwd: "/code" },
+    },
+  });
+
+  assertEquals(result, {
+    command: "ls -la",
+    cwd: "/code",
+    sessionId: "agy-session-1",
+    isFailure: false,
+  });
+});
+
+Deno.test("normalizeHookInput antigravity: normalizes failed run_command", () => {
+  const result = normalizeHookInput("antigravity", {
+    conversationId: "agy-session-1",
+    toolCall: {
+      name: "run_command",
+      args: { CommandLine: "make build", Cwd: "/code" },
+    },
+    error: "build failed",
+  });
+
+  assertEquals(result?.isFailure, true);
+  assertEquals(result?.errorMessage, "build failed");
+});
+
+Deno.test("normalizeHookInput antigravity: skips non-run_command tools", () => {
+  const result = normalizeHookInput("antigravity", {
+    conversationId: "agy-session-1",
+    toolCall: {
+      name: "view_file",
+      args: { Path: "/foo" },
+    },
+  });
+
+  assertEquals(result, null);
+});
+
 // ---- Copilot normalization (camelCase format) ----
 
 Deno.test("normalizeHookInput copilot: normalizes successful bash (camelCase)", () => {

--- a/src/domain/repo/ai_tool.ts
+++ b/src/domain/repo/ai_tool.ts
@@ -36,6 +36,7 @@ export type AiTool =
   | "copilot"
   | "kiro"
   | "pi"
+  | "antigravity"
   | "none";
 
 export { isBuiltInTool } from "./custom_tool.ts";

--- a/src/domain/repo/custom_tool.ts
+++ b/src/domain/repo/custom_tool.ts
@@ -51,6 +51,7 @@ export const BUILT_IN_TOOL_NAMES: readonly string[] = [
   "copilot",
   "kiro",
   "pi",
+  "antigravity",
   "none",
 ];
 
@@ -170,6 +171,15 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
         name: "pi",
         isBuiltIn: true,
         skillsDir: ".pi/skills",
+        instructionsFile: "AGENTS.md",
+        instructionsMode: "shared",
+        skillReferenceStyle: "name",
+      };
+    case "antigravity":
+      return {
+        name: "antigravity",
+        isBuiltIn: true,
+        skillsDir: ".agents/skills",
         instructionsFile: "AGENTS.md",
         instructionsMode: "shared",
         skillReferenceStyle: "name",

--- a/src/domain/repo/custom_tool_test.ts
+++ b/src/domain/repo/custom_tool_test.ts
@@ -40,6 +40,7 @@ Deno.test("isBuiltInTool: recognizes built-in tools", () => {
   assertEquals(isBuiltInTool("copilot"), true);
   assertEquals(isBuiltInTool("kiro"), true);
   assertEquals(isBuiltInTool("pi"), true);
+  assertEquals(isBuiltInTool("antigravity"), true);
   assertEquals(isBuiltInTool("none"), true);
 });
 
@@ -88,6 +89,16 @@ Deno.test("validateCustomToolName: rejects built-in names case-insensitively", (
   );
   assertThrows(
     () => validateCustomToolName("Pi"),
+    UserError,
+    "conflicts with a built-in",
+  );
+  assertThrows(
+    () => validateCustomToolName("antigravity"),
+    UserError,
+    "conflicts with a built-in",
+  );
+  assertThrows(
+    () => validateCustomToolName("Antigravity"),
     UserError,
     "conflicts with a built-in",
   );
@@ -162,8 +173,26 @@ Deno.test("builtInToolConfig: pi config", () => {
   assertEquals(config.skillReferenceStyle, "name");
 });
 
-Deno.test("builtInToolConfig: amp/opencode/codex/copilot share AGENTS.md", () => {
-  for (const tool of ["amp", "opencode", "codex", "copilot"] as const) {
+Deno.test("builtInToolConfig: antigravity config", () => {
+  const config = builtInToolConfig("antigravity");
+  assertEquals(config.name, "antigravity");
+  assertEquals(config.isBuiltIn, true);
+  assertEquals(config.skillsDir, ".agents/skills");
+  assertEquals(config.instructionsFile, "AGENTS.md");
+  assertEquals(config.instructionsMode, "shared");
+  assertEquals(config.skillReferenceStyle, "name");
+});
+
+Deno.test("builtInToolConfig: amp/opencode/codex/copilot/antigravity share AGENTS.md", () => {
+  for (
+    const tool of [
+      "amp",
+      "opencode",
+      "codex",
+      "copilot",
+      "antigravity",
+    ] as const
+  ) {
     const config = builtInToolConfig(tool);
     assertEquals(config.instructionsFile, "AGENTS.md");
     assertEquals(config.instructionsMode, "shared");

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -814,6 +814,14 @@ export class RepoService {
           if (changed) changedFiles.push(".pi/extensions/swamp-audit.ts");
           break;
         }
+        case "antigravity": {
+          const changed = alreadyExists
+            ? await this.updateAntiGravityHooks(repoPath)
+            : await this.createAntiGravityHooksIfNotExists(repoPath);
+          settingsChanged = changed;
+          if (changed) changedFiles.push(".agents/hooks.json");
+          break;
+        }
         case "codex":
         case "none":
           break;
@@ -2324,6 +2332,72 @@ export default function swampAudit(pi) {
       extensionPath,
       this.generatePiExtensionContent(),
     );
+  }
+
+  private generateAntiGravityHooksContent(): string {
+    const hooks = {
+      "swamp-audit": {
+        enabled: true,
+        PostToolUse: [
+          {
+            matcher: "run_command",
+            hooks: [
+              {
+                type: "command",
+                command: "swamp audit record --from-hook --tool antigravity",
+                timeout: 10,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    return JSON.stringify(hooks, null, 2) + "\n";
+  }
+
+  private createAntiGravityHooksIfNotExists(
+    repoPath: RepoPath,
+  ): Promise<boolean> {
+    const hooksPath = join(
+      repoPath.value,
+      ".agents",
+      "hooks.json",
+    );
+    return this.createFileIfNotExists(
+      hooksPath,
+      this.generateAntiGravityHooksContent(),
+    );
+  }
+
+  private async updateAntiGravityHooks(
+    repoPath: RepoPath,
+  ): Promise<boolean> {
+    const hooksPath = join(repoPath.value, ".agents", "hooks.json");
+
+    let existing: Record<string, unknown> = {};
+    let hooksExisted = false;
+
+    try {
+      const content = await Deno.readTextFile(hooksPath);
+      existing = JSON.parse(content);
+      hooksExisted = true;
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+
+    const generated = JSON.parse(this.generateAntiGravityHooksContent());
+    const merged = { ...existing, ...generated };
+    const mergedStr = JSON.stringify(merged, null, 2) + "\n";
+
+    if (hooksExisted && JSON.stringify(existing) === JSON.stringify(merged)) {
+      return false;
+    }
+
+    await ensureDir(join(repoPath.value, ".agents"));
+    await atomicWriteTextFile(hooksPath, mergedStr);
+    return true;
   }
 
   /**

--- a/src/domain/repo/skill_dirs.ts
+++ b/src/domain/repo/skill_dirs.ts
@@ -37,6 +37,7 @@ export const SKILL_DIRS: Record<string, string> = {
   copilot: ".agents/skills",
   kiro: ".kiro/skills",
   pi: ".pi/skills",
+  antigravity: ".agents/skills",
 };
 
 /**
@@ -54,6 +55,7 @@ export const GLOBAL_SKILL_DIRS: Record<string, string> = {
   copilot: ".agents/skills",
   kiro: ".kiro/skills",
   pi: ".pi/agent/skills",
+  antigravity: ".agents/skills",
 };
 
 /**

--- a/src/domain/repo/skill_dirs_test.ts
+++ b/src/domain/repo/skill_dirs_test.ts
@@ -39,12 +39,13 @@ Deno.test("GLOBAL_SKILL_DIRS: pi uses vendor-specific path", () => {
   assertEquals(GLOBAL_SKILL_DIRS["pi"], ".pi/agent/skills");
 });
 
-Deno.test("GLOBAL_SKILL_DIRS: amp/codex/cursor/opencode/copilot share .agents/skills", () => {
+Deno.test("GLOBAL_SKILL_DIRS: amp/codex/cursor/opencode/copilot/antigravity share .agents/skills", () => {
   assertEquals(GLOBAL_SKILL_DIRS["amp"], ".agents/skills");
   assertEquals(GLOBAL_SKILL_DIRS["codex"], ".agents/skills");
   assertEquals(GLOBAL_SKILL_DIRS["cursor"], ".agents/skills");
   assertEquals(GLOBAL_SKILL_DIRS["opencode"], ".agents/skills");
   assertEquals(GLOBAL_SKILL_DIRS["copilot"], ".agents/skills");
+  assertEquals(GLOBAL_SKILL_DIRS["antigravity"], ".agents/skills");
 });
 
 Deno.test("resolveGlobalSkillsDir: returns absolute path under home", () => {
@@ -124,6 +125,12 @@ Deno.test("resolveUniqueLocalSkillsDirs: pi uses .pi/skills", () => {
   const dirs = resolveUniqueLocalSkillsDirs("/repo", ["pi"]);
   assertEquals(dirs.length, 1);
   assertPathStringIncludes(dirs[0], `.pi${SEPARATOR}skills`);
+});
+
+Deno.test("resolveUniqueLocalSkillsDirs: antigravity uses .agents/skills", () => {
+  const dirs = resolveUniqueLocalSkillsDirs("/repo", ["antigravity"]);
+  assertEquals(dirs.length, 1);
+  assertPathStringIncludes(dirs[0], `.agents${SEPARATOR}skills`);
 });
 
 Deno.test("resolveUniqueLocalSkillsDirs: unknown tool uses fallback path", () => {

--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -92,6 +92,12 @@ const TOOL_GUIDANCE: Record<string, ToolGuidance> = {
     nextStepSummary:
       "Run `pi` in this directory and invoke /skill:swamp-getting-started",
   },
+  antigravity: {
+    launch: "Run agy in this directory, then invoke:",
+    command: "/skill:swamp-getting-started",
+    nextStepSummary:
+      "Run `agy` in this directory and invoke /skill:swamp-getting-started",
+  },
 };
 
 function renderToolGuidance(tool: string): void {
@@ -120,6 +126,7 @@ const TOOL_CLEANUP_PATHS: Partial<Record<string, readonly string[]>> = {
   codex: [".agents/skills/"],
   copilot: [".agents/skills/", ".github/hooks/"],
   pi: [".pi/"],
+  antigravity: [".agents/hooks.json", ".agents/skills/"],
 };
 
 /**


### PR DESCRIPTION
## Summary

- Register Google AntiGravity CLI (`agy`) as the 10th built-in AI tool alongside amp, claude, cursor, opencode, codex, copilot, kiro, and pi
- Generate `.agents/hooks.json` with PostToolUse hook that intercepts `run_command` tool calls and pipes stdin to `swamp audit record`
- Add `normalizeAntiGravity()` hook normalizer mapping AntiGravity's `toolCall.args.CommandLine/Cwd` + `conversationId` to `NormalizedHookInput`
- Add `binaryNameFor("antigravity")` → `"agy"` mapping and doctor checks (agent-config-loadable, binary-on-path, recording-smoke, swamp-binary-on-path)
- Also fixes: add Pi to `VALID_HOOK_TOOLS` (was missing from #2339, filed as #1940) and `ToolNameType.complete()`

AntiGravity follows the `.agents/` convention (shared with amp/codex/copilot/opencode): `AGENTS.md` instructions, `.agents/skills/` for project-level skills.

## Test plan

- [x] `isBuiltInTool("antigravity")` returns true, `validateCustomToolName("antigravity")` rejects
- [x] `builtInToolConfig("antigravity")` returns correct config (`.agents/skills`, `AGENTS.md`, shared, name-based)
- [x] Skill dir resolution: `.agents/skills` project and global
- [x] Hook normalization round-trip: AntiGravity PostToolUse payload → NormalizedHookInput (3 tests)
- [x] Synthetic payload normalizes to expected command
- [x] Doctor `checkAntiGravity`: pass/fail-missing/fail-no-reference coverage
- [x] `appliesTo` tests updated for binary_on_path + recording_smoke
- [x] Verification: 7/7 passed, 6 skipped (guard) — code review VERDICT: pass

Closes swamp-club#1936

🤖 Generated with [Claude Code](https://claude.com/claude-code)