### PR TITLE
docs(skill): add datastore config expression interpolation to repo reference

### DIFF
--- a/.claude/skills/swamp/references/repo/reference.md
+++ b/.claude/skills/swamp/references/repo/reference.md
@@ -290,6 +290,46 @@ export SWAMP_DATASTORE='@myorg/my-store:{"key":"val"}'
 
 For custom datastore or driver implementations, see the `swamp-extension` skill.
 
+### Config Value Interpolation
+
+String values in the datastore `config` object support `${{ }}` expression
+interpolation, using the same delimiter syntax as model and workflow
+definitions. Expressions are resolved during config resolution, before schema
+validation and provider creation.
+
+**Environment variables** — `${{ env.VAR_NAME }}`:
+
+```yaml
+datastore:
+  type: "@myorg/gitlab-datastore"
+  config:
+    token: "${{ env.GITLAB_TOKEN }}"
+    endpoint: "https://${{ env.GITLAB_HOST }}/api/v4"
+```
+
+Resolves to the value of the named environment variable. Throws a startup error
+if the variable is not set or empty.
+
+**Vault secrets** — `${{ vault.get(vaultName, secretKey) }}`:
+
+```yaml
+datastore:
+  type: "@myorg/postgres-datastore"
+  config:
+    connectionString: "${{ vault.get(infra, pg-connection-string) }}"
+```
+
+Resolves to the decrypted value of the named secret. All installed vault types
+work (native `local_encryption` and extension providers like `@swamp/aws-sm`).
+
+**Limitations:**
+
+- Only `env.*` and `vault.get()` are supported — the full CEL evaluation context
+  (model references, data lookups) is not available at this bootstrap phase.
+- Vault expressions are not supported when `managedConfig: true` — managed
+  config stores vault configurations in the datastore tier, creating a circular
+  dependency. Use environment variable expressions instead.
+
 ### Namespaces (Multi-Repo Datastores)
 
 When multiple repos share a remote datastore, each must own a **namespace** to


### PR DESCRIPTION
## Summary

- Add a "Config Value Interpolation" subsection to the swamp skill's repo reference documenting the `${{ env.VAR }}` and `${{ vault.get(name, key) }}` expression syntax for datastore config values in `.swamp.yaml`
- Placed between "Environment Variable Override" and "Namespaces" subsections, matching the content in `design/enablers/datastores.md`
- Covers both expression namespaces (env variables and vault secrets) with YAML examples and documents the limitations (no full CEL, no vault with `managedConfig: true`)

## Test plan

- [x] `deno fmt` passes
- [x] `npx tessl skill review` — swamp skill scores 96% (above 90% threshold)
- [x] Full build verification: lint, fmt, type-check, tests (10,988 passed), deps audit, compile all green
- [x] Code review: VERDICT pass, no findings
- [x] Skill trigger evals: pass

Closes swamp-club#1944

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ki6c6KtxJRNZjkhBK5B5qh