### PR TITLE
fix(tracing): append OTLP signal path to URL pathname, not after query/fragment (swamp-club#1716)

### DIFF
--- a/src/infrastructure/tracing/otel_config.ts
+++ b/src/infrastructure/tracing/otel_config.ts
@@ -35,7 +35,9 @@ export function resolveOtlpEndpoint(
     : Deno.env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
   if (!genericEndpoint) return undefined;
 
-  return `${genericEndpoint.replace(/\/+$/, "")}/v1/${signal}`;
+  const url = new URL(genericEndpoint);
+  url.pathname = `${url.pathname.replace(/\/+$/, "")}/v1/${signal}`;
+  return url.toString();
 }
 
 /**

--- a/src/infrastructure/tracing/otel_config_test.ts
+++ b/src/infrastructure/tracing/otel_config_test.ts
@@ -104,6 +104,54 @@ Deno.test("resolveOtlpEndpoint: returns undefined when no endpoint is set", () =
   }
 });
 
+Deno.test("resolveOtlpEndpoint: preserves query parameters when appending signal path", () => {
+  for (const signal of SIGNALS) {
+    withEnv(
+      {
+        OTEL_EXPORTER_OTLP_ENDPOINT:
+          "https://collector.example/otlp?token=secret",
+      },
+      () =>
+        assertEquals(
+          resolveOtlpEndpoint(signal),
+          `https://collector.example/otlp/v1/${signal}?token=secret`,
+        ),
+    );
+  }
+});
+
+Deno.test("resolveOtlpEndpoint: preserves fragment when appending signal path", () => {
+  for (const signal of SIGNALS) {
+    withEnv(
+      {
+        OTEL_EXPORTER_OTLP_ENDPOINT:
+          "https://collector.example/otlp#section",
+      },
+      () =>
+        assertEquals(
+          resolveOtlpEndpoint(signal),
+          `https://collector.example/otlp/v1/${signal}#section`,
+        ),
+    );
+  }
+});
+
+Deno.test("resolveOtlpEndpoint: preserves both query and fragment when appending signal path", () => {
+  for (const signal of SIGNALS) {
+    withEnv(
+      {
+        OTEL_EXPORTER_OTLP_ENDPOINT:
+          "https://collector.example/otlp?token=secret#section",
+      },
+      () =>
+        assertEquals(
+          resolveOtlpEndpoint(signal),
+          `https://collector.example/otlp/v1/${signal}?token=secret#section`,
+        ),
+    );
+  }
+});
+
 Deno.test("resolveOtlpEndpoint: explicit config bypasses process environment", () => {
   withEnv(
     { OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "https://environment.example" },

--- a/src/infrastructure/tracing/otel_config_test.ts
+++ b/src/infrastructure/tracing/otel_config_test.ts
@@ -124,8 +124,7 @@ Deno.test("resolveOtlpEndpoint: preserves fragment when appending signal path", 
   for (const signal of SIGNALS) {
     withEnv(
       {
-        OTEL_EXPORTER_OTLP_ENDPOINT:
-          "https://collector.example/otlp#section",
+        OTEL_EXPORTER_OTLP_ENDPOINT: "https://collector.example/otlp#section",
       },
       () =>
         assertEquals(


### PR DESCRIPTION
## Summary

- Fix `resolveOtlpEndpoint` to use the `URL` constructor instead of string concatenation, so `/v1/<signal>` is appended to the pathname rather than after query parameters or fragments
- Add tests for query-only, fragment-only, and combined query+fragment OTLP endpoint URLs

## Problem

Generic OTLP endpoint construction appended `/v1/<signal>` to the raw URL string. An endpoint like `https://collector.example/otlp?token=secret` became `https://collector.example/otlp?token=secret/v1/traces` — the signal suffix landed in the query instead of the URL path.

## Fix

Parse the endpoint with the `URL` constructor, modify `pathname`, and reconstruct via `toString()`. This preserves query and fragment components in their correct positions.

## Test Plan

- Added 3 new unit tests covering query, fragment, and combined query+fragment endpoints
- All 19 tests in `otel_config_test.ts` pass (16 existing + 3 new)
- Verified reproduction scenario produces correct URLs after fix
- Full verification workflow passed: lint, fmt, type-check, tests, compile, code review (pass), adversarial review (pass)

Closes swamp-club#1716