### PR TITLE
fix(extensions): split methods catch-all in formatUserModelError into specific sub-field checks (swamp-club#1939)

### DIFF
--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -196,16 +196,73 @@ function formatUserModelError(error: z.ZodError): string {
   }
 
   const methodArgsIssue = issues.find(
-    (i) => i.path[0] === "methods" && String(i.path[2]) === "arguments",
+    (i) =>
+      i.path[0] === "methods" && i.path.length >= 3 &&
+      String(i.path[i.path.length - 1]) === "arguments",
   );
   if (methodArgsIssue) {
+    const methodName = String(
+      methodArgsIssue.path[methodArgsIssue.path.length - 2],
+    );
     return (
-      "Missing or invalid 'arguments' on method definition. " +
+      `Missing or invalid 'arguments' on method '${methodName}'. ` +
       "Add a Zod schema to validate method arguments.\n\n" +
       "Example:\n" +
       "  arguments: z.object({\n" +
       '    name: z.string().describe("Resource name"),\n' +
       "  }),"
+    );
+  }
+
+  const methodExecuteIssue = issues.find(
+    (i) =>
+      i.path[0] === "methods" && i.path.length >= 3 &&
+      String(i.path[i.path.length - 1]) === "execute",
+  );
+  if (methodExecuteIssue) {
+    const methodName = String(
+      methodExecuteIssue.path[methodExecuteIssue.path.length - 2],
+    );
+    return (
+      `Missing or invalid 'execute' on method '${methodName}'. ` +
+      "'execute' must be an async function.\n\n" +
+      "Example:\n" +
+      "  execute: async (args, context) => {\n" +
+      "    // Your logic here\n" +
+      "    return { dataHandles: [] };\n" +
+      "  },"
+    );
+  }
+
+  const methodKindIssue = issues.find(
+    (i) =>
+      i.path[0] === "methods" && i.path.length >= 3 &&
+      String(i.path[i.path.length - 1]) === "kind",
+  );
+  if (methodKindIssue) {
+    const methodName = String(
+      methodKindIssue.path[methodKindIssue.path.length - 2],
+    );
+    return (
+      `Invalid 'kind' value on method '${methodName}'. ` +
+      "Allowed values: create, read, update, delete, list, action."
+    );
+  }
+
+  const methodDescriptionIssue = issues.find(
+    (i) =>
+      i.path[0] === "methods" && i.path.length >= 3 &&
+      String(i.path[i.path.length - 1]) === "description",
+  );
+  if (methodDescriptionIssue) {
+    const methodName = String(
+      methodDescriptionIssue.path[methodDescriptionIssue.path.length - 2],
+    );
+    return (
+      `Missing 'description' on method '${methodName}'. ` +
+      "Every method must have a description string.\n\n" +
+      "Example:\n" +
+      '  description: "Execute the model",'
     );
   }
 
@@ -229,8 +286,10 @@ function formatUserModelError(error: z.ZodError): string {
     );
   }
 
