### PR TITLE
fix(install): verify tarball against resolved version checksum to avoid alias race (swamp-club#1941)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,9 +84,14 @@ main() {
   checksum="$asset.sha256"
   download "$asset_url" "$tmpdir/$asset"
   resolved_asset_url="$DOWNLOADED_URL"
-  download "$asset_url.sha256" "$tmpdir/$checksum"
 
-  verify_sha256 "$tmpdir/$asset" "$tmpdir/$checksum"
+  # Download the checksum from the resolved (version-pinned) URL, not the
+  # alias URL. The alias tarball and alias .sha256 are separate S3 objects
+  # updated non-atomically, so fetching both from the alias can race during
+  # releases. The version-pinned checksum is immutable.
+  download "$resolved_asset_url.sha256" "$tmpdir/$checksum"
+
+  verify_sha256_resolved "$tmpdir/$asset" "$tmpdir/$checksum"
   validate_archive "$tmpdir/$asset" "$bin"
 
   release_version="$(release_version_from_url "$resolved_asset_url")"
@@ -391,6 +396,24 @@ compute_sha256() {
   fi
 
   echo "${actual%% *}"
+}
+
+verify_sha256_resolved() {
+  local archive checksum expected actual
+  archive="$1"
+  checksum="$2"
+
+  expected=""
+  IFS=' ' read -r expected _ <"$checksum" || true
+  validate_sha256 "$expected" "$(basename "$archive")"
+
+  actual="$(compute_sha256 "$archive")"
+
+  if [ "$expected" != "$actual" ]; then
+    die "SHA-256 checksum verification failed for '$(basename "$archive")'"
+  fi
+
+  info "Verified SHA-256 checksum for '$(basename "$archive")'"
 }
 
 verify_sha256() {


### PR DESCRIPTION
## Summary

- Fix race condition in `install.sh` where the `stable` alias tarball and `.sha256` checksum are fetched as two separate S3 objects that can resolve to different release versions during the 15-20 minute UAT window when the alias is being updated
- Download the `.sha256` from the resolved (version-pinned, immutable) URL derived from the tarball's S3 redirect instead of from the alias URL, guaranteeing both artifacts reference the same release
- Add `verify_sha256_resolved` function that extracts only the hash (ignoring the filename field) since the resolved checksum references the version-specific filename

## Test Plan

- [x] Unit tests: sourced install.sh functions and verified `verify_sha256_resolved` accepts correct hash with mismatched filename, rejects wrong hash, and handles version-specific filenames
- [x] End-to-end: ran `install.sh -V stable` — confirmed tarball downloads via alias redirect, checksum downloads from resolved version path, and both verifications pass
- [x] End-to-end: ran `install.sh -V <pinned-version>` — confirmed no regression for non-alias installs
- [x] Build verification: lint, fmt, type-check, tests, vuln-scan, compile all pass
- [x] Adversarial review: VERDICT pass, no findings
- [x] UX review: VERDICT pass, no UX impact

Closes swamp-club#1941

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: magistr <magistr@users.noreply.github.com>