### PR TITLE
fix(docker): update Deno base image from 2.8.3 to 2.9.6 (swamp-club#1965)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM denoland/deno:2.8.3
+FROM denoland/deno:2.9.6
 
 ARG SWAMP_VERSION="dev"
 ARG VCS_REF=""


### PR DESCRIPTION
## Summary

- Update Dockerfile `FROM denoland/deno:2.8.3` to `FROM denoland/deno:2.9.6` to align with CI, which uses `deno-version: v2.9.x` across all workflows

## Test Plan

- Verification workflow passed: lint, fmt, type-check, tests, deps audit, compile, binary smoke test, and code review all green
- No new tests needed — the Dockerfile only packages a pre-compiled binary; the existing release pipeline (`docker` job in `release.yml`) validates multi-arch image builds

Closes swamp-club#1965