-  const methodsIssue = issues.find((i) => i.path[0] === "methods");
-  if (methodsIssue) {
+  const methodsMissingIssue = issues.find(
+    (i) => i.path[0] === "methods" && i.path.length === 1,
+  );
+  if (methodsMissingIssue) {
     return (
       "Missing required 'methods' field. " +
       "Add at least one method to your model.\n\n" +
@@ -246,6 +305,15 @@ function formatUserModelError(error: z.ZodError): string {
       "    },\n" +
       "  },"
     );
+  }
+
+  const methodSubFieldIssue = issues.find(
+    (i) => i.path[0] === "methods" && i.path.length > 1,
+  );
+  if (methodSubFieldIssue) {
+    return `${
+      methodSubFieldIssue.path.join(".")
+    }: ${methodSubFieldIssue.message}`;
   }
 
   return issues

--- a/src/domain/extensions/model_kind_adapter_test.ts
+++ b/src/domain/extensions/model_kind_adapter_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { z } from "zod";
 import {
   clearAttachedExtensions,
@@ -403,4 +403,98 @@ Deno.test("processSecondaryExport: no collision — all methods merged normally"
     modelRegistry.invalidateType(type);
     resetExtensionLoadWarnings();
   }
+});
+
+// --- formatValidationError tests ---
+
+Deno.test("formatValidationError: missing execute reports method name", () => {
+  const error = new z.ZodError([
+    {
+      code: "custom",
+      path: ["methods", "create", "execute"],
+      message: "Invalid input",
+    },
+  ]);
+  const result = modelKindAdapter.formatValidationError(error);
+  assertStringIncludes(result, "'execute'");
+  assertStringIncludes(result, "'create'");
+  assertStringIncludes(result, "async function");
+});
+
+Deno.test("formatValidationError: invalid kind reports method name and allowed values", () => {
+  const error = new z.ZodError([
+    {
+      code: "custom",
+      path: ["methods", "connect", "kind"],
+      message: "Invalid enum value",
+    },
+  ]);
+  const result = modelKindAdapter.formatValidationError(error);
+  assertStringIncludes(result, "'kind'");
+  assertStringIncludes(result, "'connect'");
+  assertStringIncludes(result, "create, read, update, delete, list, action");
+});
+
+Deno.test("formatValidationError: missing description reports method name", () => {
+  const error = new z.ZodError([
+    {
+      code: "custom",
+      path: ["methods", "run", "description"],
+      message: "Required",
+    },
+  ]);
+  const result = modelKindAdapter.formatValidationError(error);
+  assertStringIncludes(result, "'description'");
+  assertStringIncludes(result, "'run'");
+});
+
+Deno.test("formatValidationError: truly missing methods still reports missing field", () => {
+  const error = new z.ZodError([
+    {
+      code: "custom",
+      path: ["methods"],
+      message: "Required",
+    },
+  ]);
+  const result = modelKindAdapter.formatValidationError(error);
+  assertStringIncludes(result, "Missing required 'methods' field");
+});
+
+Deno.test("formatValidationError: extension schema execute path reports method name", () => {
+  const error = new z.ZodError([
+    {
+      code: "custom",
+      path: ["methods", 0, "create", "execute"],
+      message: "Invalid input",
+    },
+  ]);
+  const result = modelKindAdapter.formatValidationError(error);
+  assertStringIncludes(result, "'execute'");
+  assertStringIncludes(result, "'create'");
+});
+
+Deno.test("formatValidationError: unknown method sub-field includes path", () => {
+  const error = new z.ZodError([
+    {
+      code: "custom",
+      path: ["methods", "run", "unknownField"],
+      message: "Unexpected field",
+    },
+  ]);
+  const result = modelKindAdapter.formatValidationError(error);
+  assertStringIncludes(result, "methods.run.unknownField");
+  assertStringIncludes(result, "Unexpected field");
+});
+
+Deno.test("formatValidationError: arguments on method includes method name", () => {
+  const error = new z.ZodError([
+    {
+      code: "custom",
+      path: ["methods", "deploy", "arguments"],
+      message: "Invalid input",
+    },
+  ]);
+  const result = modelKindAdapter.formatValidationError(error);
+  assertStringIncludes(result, "'arguments'");
+  assertStringIncludes(result, "'deploy'");
 });


### PR DESCRIPTION
## Summary

- Split the catch-all `methodsIssue` check in `formatUserModelError` that matched any Zod issue with `path[0] === "methods"` into specific sub-field checks for `execute`, `kind`, and `description`, plus a path-length-guarded truly-missing-methods check and a generic sub-field fallback
- Fixed the existing `methodArgsIssue` check to use path-independent indexing (`path[path.length - 1]` instead of `path[2]`) so it works for both model and extension schemas
- Added method name to all error messages so users know which method has the problem
- Added 7 unit tests covering each error case including extension schema paths

## Test plan

- [x] `deno run test src/domain/extensions/model_kind_adapter_test.ts` — 25 tests pass (7 new)
- [x] Full verification: lint, fmt, type-check, tests (10989 passed), compile, code review (pass), adversarial review (pass)
- [x] Attestation posted: `8c0869d0-eefd-4b58-a2af-52dece1b5567`

Closes swamp-club#1939
Fixes swamp-club#1943

🤖 Generated with [Claude Code](https://claude.com/claude-code)