### PR TITLE
fix(init): normalize pi tool to use .agents/skills like other AGENTS.md tools (swamp-club#1946)

### DIFF
--- a/design/surfaces/agent-interface.md
+++ b/design/surfaces/agent-interface.md
@@ -35,13 +35,12 @@ Each AI tool has a native global skills path that it reads at runtime:
 | codex    | reads from `~/.agents/skills/` directly  | Yes                        |
 | copilot  | reads from `~/.agents/skills/` directly  | Yes                        |
 | kiro     | `~/.kiro/skills/`                        | No                         |
-| pi       | `~/.pi/agent/skills/`                    | Yes                        |
+| pi       | reads from `~/.agents/skills/` directly  | Yes                        |
 | antigravity | reads from `~/.agents/skills/` directly | Yes                     |
 
 Tools that read from `~/.agents/skills/` natively (Amp, Cursor, OpenCode, Codex,
 Copilot, Pi, AntiGravity) share a single copy. Claude Code and Kiro require
-their own copies at their vendor-specific global paths. Pi also reads from its
-own `~/.pi/agent/skills/` directory.
+their own copies at their vendor-specific global paths.
 
 The `GLOBAL_SKILL_DIRS` mapping in `src/domain/repo/skill_dirs.ts` defines
 the home-relative path per built-in tool:
@@ -55,7 +54,7 @@ export const GLOBAL_SKILL_DIRS: Record<string, string> = {
   codex: ".agents/skills",
   copilot: ".agents/skills",
   kiro: ".kiro/skills",
-  pi: ".pi/agent/skills",
+  pi: ".agents/skills",
   antigravity: ".agents/skills",
 };
 ```
@@ -63,9 +62,8 @@ export const GLOBAL_SKILL_DIRS: Record<string, string> = {
 `resolveUniqueGlobalSkillsDirs(tools)` resolves these against the home
 directory and deduplicates, so a repo enrolled for codex + copilot + opencode
 writes `~/.agents/skills/` once. After deduplication swamp writes to at most
-four directories: `~/.claude/skills/`, `~/.agents/skills/`,
-`~/.kiro/skills/`, and `~/.pi/agent/skills/`, each holding `swamp/` and
-`swamp-getting-started/`.
+three directories: `~/.claude/skills/`, `~/.agents/skills/`, and
+`~/.kiro/skills/`, each holding `swamp/` and `swamp-getting-started/`.
 
 The `none` tool has no global directory; skill directory resolution for it
 (and for unknown tools) falls back to `.swamp/pulled-extensions/skills/`,

--- a/src/domain/repo/custom_tool.ts
+++ b/src/domain/repo/custom_tool.ts
@@ -170,7 +170,7 @@ export function builtInToolConfig(tool: AiTool): ToolConfig {
       return {
         name: "pi",
         isBuiltIn: true,
-        skillsDir: ".pi/skills",
+        skillsDir: ".agents/skills",
         instructionsFile: "AGENTS.md",
         instructionsMode: "shared",
         skillReferenceStyle: "name",

--- a/src/domain/repo/custom_tool_test.ts
+++ b/src/domain/repo/custom_tool_test.ts
@@ -167,7 +167,7 @@ Deno.test("builtInToolConfig: pi config", () => {
   const config = builtInToolConfig("pi");
   assertEquals(config.name, "pi");
   assertEquals(config.isBuiltIn, true);
-  assertEquals(config.skillsDir, ".pi/skills");
+  assertEquals(config.skillsDir, ".agents/skills");
   assertEquals(config.instructionsFile, "AGENTS.md");
   assertEquals(config.instructionsMode, "shared");
   assertEquals(config.skillReferenceStyle, "name");

--- a/src/domain/repo/skill_dirs.ts
+++ b/src/domain/repo/skill_dirs.ts
@@ -36,7 +36,7 @@ export const SKILL_DIRS: Record<string, string> = {
   codex: ".agents/skills",
   copilot: ".agents/skills",
   kiro: ".kiro/skills",
-  pi: ".pi/skills",
+  pi: ".agents/skills",
   antigravity: ".agents/skills",
 };
 
@@ -54,7 +54,7 @@ export const GLOBAL_SKILL_DIRS: Record<string, string> = {
   codex: ".agents/skills",
   copilot: ".agents/skills",
   kiro: ".kiro/skills",
-  pi: ".pi/agent/skills",
+  pi: ".agents/skills",
   antigravity: ".agents/skills",
 };
 

--- a/src/domain/repo/skill_dirs_test.ts
+++ b/src/domain/repo/skill_dirs_test.ts
@@ -35,16 +35,17 @@ Deno.test("GLOBAL_SKILL_DIRS: kiro uses vendor-specific path", () => {
   assertEquals(GLOBAL_SKILL_DIRS["kiro"], ".kiro/skills");
 });
 
-Deno.test("GLOBAL_SKILL_DIRS: pi uses vendor-specific path", () => {
-  assertEquals(GLOBAL_SKILL_DIRS["pi"], ".pi/agent/skills");
+Deno.test("GLOBAL_SKILL_DIRS: pi shares .agents/skills", () => {
+  assertEquals(GLOBAL_SKILL_DIRS["pi"], ".agents/skills");
 });
 
-Deno.test("GLOBAL_SKILL_DIRS: amp/codex/cursor/opencode/copilot/antigravity share .agents/skills", () => {
+Deno.test("GLOBAL_SKILL_DIRS: amp/codex/cursor/opencode/copilot/pi/antigravity share .agents/skills", () => {
   assertEquals(GLOBAL_SKILL_DIRS["amp"], ".agents/skills");
   assertEquals(GLOBAL_SKILL_DIRS["codex"], ".agents/skills");
   assertEquals(GLOBAL_SKILL_DIRS["cursor"], ".agents/skills");
   assertEquals(GLOBAL_SKILL_DIRS["opencode"], ".agents/skills");
   assertEquals(GLOBAL_SKILL_DIRS["copilot"], ".agents/skills");
+  assertEquals(GLOBAL_SKILL_DIRS["pi"], ".agents/skills");
   assertEquals(GLOBAL_SKILL_DIRS["antigravity"], ".agents/skills");
 });
 
@@ -57,7 +58,7 @@ Deno.test("resolveGlobalSkillsDir: returns absolute path under home", () => {
 Deno.test("resolveGlobalSkillsDir: returns absolute path under home for pi", () => {
   const dir = resolveGlobalSkillsDir("pi");
   assertEquals(dir !== null, true);
-  assertPathStringIncludes(dir!, `.pi${SEPARATOR}agent${SEPARATOR}skills`);
+  assertPathStringIncludes(dir!, `.agents${SEPARATOR}skills`);
 });
 
 Deno.test("resolveGlobalSkillsDir: returns null for none", () => {
@@ -121,10 +122,10 @@ Deno.test("resolveUniqueLocalSkillsDirs: single tool returns one dir", () => {
   assertPathStringIncludes(dirs[0], `.claude${SEPARATOR}skills`);
 });
 
-Deno.test("resolveUniqueLocalSkillsDirs: pi uses .pi/skills", () => {
+Deno.test("resolveUniqueLocalSkillsDirs: pi uses .agents/skills", () => {
   const dirs = resolveUniqueLocalSkillsDirs("/repo", ["pi"]);
   assertEquals(dirs.length, 1);
-  assertPathStringIncludes(dirs[0], `.pi${SEPARATOR}skills`);
+  assertPathStringIncludes(dirs[0], `.agents${SEPARATOR}skills`);
 });
 
 Deno.test("resolveUniqueLocalSkillsDirs: antigravity uses .agents/skills", () => {

--- a/src/presentation/renderers/repo_init.ts
+++ b/src/presentation/renderers/repo_init.ts
@@ -125,7 +125,7 @@ const TOOL_CLEANUP_PATHS: Partial<Record<string, readonly string[]>> = {
   opencode: [".opencode/", ".agents/skills/"],
   codex: [".agents/skills/"],
   copilot: [".agents/skills/", ".github/hooks/"],
-  pi: [".pi/"],
+  pi: [".pi/", ".agents/skills/"],
   antigravity: [".agents/hooks.json", ".agents/skills/"],
 };
 


### PR DESCRIPTION
## Summary

- Normalize pi tool's skill directories from `.pi/skills` (local) and `~/.pi/agent/skills` (global) to `.agents/skills`, matching all other AGENTS.md-based tools (copilot, opencode, codex, amp, antigravity)
- Pi auto-discovers skills from `.agents/` natively, so the separate `.pi/skills` directory caused duplicate/conflicting skill definitions when initialized alongside copilot or other tools
- Updated cleanup paths, tests, and design docs to reflect the change
- Filed docs issue #1954 for manual reference page update

## Test plan

- [x] Unit tests updated and passing (custom_tool_test.ts, skill_dirs_test.ts)
- [x] Full verification workflow green (build, reviews, skills)
- [x] Code review: pass, adversarial review: pass, UX review: pass

Fixes swamp-club#1946

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ncbyUJyYPU2vLtu1P1oUa