### PR TITLE
fix(dashboard): align approval UI with flat PendingApproval API shape (swamp-club#1956)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -77,11 +77,7 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
   const health = useHealthStream();
 
   const { data: approvalsData } = useRequest("workflow.approvals");
-  const approvals = extractArray<{ steps?: unknown[] }>(approvalsData);
-  const approvalCount = approvals.reduce(
-    (n, a) => n + (Array.isArray(a.steps) ? a.steps.length : 0),
-    0,
-  );
+  const approvalCount = extractArray(approvalsData).length;
 
   const openRun = (workflowName: string, runId?: string) => {
     setDetail({ kind: "run", workflowName, runId });

--- a/packages/dashboard/src/views/Approvals.tsx
+++ b/packages/dashboard/src/views/Approvals.tsx
@@ -26,12 +26,10 @@ import { StatusPill } from "../components/StatusPill";
 interface ApprovalInfo {
   workflowName: string;
   runId: string;
-  steps: Array<{
-    name: string;
-    prompt?: string;
-    timeout?: number;
-    suspendedAt?: string;
-  }>;
+  stepName: string;
+  suspendedAt?: string;
+  prompt?: string;
+  inputs?: Readonly<Record<string, unknown>>;
 }
 
 export function Approvals() {
@@ -61,10 +59,7 @@ export function Approvals() {
     [request, refetch],
   );
 
-  const totalGates = approvals.reduce(
-    (n, a) => n + (Array.isArray(a.steps) ? a.steps.length : 0),
-    0,
-  );
+  const totalGates = approvals.length;
 
   return (
     <>
@@ -89,65 +84,63 @@ export function Approvals() {
         {approvals.length === 0
           ? <div className="loading">No pending approvals</div>
           : (
-            approvals.flatMap((a) =>
-              (a.steps ?? []).map((step) => (
-                <div
-                  className="approval-row"
-                  key={`${a.runId}-${step.name}`}
-                >
-                  <div>
+            approvals.map((a) => (
+              <div
+                className="approval-row"
+                key={`${a.runId}-${a.stepName}`}
+              >
+                <div>
+                  <div
+                    style={{
+                      fontWeight: 500,
+                      fontSize: "0.85rem",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                    }}
+                  >
+                    {a.workflowName}
+                    <StatusPill status="suspended" />
+                  </div>
+                  <div
+                    style={{
+                      fontSize: "0.82rem",
+                      color: "var(--text-2)",
+                      marginTop: 2,
+                    }}
+                  >
+                    Step: <strong>{a.stepName}</strong>
+                  </div>
+                  {a.prompt && (
                     <div
                       style={{
-                        fontWeight: 500,
-                        fontSize: "0.85rem",
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 6,
-                      }}
-                    >
-                      {a.workflowName}
-                      <StatusPill status="suspended" />
-                    </div>
-                    <div
-                      style={{
-                        fontSize: "0.82rem",
-                        color: "var(--text-2)",
+                        fontSize: "0.78rem",
+                        color: "var(--text-3)",
                         marginTop: 2,
                       }}
                     >
-                      Step: <strong>{step.name}</strong>
+                      {a.prompt}
                     </div>
-                    {step.prompt && (
-                      <div
-                        style={{
-                          fontSize: "0.78rem",
-                          color: "var(--text-3)",
-                          marginTop: 2,
-                        }}
-                      >
-                        {step.prompt}
-                      </div>
-                    )}
-                  </div>
-                  <div className="approval-actions">
-                    <button
-                      type="button"
-                      className="btn-sm btn-approve"
-                      onClick={() => handleApprove(a.workflowName, step.name)}
-                    >
-                      Approve
-                    </button>
-                    <button
-                      type="button"
-                      className="btn-sm btn-reject"
-                      onClick={() => handleReject(a.workflowName, step.name)}
-                    >
-                      Reject
-                    </button>
-                  </div>
+                  )}
                 </div>
-              ))
-            )
+                <div className="approval-actions">
+                  <button
+                    type="button"
+                    className="btn-sm btn-approve"
+                    onClick={() => handleApprove(a.workflowName, a.stepName)}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-sm btn-reject"
+                    onClick={() => handleReject(a.workflowName, a.stepName)}
+                  >
+                    Reject
+                  </button>
+                </div>
+              </div>
+            ))
           )}
       </div>
     </>

--- a/packages/dashboard/src/views/Overview.tsx
+++ b/packages/dashboard/src/views/Overview.tsx
@@ -42,12 +42,10 @@ interface WorkflowRunSearchItem {
 interface ApprovalInfo {
   workflowName: string;
   runId: string;
-  steps: Array<{
-    name: string;
-    prompt?: string;
-    timeout?: number;
-    suspendedAt?: string;
-  }>;
+  stepName: string;
+  suspendedAt?: string;
+  prompt?: string;
+  inputs?: Readonly<Record<string, unknown>>;
 }
 
 interface OverviewProps {
@@ -203,7 +201,7 @@ export function Overview({ health, onOpenRun }: OverviewProps) {
                     color: "#000",
                   }}
                 >
-                  {approvals.reduce((n, a) => n + a.steps.length, 0)}
+                  {approvals.length}
                 </span>
               )}
             </div>
@@ -212,55 +210,53 @@ export function Overview({ health, onOpenRun }: OverviewProps) {
             {approvals.length === 0 && (
               <div className="loading">No pending approvals</div>
             )}
-            {approvals.flatMap((a) =>
-              a.steps.map((step) => (
-                <div className="approval-row" key={`${a.runId}-${step.name}`}>
-                  <div>
+            {approvals.map((a) => (
+              <div className="approval-row" key={`${a.runId}-${a.stepName}`}>
+                <div>
+                  <div
+                    style={{
+                      fontWeight: 500,
+                      fontSize: "0.85rem",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                    }}
+                  >
+                    {a.workflowName}
+                    <StatusPill status="suspended" />
+                  </div>
+                  {a.prompt && (
                     <div
                       style={{
-                        fontWeight: 500,
-                        fontSize: "0.85rem",
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 6,
+                        fontSize: "0.75rem",
+                        color: "var(--text-3)",
+                        marginTop: 2,
                       }}
                     >
-                      {a.workflowName}
-                      <StatusPill status="suspended" />
+                      {a.prompt}
                     </div>
-                    {step.prompt && (
-                      <div
-                        style={{
-                          fontSize: "0.75rem",
-                          color: "var(--text-3)",
-                          marginTop: 2,
-                        }}
-                      >
-                        {step.prompt}
-                      </div>
-                    )}
-                  </div>
-                  <div className="approval-actions">
-                    <button
-                      type="button"
-                      className="btn-sm btn-approve"
-                      onClick={() =>
-                        handleApprove(a.workflowName, step.name)}
-                    >
-                      Approve
-                    </button>
-                    <button
-                      type="button"
-                      className="btn-sm btn-reject"
-                      onClick={() =>
-                        handleReject(a.workflowName, step.name)}
-                    >
-                      Reject
-                    </button>
-                  </div>
+                  )}
                 </div>
-              ))
-            )}
+                <div className="approval-actions">
+                  <button
+                    type="button"
+                    className="btn-sm btn-approve"
+                    onClick={() =>
+                      handleApprove(a.workflowName, a.stepName)}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-sm btn-reject"
+                    onClick={() =>
+                      handleReject(a.workflowName, a.stepName)}
+                  >
+                    Reject
+                  </button>
+                </div>
+              </div>
+            ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Fix dashboard crash when any workflow run has a pending `manual_approval` step
- The dashboard's `ApprovalInfo` interface expected grouped entries with a nested `steps` array, but `workflow.approvals` has always returned flat `PendingApproval` entries (one per suspended step)
- Align `Overview.tsx`, `Approvals.tsx`, and `App.tsx` to consume the flat shape directly — `stepName`, `prompt`, `suspendedAt` — instead of the non-existent grouped structure

## Root Cause

The dashboard was introduced in commit `500e9122` (2026-08-22) with an `ApprovalInfo` interface that assumed approvals were grouped by `(workflowName, runId)` with a nested `steps` array. The `workflow.approvals` API has always returned flat entries (one `PendingApproval` per suspended step). When any approval existed, accessing `a.steps.length` threw a `TypeError` that unmounted the entire React tree, leaving a blank page.

## Changes

| File | Change |
|------|--------|
| `packages/dashboard/src/views/Overview.tsx` | Replace grouped `ApprovalInfo` with flat shape; badge count → `approvals.length`; list renders directly; approve/reject use `a.stepName` |
| `packages/dashboard/src/views/Approvals.tsx` | Same flat shape fix; `totalGates` → `approvals.length`; direct map over entries |
| `packages/dashboard/src/App.tsx` | Sidebar badge → `extractArray(approvalsData).length` |

## Test plan

- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno check` (type-check) passes
- [x] All 10,990 tests pass
- [x] Compiles successfully
- [x] Code review: pass
- [ ] Manual verification: run `swamp serve --dashboard` with a pending `manual_approval` step and confirm the dashboard renders the approval count, list, and working Approve/Reject buttons

Closes swamp-club#1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)