### PR TITLE
fix(run-tracker): use instanceId for PID namespace locality in containers (swamp-club#1958)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -2632,13 +2632,16 @@ export const serveCommand = new Command()
         { count: scrubbedHeaders },
       );
     }
-    const reapedRuns = runTracker.reapStaleRuns(DEFAULT_STALE_TTL_MS);
+    const reapedRuns = runTracker.reapStaleRuns(
+      DEFAULT_STALE_TTL_MS,
+      instanceId,
+    );
     for (const run of reapedRuns) {
       logger.warn`Reaped stale ${run.runKind} run ${run.id} (${
         run.methodName ?? run.workflowName ?? "unknown"
       })`;
     }
-    const deadPidRuns = runTracker.reapDeadProcessRuns();
+    const deadPidRuns = runTracker.reapDeadProcessRuns(instanceId);
     for (const run of deadPidRuns) {
       logger.warn`Reaped dead-process ${run.runKind} run ${run.id} (${
         run.methodName ?? run.workflowName ?? "unknown"
@@ -4121,7 +4124,7 @@ export const serveCommand = new Command()
           .info`Reaped ${remoteReaped} run(s) from dead remote instance(s)`;
       }
 
-      const deadPidRunsRemote = runTracker.reapDeadProcessRuns();
+      const deadPidRunsRemote = runTracker.reapDeadProcessRuns(instanceId);
       for (const run of deadPidRunsRemote) {
         logger.warn`Reaped dead-process ${run.runKind} run ${run.id} (${
           run.methodName ?? run.workflowName ?? "unknown"

--- a/src/domain/models/run_tracker_repository.ts
+++ b/src/domain/models/run_tracker_repository.ts
@@ -38,7 +38,7 @@ export interface RunTrackerRepository {
 
   findRecent(hours?: number): ActiveRun[];
 
-  reapStaleRuns(ttlMs: number): ActiveRun[];
+  reapStaleRuns(ttlMs: number, instanceId?: string): ActiveRun[];
 
   close(): void;
 }

--- a/src/infrastructure/persistence/run_tracker_store.ts
+++ b/src/infrastructure/persistence/run_tracker_store.ts
@@ -354,15 +354,17 @@ export class RunTrackerStore implements RunTrackerRepository {
     return rows.map((r) => ActiveRun.fromData(this.rowToData(r)));
   }
 
-  reapStaleRuns(ttlMs: number): ActiveRun[] {
+  reapStaleRuns(ttlMs: number, instanceId?: string): ActiveRun[] {
     const currentHostname = hostname();
     const stale = this.findStaleRuns(ttlMs);
     const reaped: ActiveRun[] = [];
 
     for (const run of stale) {
-      const shouldReap = run.hostname === currentHostname
-        ? isProcessDead(run.pid)
-        : true; // Cross-machine: rely on TTL alone
+      const isLocal = instanceId && run.instanceId
+        ? run.instanceId === instanceId
+        : run.hostname === currentHostname;
+
+      const shouldReap = isLocal ? isProcessDead(run.pid) : true;
 
       if (shouldReap) {
         this.complete(run.id, "failed");
@@ -373,13 +375,17 @@ export class RunTrackerStore implements RunTrackerRepository {
     return reaped;
   }
 
-  reapDeadProcessRuns(): ActiveRun[] {
+  reapDeadProcessRuns(instanceId?: string): ActiveRun[] {
     const currentHostname = hostname();
     const running = this.findAllRunning();
     const reaped: ActiveRun[] = [];
 
     for (const run of running) {
-      if (run.hostname !== currentHostname) continue;
+      const isLocal = instanceId && run.instanceId
+        ? run.instanceId === instanceId
+        : run.hostname === currentHostname;
+
+      if (!isLocal) continue;
       if (run.pid === Deno.pid) continue;
       if (!isProcessDead(run.pid)) continue;
 

--- a/src/infrastructure/persistence/run_tracker_store_test.ts
+++ b/src/infrastructure/persistence/run_tracker_store_test.ts
@@ -502,6 +502,224 @@ Deno.test("RunTrackerStore: reapDeadProcessRuns skips completed runs", () => {
   }
 });
 
+// ── instanceId-aware reaping tests ────────────────────────────────
+
+Deno.test("RunTrackerStore: reapStaleRuns with instanceId skips rows from different instance on same hostname", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "foreign-instance-1",
+      runKind: "workflow",
+      modelType: null,
+      methodName: null,
+      workflowName: "test-workflow",
+      pid: 7,
+      hostname: hostname(),
+      startedAt: new Date(Date.now() - 120_000).toISOString(),
+      heartbeatAt: new Date(Date.now() - 120_000).toISOString(),
+      status: "running",
+      instanceId: "instance-A",
+    });
+    store.register(run);
+
+    const reaped = store.reapStaleRuns(90_000, "instance-B");
+
+    assertEquals(reaped.length, 1);
+    assertEquals(reaped[0].id, "foreign-instance-1");
+    assertEquals(store.findById("foreign-instance-1")?.status, "failed");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapStaleRuns with instanceId checks PID for same-instance rows", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "local-instance-1",
+      runKind: "workflow",
+      modelType: null,
+      methodName: null,
+      workflowName: "test-workflow",
+      pid: Deno.pid,
+      hostname: hostname(),
+      startedAt: new Date(Date.now() - 120_000).toISOString(),
+      heartbeatAt: new Date(Date.now() - 120_000).toISOString(),
+      status: "running",
+      instanceId: "instance-A",
+    });
+    store.register(run);
+
+    const reaped = store.reapStaleRuns(90_000, "instance-A");
+
+    assertEquals(reaped.length, 0);
+    assertEquals(store.findById("local-instance-1")?.status, "running");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapStaleRuns falls back to hostname when row has no instanceId", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "legacy-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 2147483647,
+      hostname: hostname(),
+      startedAt: new Date(Date.now() - 120_000).toISOString(),
+      heartbeatAt: new Date(Date.now() - 120_000).toISOString(),
+      status: "running",
+    });
+    store.register(run);
+
+    const reaped = store.reapStaleRuns(90_000, "instance-A");
+
+    assertEquals(reaped.length, 1);
+    assertEquals(reaped[0].id, "legacy-1");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapStaleRuns falls back to hostname when no instanceId passed", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "no-param-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 2147483647,
+      hostname: "other-host",
+      startedAt: new Date(Date.now() - 120_000).toISOString(),
+      heartbeatAt: new Date(Date.now() - 120_000).toISOString(),
+      status: "running",
+      instanceId: "instance-A",
+    });
+    store.register(run);
+
+    const reaped = store.reapStaleRuns(90_000);
+
+    assertEquals(reaped.length, 1);
+    assertEquals(reaped[0].id, "no-param-1");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapDeadProcessRuns with instanceId skips rows from different instance on same hostname", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "container-1",
+      runKind: "workflow",
+      modelType: null,
+      methodName: null,
+      workflowName: "test-workflow",
+      pid: 2147483647,
+      hostname: hostname(),
+      startedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      status: "running",
+      instanceId: "instance-A",
+    });
+    store.register(run);
+
+    const reaped = store.reapDeadProcessRuns("instance-B");
+
+    assertEquals(reaped.length, 0);
+    assertEquals(store.findById("container-1")?.status, "running");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapDeadProcessRuns with instanceId reaps dead PIDs from same instance", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "same-instance-dead-1",
+      runKind: "workflow",
+      modelType: null,
+      methodName: null,
+      workflowName: "test-workflow",
+      pid: 2147483647,
+      hostname: hostname(),
+      startedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      status: "running",
+      instanceId: "instance-A",
+    });
+    store.register(run);
+
+    const reaped = store.reapDeadProcessRuns("instance-A");
+
+    assertEquals(reaped.length, 1);
+    assertEquals(reaped[0].id, "same-instance-dead-1");
+    assertEquals(store.findById("same-instance-dead-1")?.status, "failed");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapDeadProcessRuns falls back to hostname when row has no instanceId", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "legacy-dead-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 2147483647,
+      hostname: hostname(),
+      startedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      status: "running",
+    });
+    store.register(run);
+
+    const reaped = store.reapDeadProcessRuns("instance-A");
+
+    assertEquals(reaped.length, 1);
+    assertEquals(reaped[0].id, "legacy-dead-1");
+  } finally {
+    store.close();
+  }
+});
+
+Deno.test("RunTrackerStore: reapDeadProcessRuns falls back to hostname when no instanceId passed", () => {
+  const store = new RunTrackerStore(makeTempDbPath());
+  try {
+    const run = ActiveRun.fromData({
+      id: "no-param-dead-1",
+      runKind: "model_method",
+      modelType: "@test/model",
+      methodName: "start",
+      workflowName: null,
+      pid: 2147483647,
+      hostname: hostname(),
+      startedAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString(),
+      status: "running",
+      instanceId: "instance-A",
+    });
+    store.register(run);
+
+    const reaped = store.reapDeadProcessRuns();
+
+    assertEquals(reaped.length, 1);
+    assertEquals(reaped[0].id, "no-param-dead-1");
+  } finally {
+    store.close();
+  }
+});
+
 Deno.test("RunTrackerStore: schema v3 migration adds initiated_by column", () => {
   const dbPath = makeTempDbPath();
   const store1 = new RunTrackerStore(dbPath);

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -1683,7 +1683,10 @@ export function handleRunDoctor(
 
   let reaped = 0;
   if (payload?.fix && stale.length > 0) {
-    const reapedRuns = ctx.runTracker.reapStaleRuns(STALE_TTL_MS);
+    const reapedRuns = ctx.runTracker.reapStaleRuns(
+      STALE_TTL_MS,
+      ctx.instanceId,
+    );
     reaped = reapedRuns.length;
   }
 


### PR DESCRIPTION
## Summary

- **Bug:** `reapStaleRuns` and `reapDeadProcessRuns` used `hostname()` to determine PID namespace locality. In Docker, multiple containers sharing a hostname but with separate PID namespaces caused the liveness check to incorrectly identify foreign-container rows as local — stale records accumulated indefinitely.
- **Fix:** Both reap methods now accept an optional `instanceId` parameter. When provided (serve context), `instanceId` is used instead of `hostname` for PID namespace discrimination. Falls back to hostname for CLI callers and legacy rows without `instanceId`.
- Mirrors the pattern already used in serve boot reconciliation (`serve.ts:562-578`).

## Test plan

- [x] 8 new unit tests covering all instanceId-aware branches: same/different instance for both reap methods, legacy rows, and no-instanceId parameter fallback
- [x] All 37 existing run tracker tests pass
- [x] Type check passes across all changed files
- [x] Build verification: lint, fmt, type-check, tests, compile all green
- [x] Code review: no findings
- [x] Adversarial review: no findings

Closes swamp-club#1958

🤖 Generated with [Claude Code](https://claude.com/claude-code)