### PR TITLE
feat(ci): add Windows x86_64 binary to release pipeline (swamp-club#1959)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,14 @@ jobs:
             --target aarch64-apple-darwin \
             --output dist/swamp-darwin-aarch64
 
+          # Windows x86_64 (cross-compiled, packaged as .zip)
+          deno run -A scripts/compile.ts \
+            --version "$VERSION" \
+            --target x86_64-pc-windows-msvc \
+            --output /tmp/swamp.exe
+          (cd /tmp && zip -j "$GITHUB_WORKSPACE/dist/swamp-windows-x86_64.zip" swamp.exe)
+          rm /tmp/swamp.exe
+
       - name: Create checksums
         working-directory: dist
         run: |
@@ -140,6 +148,12 @@ jobs:
             echo "curl -L https://github.com/${REPO}/releases/download/v${VERSION}/swamp-linux-aarch64 -o swamp"
             echo 'chmod +x swamp && sudo mv swamp /usr/local/bin/'
             echo '```'
+            echo ""
+            echo "**Windows (x86_64):**"
+            echo '```powershell'
+            echo "Invoke-WebRequest -Uri https://github.com/${REPO}/releases/download/v${VERSION}/swamp-windows-x86_64.zip -OutFile swamp.zip"
+            echo "Expand-Archive swamp.zip -DestinationPath .; Move-Item swamp.exe 'C:\\Program Files\\swamp\\'"
+            echo '```'
           } >> /tmp/release_body.md
 
       - name: Create GitHub Release
@@ -153,6 +167,7 @@ jobs:
             dist/swamp-linux-aarch64
             dist/swamp-darwin-x86_64
             dist/swamp-darwin-aarch64
+            dist/swamp-windows-x86_64.zip
             dist/checksums.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -164,6 +179,34 @@ jobs:
           repository: swamp-club/swamp-uat
           event-type: run-uat
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
+
+  windows-smoke:
+    name: Windows Smoke Test
+    runs-on: windows-latest
+    needs: release
+    permissions:
+      contents: read
+
+    steps:
+      - name: Download Windows binary from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
+        shell: bash
+        run: |
+          RELEASE_TAG="v${RELEASE_VERSION}"
+          gh release download "${RELEASE_TAG}" \
+            --repo "${{ github.repository }}" \
+            --pattern "swamp-windows-x86_64.zip" \
+            --dir .
+
+      - name: Extract and smoke test
+        shell: pwsh
+        run: |
+          Expand-Archive -Path swamp-windows-x86_64.zip -DestinationPath .
+          .\swamp.exe --version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          .\swamp.exe --help | Out-Null
 
   docker:
     name: Build and Push Docker Image


### PR DESCRIPTION
## Summary

- Cross-compile Windows x86_64 binary on the existing Linux runner using `--target x86_64-pc-windows-msvc`
- Package as `.zip` (matching `install.ps1` expectations), include in checksums and GitHub Release assets
- Add Windows PowerShell installation instructions to the release body
- Add a `windows-smoke` job on `windows-latest` that downloads the `.zip`, extracts, and runs `swamp.exe --version` / `--help`

## Details

The groundwork was already in place: `scripts/download_deno.ts` supports `x86_64-pc-windows-msvc`, `scripts/compile.ts` handles cross-compilation targets, `windows-compat.yml` validates the codebase compiles and tests pass on Windows, and `scripts/install.ps1` is ready for `.zip` artifacts. This PR wires the Windows target into the release pipeline.

The `.exe` is compiled to `/tmp/` and zipped into `dist/` so only the `.zip` appears in `dist/` — the `sha256sum swamp-*` glob captures it cleanly alongside the bare Linux/macOS binaries.

The smoke test job runs with `permissions: contents: read` (least-privilege) and checks `$LASTEXITCODE` after `--version` to catch PowerShell's native-command exit-code swallowing.

S3 upload to `artifacts.swamp-club.com` is out of scope — no existing platform does S3 uploads in `release.yml`.

Closes swamp-club#1959

## Test plan

- [x] Verification workflow passed (build, reviews, skills) — commit `32e71394`
- [x] Code review: VERDICT pass
- [x] Adversarial review: VERDICT pass
- [x] CI security review: VERDICT pass
- [ ] CI validates attestation for commit SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)