### PR TITLE
docs(skill): add swamp run gc to data and model quick-reference tables (swamp-club#1952)

### DIFF
--- a/.claude/skills/swamp/references/data/guide.md
+++ b/.claude/skills/swamp/references/data/guide.md
@@ -35,26 +35,32 @@ for the full list of queryable fields and predicate operators.
 
 ## Quick Reference
 
-| Task                    | Command                                               |
-| ----------------------- | ----------------------------------------------------- |
-| Query by model          | `swamp data query 'modelName == "my-model"'`          |
-| Query by type           | `swamp data query 'dataType == "resource"'`           |
-| Query with projection   | `swamp data query 'modelName == "x"' --select 'name'` |
-| Query by tags           | `swamp data query 'tags.env == "prod"'`               |
-| Query by content        | `swamp data query 'attributes.status == "failed"'`    |
-| List model data         | `swamp data list <model> --json`                      |
-| List workflow data      | `swamp data list --workflow <name> --json`            |
-| Get specific data       | `swamp data get <model> <name> --json`                |
-| Get metadata only       | `swamp data get <model> <name> --no-content --json`   |
-| Get data via workflow   | `swamp data get --workflow <name> <data_name> --json` |
-| View version history    | `swamp data versions <model> <name> --json`           |
-| Run garbage collection  | `swamp data gc --json`                                |
-| Prune orphaned data     | `swamp data prune --force --json`                     |
-| Preview prune (dry run) | `swamp data prune --dry-run --json`                   |
-| Rename data instance    | `swamp data rename <model> <old> <new>`               |
-| Delete data artifact    | `swamp data delete <model> <name> --force`            |
-| Delete one version      | `swamp data delete <model> <name> --version 3`        |
-| Preview GC (dry run)    | `swamp data gc --dry-run --json`                      |
+| Task                     | Command                                               |
+| ------------------------ | ----------------------------------------------------- |
+| Query by model           | `swamp data query 'modelName == "my-model"'`          |
+| Query by type            | `swamp data query 'dataType == "resource"'`           |
+| Query with projection    | `swamp data query 'modelName == "x"' --select 'name'` |
+| Query by tags            | `swamp data query 'tags.env == "prod"'`               |
+| Query by content         | `swamp data query 'attributes.status == "failed"'`    |
+| List model data          | `swamp data list <model> --json`                      |
+| List workflow data       | `swamp data list --workflow <name> --json`            |
+| Get specific data        | `swamp data get <model> <name> --json`                |
+| Get metadata only        | `swamp data get <model> <name> --no-content --json`   |
+| Get data via workflow    | `swamp data get --workflow <name> <data_name> --json` |
+| View version history     | `swamp data versions <model> <name> --json`           |
+| Run garbage collection   | `swamp data gc --json`                                |
+| Prune orphaned data      | `swamp data prune --force --json`                     |
+| Preview prune (dry run)  | `swamp data prune --dry-run --json`                   |
+| Rename data instance     | `swamp data rename <model> <old> <new>`               |
+| Delete data artifact     | `swamp data delete <model> <name> --force`            |
+| Delete one version       | `swamp data delete <model> <name> --version 3`        |
+| Preview GC (dry run)     | `swamp data gc --dry-run --json`                      |
+| GC workflow runs/outputs | `swamp run gc --dry-run`                              |
+| GC runs (force)          | `swamp run gc --force`                                |
+
+`swamp data gc` and `swamp data prune` operate on `.swamp/data/` (the data
+catalog). `swamp run gc` operates on `.swamp/outputs/` (workflow-run history and
+model-method outputs). Use both to reclaim full `.swamp/` storage.
 
 See [references/concepts.md](references/concepts.md) for lifetime types, tags,
 and version GC policies.

--- a/.claude/skills/swamp/references/model/guide.md
+++ b/.claude/skills/swamp/references/model/guide.md
@@ -81,6 +81,9 @@ create per-input ephemeral instances for concurrent dispatch. See
 | Active runs         | `swamp run history --active`                                         |
 | Recent runs         | `swamp run history`                                                  |
 | Diagnose stale runs | `swamp run doctor`                                                   |
+| Preview run GC      | `swamp run gc --dry-run`                                             |
+| Run GC (outputs)    | `swamp run gc --force`                                               |
+| Run GC (custom age) | `swamp run gc --older-than 7d`                                       |
 
 ## Discover Before Shelling Out
 

--- a/.claude/skills/swamp/references/model/references/troubleshooting.md
+++ b/.claude/skills/swamp/references/model/references/troubleshooting.md
@@ -349,6 +349,23 @@ swamp model output search "my-model" --json
 swamp model output get <output-id> --json
 ```
 
+### Large `.swamp/outputs/` Directory
+
+```bash
+# Preview what run gc would collect (default: older than 30 days)
+swamp run gc --dry-run
+
+# Delete old workflow runs and method outputs
+swamp run gc --force
+
+# Custom retention period
+swamp run gc --older-than 7d
+```
+
+`swamp run gc` cleans `.swamp/outputs/` (workflow-run history and model-method
+outputs). `swamp data gc` cleans `.swamp/data/` (the data catalog) — they cover
+different storage areas.
+
 ### Data Versions Not Visible
 
 ```bash


### PR DESCRIPTION
## Summary

- Add `swamp run gc` (preview, force, custom age) to the model guide's quick-reference table alongside `run doctor` and `run history`
- Add cross-reference in the data guide's quick-reference table with a clarifying paragraph distinguishing `data gc` (`.swamp/data/`) from `run gc` (`.swamp/outputs/`)
- Add "Large `.swamp/outputs/` Directory" troubleshooting entry in the model troubleshooting reference

## Test plan

- [x] `grep -rn "run gc" .claude/skills/swamp/` confirms command appears in all three files
- [x] `deno fmt` passes
- [x] Full verification workflow passes (build 9/9, code review VERDICT: pass, skill review 96%/94%)

Closes swamp-club#1952

Co-authored-by: Bruce Johnson <brucejo75@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KadCCjgbL6awF3r2ErA97