### PR TITLE
feat(ci): upgrade Deno from 2.8.x to 2.9.x (swamp-club#1945)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.8.x
+          deno-version: v2.9.x
 
       - name: Run deno lint
         run: deno lint
@@ -110,7 +110,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.8.x
+          deno-version: v2.9.x
 
       - name: Scan for known vulnerabilities
         run: deno task audit
@@ -153,7 +153,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.8.x
+          deno-version: v2.9.x
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -179,7 +179,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.8.x
+          deno-version: v2.9.x
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/multi-model-eval.yml
+++ b/.github/workflows/multi-model-eval.yml
@@ -52,7 +52,7 @@ jobs:
         if: steps.check.outputs.run == 'true'
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.8.x
+          deno-version: v2.9.x
 
       - name: Setup Node.js
         if: steps.check.outputs.run == 'true'
@@ -92,7 +92,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.8.x
+          deno-version: v2.9.x
 
       - name: Download all eval results
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
-          deno-version: v2.8.x
+          deno-version: v2.9.x
 
       - name: Generate version
         id: version

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
-          deno-version: v2.8.x
+          deno-version: v2.9.x
 
       - name: Generate version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.8.x
+          deno-version: v2.9.x
 
       - name: Generate version
         id: version

--- a/.github/workflows/windows-compat.yml
+++ b/.github/workflows/windows-compat.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.8.x
+          deno-version: v2.9.x
 
       - name: Run deno lint
         run: deno lint

--- a/integration/tls_trust_test.ts
+++ b/integration/tls_trust_test.ts
@@ -164,7 +164,9 @@ try {
   const r = await fetch(${JSON.stringify(opts.url)});
   console.log("RESULT:OK:" + r.status);
 } catch (e) {
-  console.log("RESULT:ERR:" + (e instanceof Error ? e.message : String(e)));
+  const msg = e instanceof Error ? e.message : String(e);
+  const cause = e instanceof Error && e.cause instanceof Error ? e.cause.message : "";
+  console.log("RESULT:ERR:" + msg + (cause ? ": " + cause : ""));
 }
 `;
   // Preserve PATH/HOME/DENO_DIR so deno can resolve its cache, but drop any
@@ -318,7 +320,7 @@ Deno.env.set("DENO_CERT", ${JSON.stringify(caPath)});
 try { const r = await fetch(${
         JSON.stringify(url)
       }); console.log("RESULT:OK:" + r.status); }
-catch (e) { console.log("RESULT:ERR:" + (e instanceof Error ? e.message : String(e))); }
+catch (e) { const msg = e instanceof Error ? e.message : String(e); const cause = e instanceof Error && e.cause instanceof Error ? e.cause.message : ""; console.log("RESULT:ERR:" + msg + (cause ? ": " + cause : "")); }
 `;
       const result = await runScript(script, {});
       assertStringIncludes(result, "RESULT:ERR:");


### PR DESCRIPTION
## Summary

- Update Deno version pins from `v2.8.x` to `v2.9.x` across all 7 CI workflow files (ci, release, multi-model-eval, publish-client, publish-testing, windows-compat)
- Fix TLS trust test error extraction for Deno 2.9 compatibility — `fetch()` TLS errors now wrap the detail in `e.cause` instead of `e.message`

## Test plan

- [x] `deno check` passes on 2.9.6
- [x] `deno lint` passes (1,928 files)
- [x] Full test suite: 10,983 passed, 0 failed
- [x] Binary compilation succeeds
- [x] Binary end-to-end: repo init, model create, method run, data get
- [x] `swamp serve`: startup, worker enrollment, remote dispatch, health endpoint
- [x] Extension pull from registry (vault + model types)
- [x] Extension bundling (TS→JS with npm deps)
- [x] Extension fmt (embedded Deno formatter + linter)
- [x] Extension quality scoring (full packaging pipeline)

Closes swamp-club#1945

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNK183i9vFq53hAEec8TQY