### PR TITLE
fix(serve): replace broken model-method sweep with direct repo writes in boot reconciliation (swamp-club#1955)

### DIFF
--- a/integration/remote_execution_test.ts
+++ b/integration/remote_execution_test.ts
@@ -198,7 +198,7 @@ async function startOrchestrator(
   });
   dispatchService.setOnDispatchEnd((id) => dataPlane.releaseDispatch(id));
 
-  await sweepStaleRecords({ repoDir, repoContext });
+  await sweepStaleRecords({ repoContext });
 
   const server = Deno.serve(
     { port: 0, hostname: "127.0.0.1", onListen: () => {} },

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -2667,7 +2667,6 @@ export const serveCommand = new Command()
 
     logger.info("Boot: sweeping stale records");
     const swept = await sweepStaleRecords({
-      repoDir: resolvedRepoDir,
       repoContext,
     });
     if (swept.leases + swept.pendingDispatches + swept.workers > 0) {

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -18,20 +18,12 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
-import {
-  createLibSwampContext,
-  createWorkerModelRunDeps,
-  modelMethodRun,
-} from "../libswamp/mod.ts";
 import { STEP_LEASE_MODEL_TYPE } from "../domain/models/worker/step_lease_model.ts";
 import { PENDING_DISPATCH_MODEL_TYPE } from "../domain/models/worker/pending_dispatch_model.ts";
-import {
-  WORKER_MODEL_TYPE,
-  workerDefinitionName,
-} from "../domain/models/worker/worker_model.ts";
+import { WORKER_MODEL_TYPE } from "../domain/models/worker/worker_model.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import type { ModelType } from "../domain/models/model_type.ts";
-import type { Data } from "../domain/data/data.ts";
+import { Data } from "../domain/data/data.ts";
 import type { FileSystemUnifiedDataRepository } from "../infrastructure/persistence/unified_data_repository.ts";
 import type { ControlPlaneStore } from "../domain/datastore/control_plane_store.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
@@ -50,17 +42,8 @@ import type {
 
 const logger = getSwampLogger(["serve", "boot-reconciliation"]);
 
-export interface TransitionInput {
-  typeArg: string;
-  definitionName: string;
-  methodName: string;
-  inputs: Record<string, unknown>;
-}
-
 export interface BootReconciliationDeps {
-  repoDir: string;
   repoContext: RepositoryContext;
-  runTransition?: (input: TransitionInput) => Promise<void>;
 }
 
 export interface SweepResult {
@@ -108,46 +91,32 @@ export async function hydrateLocalCache(
   }
 }
 
-async function defaultRunTransition(
-  repoDir: string,
-  repoContext: RepositoryContext,
-  input: TransitionInput,
-): Promise<void> {
-  const runDeps = await createWorkerModelRunDeps(repoDir, repoContext);
-  for await (
-    const event of modelMethodRun(createLibSwampContext({}), runDeps, {
-      modelIdOrName: input.definitionName,
-      methodName: input.methodName,
-      inputs: input.inputs,
-      lastEvaluated: false,
-      typeArg: input.typeArg,
-      definitionName: input.definitionName,
-      skipAllReports: true,
-    })
-  ) {
-    if (event.kind === "error") {
-      const detail = event.error;
-      const message = typeof detail === "object" && detail !== null &&
-          "message" in detail
-        ? String((detail as { message: unknown }).message)
-        : String(detail);
-      throw new Error(message);
-    }
-  }
+const encoder = new TextEncoder();
+
+function writeData(
+  existing: Data,
+  updatedAttrs: Record<string, unknown>,
+): { data: Data; content: Uint8Array } {
+  const content = encoder.encode(JSON.stringify(updatedAttrs));
+  const data = Data.create({
+    name: existing.name,
+    contentType: existing.contentType,
+    lifetime: existing.lifetime,
+    garbageCollection: existing.garbageCollection,
+    tags: existing.tags,
+    ownerDefinition: existing.ownerDefinition,
+  });
+  return { data, content };
 }
 
 export async function sweepStaleRecords(
   deps: BootReconciliationDeps,
 ): Promise<SweepResult> {
-  const transition = deps.runTransition ??
-    ((input: TransitionInput) =>
-      defaultRunTransition(deps.repoDir, deps.repoContext, input));
-
   const result: SweepResult = { leases: 0, pendingDispatches: 0, workers: 0 };
   const repo = deps.repoContext.unifiedDataRepo;
 
   for (
-    const { attrs, modelName } of await loadAttrsForType(
+    const { attrs, modelId, data: existing } of await loadAttrsForType(
       repo,
       STEP_LEASE_MODEL_TYPE,
     )
@@ -156,12 +125,13 @@ export async function sweepStaleRecords(
     const leaseId = attrs.leaseId;
     if (typeof leaseId !== "string") continue;
     try {
-      await transition({
-        typeArg: STEP_LEASE_MODEL_TYPE.normalized,
-        definitionName: modelName,
-        methodName: "expire",
-        inputs: { leaseId, error: "orchestrator restart" },
+      const { data, content } = writeData(existing, {
+        ...attrs,
+        state: "expired",
+        endedAt: new Date().toISOString(),
+        error: "orchestrator restart",
       });
+      await repo.save(STEP_LEASE_MODEL_TYPE, modelId, data, content);
       result.leases++;
     } catch (err) {
       logger.warn("Failed to expire stale lease {leaseId}: {error}", {
@@ -172,7 +142,7 @@ export async function sweepStaleRecords(
   }
 
   for (
-    const { attrs, modelName } of await loadAttrsForType(
+    const { attrs, modelId, data: existing } of await loadAttrsForType(
       repo,
       PENDING_DISPATCH_MODEL_TYPE,
     )
@@ -181,12 +151,12 @@ export async function sweepStaleRecords(
     const queueId = attrs.queueId;
     if (typeof queueId !== "string") continue;
     try {
-      await transition({
-        typeArg: PENDING_DISPATCH_MODEL_TYPE.normalized,
-        definitionName: modelName,
-        methodName: "orphan",
-        inputs: { queueId, endedAt: new Date().toISOString() },
+      const { data, content } = writeData(existing, {
+        ...attrs,
+        state: "orphaned",
+        endedAt: new Date().toISOString(),
       });
+      await repo.save(PENDING_DISPATCH_MODEL_TYPE, modelId, data, content);
       result.pendingDispatches++;
     } catch (err) {
       logger.warn(
@@ -199,23 +169,30 @@ export async function sweepStaleRecords(
     }
   }
 
+  // Mirrors worker_model.ts setStatus (lines 141–162): disconnecting
+  // clears activeDispatchIds, sets disconnectedAt, clears
+  // verifyFailureReason, and updates lastSeenAt.
   for (
-    const { attrs, data } of await loadAttrsForType(
+    const { attrs, modelId, data: existing } of await loadAttrsForType(
       repo,
       WORKER_MODEL_TYPE,
     )
   ) {
-    if (data.name !== "state-main") continue;
+    if (existing.name !== "state-main") continue;
     if (attrs.status === "disconnected") continue;
     const workerName = attrs.name;
     if (typeof workerName !== "string") continue;
     try {
-      await transition({
-        typeArg: WORKER_MODEL_TYPE.normalized,
-        definitionName: workerDefinitionName(workerName),
-        methodName: "set_status",
-        inputs: { status: "disconnected" },
+      const now = new Date().toISOString();
+      const { data, content } = writeData(existing, {
+        ...attrs,
+        status: "disconnected",
+        lastSeenAt: now,
+        activeDispatchIds: [],
+        disconnectedAt: now,
+        verifyFailureReason: undefined,
       });
+      await repo.save(WORKER_MODEL_TYPE, modelId, data, content);
       result.workers++;
     } catch (err) {
       logger.warn(
@@ -855,11 +832,21 @@ async function loadAttrsForType(
   repo: FileSystemUnifiedDataRepository,
   modelType: ModelType,
 ): Promise<
-  Array<{ data: Data; modelName: string; attrs: Record<string, unknown> }>
+  Array<{
+    data: Data;
+    modelId: string;
+    modelName: string;
+    attrs: Record<string, unknown>;
+  }>
 > {
   const items = await repo.findAllForType(modelType);
   const results: Array<
-    { data: Data; modelName: string; attrs: Record<string, unknown> }
+    {
+      data: Data;
+      modelId: string;
+      modelName: string;
+      attrs: Record<string, unknown>;
+    }
   > = [];
   for (const { data, modelType: mt, modelId } of items) {
     if (data.isRenamed || data.isDeleted) continue;
@@ -870,7 +857,12 @@ async function loadAttrsForType(
         string,
         unknown
       >;
-      results.push({ data, modelName: data.tags["modelName"] ?? "", attrs });
+      results.push({
+        data,
+        modelId,
+        modelName: data.tags["modelName"] ?? "",
+        attrs,
+      });
     } catch {
       // Skip items with unparseable content
     }

--- a/src/serve/boot_reconciliation_test.ts
+++ b/src/serve/boot_reconciliation_test.ts
@@ -32,7 +32,6 @@ import {
   sweepStaleRecords,
   sweepTokenConsistency,
   type TokenConsistencyDeps,
-  type TransitionInput,
 } from "./boot_reconciliation.ts";
 import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
 import type { PendingRunEntry } from "../infrastructure/persistence/run_tracker_store.ts";
@@ -71,9 +70,18 @@ function makeData(
   return { data, modelType, modelId };
 }
 
-function createHarness(items: Map<string, DataItem[]>) {
-  const transitions: TransitionInput[] = [];
-  let failOn: string | null = null;
+interface SaveCall {
+  modelType: string;
+  modelId: string;
+  dataName: string;
+  content: Record<string, unknown>;
+}
+
+function createHarness(
+  items: Map<string, DataItem[]>,
+  opts?: { failSave?: boolean },
+) {
+  const saves: SaveCall[] = [];
   const contentMap = new Map<string, Uint8Array>();
   const dataByType = new Map<
     string,
@@ -94,7 +102,6 @@ function createHarness(items: Map<string, DataItem[]>) {
   }
 
   const deps: BootReconciliationDeps = {
-    repoDir: "/tmp/test",
     repoContext: {
       unifiedDataRepo: {
         findAllForType: (type: ModelType) => {
@@ -108,32 +115,39 @@ function createHarness(items: Map<string, DataItem[]>) {
           const key = `${type.normalized}/${modelId}/${dataName}`;
           return Promise.resolve(contentMap.get(key) ?? null);
         },
+        save: (
+          type: ModelType,
+          modelId: string,
+          data: Data,
+          content: Uint8Array,
+        ) => {
+          if (opts?.failSave) {
+            return Promise.reject(new Error("save failed"));
+          }
+          const parsed = JSON.parse(
+            new TextDecoder().decode(content),
+          ) as Record<string, unknown>;
+          saves.push({
+            modelType: type.normalized,
+            modelId,
+            dataName: data.name,
+            content: parsed,
+          });
+          return Promise.resolve({ version: 2 });
+        },
       },
     } as unknown as RepositoryContext,
-    runTransition: (input: TransitionInput) => {
-      if (failOn && input.definitionName === failOn) {
-        return Promise.reject(new Error(`transition failed: ${failOn}`));
-      }
-      transitions.push(input);
-      return Promise.resolve();
-    },
   };
 
-  return {
-    deps,
-    transitions,
-    setFailOn: (name: string) => {
-      failOn = name;
-    },
-  };
+  return { deps, saves };
 }
 
-Deno.test("sweepStaleRecords: clean boot returns zeros with no transitions", async () => {
+Deno.test("sweepStaleRecords: clean boot returns zeros with no writes", async () => {
   const h = createHarness(new Map());
   const result = await sweepStaleRecords(h.deps);
 
   assertEquals(result, { leases: 0, pendingDispatches: 0, workers: 0 });
-  assertEquals(h.transitions.length, 0);
+  assertEquals(h.saves.length, 0);
 });
 
 Deno.test("sweepStaleRecords: expires active leases", async () => {
@@ -159,12 +173,14 @@ Deno.test("sweepStaleRecords: expires active leases", async () => {
   const result = await sweepStaleRecords(h.deps);
 
   assertEquals(result.leases, 2);
-  assertEquals(h.transitions.length, 2);
-  assertEquals(h.transitions[0].typeArg, "swamp/step-lease");
-  assertEquals(h.transitions[0].methodName, "expire");
-  assertEquals(h.transitions[0].inputs.leaseId, "lease-1");
-  assertEquals(h.transitions[0].inputs.error, "orchestrator restart");
-  assertEquals(h.transitions[1].inputs.leaseId, "lease-2");
+  assertEquals(h.saves.length, 2);
+  assertEquals(h.saves[0].modelType, "swamp/step-lease");
+  assertEquals(h.saves[0].content.state, "expired");
+  assertEquals(h.saves[0].content.leaseId, "lease-1");
+  assertEquals(h.saves[0].content.error, "orchestrator restart");
+  assertEquals(typeof h.saves[0].content.endedAt, "string");
+  assertEquals(h.saves[1].content.leaseId, "lease-2");
+  assertEquals(h.saves[1].content.state, "expired");
 });
 
 Deno.test("sweepStaleRecords: orphans waiting pending dispatches", async () => {
@@ -184,14 +200,14 @@ Deno.test("sweepStaleRecords: orphans waiting pending dispatches", async () => {
   const result = await sweepStaleRecords(h.deps);
 
   assertEquals(result.pendingDispatches, 1);
-  assertEquals(h.transitions.length, 1);
-  assertEquals(h.transitions[0].typeArg, "swamp/pending-dispatch");
-  assertEquals(h.transitions[0].methodName, "orphan");
-  assertEquals(h.transitions[0].inputs.queueId, "q-1");
-  assertEquals(typeof h.transitions[0].inputs.endedAt, "string");
+  assertEquals(h.saves.length, 1);
+  assertEquals(h.saves[0].modelType, "swamp/pending-dispatch");
+  assertEquals(h.saves[0].content.state, "orphaned");
+  assertEquals(h.saves[0].content.queueId, "q-1");
+  assertEquals(typeof h.saves[0].content.endedAt, "string");
 });
 
-Deno.test("sweepStaleRecords: disconnects stale workers", async () => {
+Deno.test("sweepStaleRecords: disconnects stale workers with full field update", async () => {
   const h = createHarness(
     new Map([
       ["swamp/worker", [
@@ -199,7 +215,13 @@ Deno.test("sweepStaleRecords: disconnects stale workers", async () => {
           modelName: "worker-w1",
           dataName: "state-main",
           modelType: "swamp/worker",
-          attrs: { name: "w1", status: "idle" },
+          attrs: {
+            name: "w1",
+            status: "idle",
+            activeDispatchIds: ["d-1", "d-2"],
+            lastSeenAt: "2026-01-01T00:00:00.000Z",
+            verifyFailureReason: "probe failed",
+          },
         },
       ]],
     ]),
@@ -208,14 +230,17 @@ Deno.test("sweepStaleRecords: disconnects stale workers", async () => {
   const result = await sweepStaleRecords(h.deps);
 
   assertEquals(result.workers, 1);
-  assertEquals(h.transitions.length, 1);
-  assertEquals(h.transitions[0].typeArg, "swamp/worker");
-  assertEquals(h.transitions[0].definitionName, "worker-w1");
-  assertEquals(h.transitions[0].methodName, "set_status");
-  assertEquals(h.transitions[0].inputs.status, "disconnected");
+  assertEquals(h.saves.length, 1);
+  assertEquals(h.saves[0].modelType, "swamp/worker");
+  assertEquals(h.saves[0].content.status, "disconnected");
+  assertEquals(h.saves[0].content.name, "w1");
+  assertEquals(h.saves[0].content.activeDispatchIds, []);
+  assertEquals(typeof h.saves[0].content.disconnectedAt, "string");
+  assertEquals(typeof h.saves[0].content.lastSeenAt, "string");
+  assertEquals(h.saves[0].content.verifyFailureReason, undefined);
 });
 
-Deno.test("sweepStaleRecords: transition failure warns but continues sweeping", async () => {
+Deno.test("sweepStaleRecords: save failure warns but continues sweeping", async () => {
   const h = createHarness(
     new Map([
       ["swamp/step-lease", [
@@ -233,17 +258,17 @@ Deno.test("sweepStaleRecords: transition failure warns but continues sweeping", 
         },
       ]],
     ]),
+    { failSave: true },
   );
-  h.setFailOn("leases");
 
   const result = await sweepStaleRecords(h.deps);
 
   assertEquals(result.leases, 0);
-  assertEquals(h.transitions.length, 0);
+  assertEquals(h.saves.length, 0);
 });
 
-Deno.test("sweepStaleRecords: mixed failure and success across model types", async () => {
-  let callCount = 0;
+Deno.test("sweepStaleRecords: mixed save failure and success across model types", async () => {
+  let saveCount = 0;
   const leaseItem = makeData({
     modelName: "leases",
     dataName: "data-main",
@@ -270,8 +295,8 @@ Deno.test("sweepStaleRecords: mixed failure and success across model types", asy
     encoder.encode(JSON.stringify(workerAttrs)),
   );
 
+  const saves: SaveCall[] = [];
   const deps: BootReconciliationDeps = {
-    repoDir: "/tmp/test",
     repoContext: {
       unifiedDataRepo: {
         findAllForType: (type: ModelType) => {
@@ -291,15 +316,29 @@ Deno.test("sweepStaleRecords: mixed failure and success across model types", asy
           const key = `${type.normalized}/${modelId}/${dataName}`;
           return Promise.resolve(contentMap.get(key) ?? null);
         },
+        save: (
+          type: ModelType,
+          modelId: string,
+          data: Data,
+          content: Uint8Array,
+        ) => {
+          saveCount++;
+          if (saveCount === 1) {
+            return Promise.reject(new Error("lease save failed"));
+          }
+          const parsed = JSON.parse(
+            new TextDecoder().decode(content),
+          ) as Record<string, unknown>;
+          saves.push({
+            modelType: type.normalized,
+            modelId,
+            dataName: data.name,
+            content: parsed,
+          });
+          return Promise.resolve({ version: 2 });
+        },
       },
     } as unknown as RepositoryContext,
-    runTransition: () => {
-      callCount++;
-      if (callCount === 1) {
-        return Promise.reject(new Error("lease transition failed"));
-      }
-      return Promise.resolve();
-    },
   };
 
   const result = await sweepStaleRecords(deps);
@@ -326,7 +365,7 @@ Deno.test("sweepStaleRecords: skips records with missing leaseId attribute", asy
   const result = await sweepStaleRecords(h.deps);
 
   assertEquals(result.leases, 0);
-  assertEquals(h.transitions.length, 0);
+  assertEquals(h.saves.length, 0);
 });
 
 Deno.test("sweepStaleRecords: skips records with missing queueId attribute", async () => {
@@ -346,7 +385,7 @@ Deno.test("sweepStaleRecords: skips records with missing queueId attribute", asy
   const result = await sweepStaleRecords(h.deps);
 
   assertEquals(result.pendingDispatches, 0);
-  assertEquals(h.transitions.length, 0);
+  assertEquals(h.saves.length, 0);
 });
 
 Deno.test("sweepStaleRecords: skips records with missing worker name attribute", async () => {
@@ -366,7 +405,7 @@ Deno.test("sweepStaleRecords: skips records with missing worker name attribute",
   const result = await sweepStaleRecords(h.deps);
 
   assertEquals(result.workers, 0);
-  assertEquals(h.transitions.length, 0);
+  assertEquals(h.saves.length, 0);
 });
 
 // ── replayPendingRuns tests ──────────────────────────────────────────
@@ -710,7 +749,7 @@ Deno.test("sweepStaleRecords: sweeps all three model types together", async () =
   const result = await sweepStaleRecords(h.deps);
 
   assertEquals(result, { leases: 1, pendingDispatches: 1, workers: 1 });
-  assertEquals(h.transitions.length, 3);
+  assertEquals(h.saves.length, 3);
 });
 
 // ── replayPendingRuns remote merge tests ──────────────────────────────


### PR DESCRIPTION
## Summary

- `sweepStaleRecords` ran a full `modelMethodRun` per stale lease (~12.5s each) to flip a state field. `readResource` is scoped to the current definition UUID, but when the auto-definition was recreated (ephemeral filesystem + persistent data in a remote datastore), the UUID diverged — causing 100% expiry failure and a multi-minute boot stall.
- Replace the transition-based sweep with direct `repo.save()` writes using the actual filesystem `modelId` from `loadAttrsForType`. All three sweep types (leases, pending dispatches, workers) are fixed.
- Worker sweep replicates the full `setStatus` field-update logic (clearing `activeDispatchIds`, setting `disconnectedAt`, clearing `verifyFailureReason`, updating `lastSeenAt`).
- Removed `defaultRunTransition`, `TransitionInput`, `runTransition` from `BootReconciliationDeps`, and unused libswamp imports.

Reported by @magistr — thank you for the thorough diagnosis.

## Related

- Fixes swamp-club#1955
- Filed swamp-club#1958 for the separate PID namespace collision in run tracker

## Reproduction

Verified with MinIO as S3-compatible datastore:
1. Init repo with `@swamp/s3-datastore` pointing at MinIO
2. Acquire active leases, sync to MinIO
3. Delete local managed cache (simulating container restart)
4. Start serve — data hydrates from MinIO under old UUID

**Installed binary (bug):** `Failed to expire stale lease "test-lease-1": "Step lease 'test-lease-1' does not exist"` — 0 leases swept.

**Fixed binary:** `Boot reconciliation: swept 2 lease(s)` — sub-second boot.

## Test plan

- [x] 61 unit tests pass in `boot_reconciliation_test.ts` (rewritten for `repo.save()`)
- [x] Worker sweep test verifies full field-update logic
- [x] Save failure test verifies warning + continue behavior
- [x] Type checks pass on all 4 modified files
- [x] Integration test compiles with new interface
- [x] Verification: build 9/9 + reviews (code-review pass, adversarial-review pass)
- [x] S3 datastore reproduction confirmed fix end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)