### PR TITLE
fix(update): handle Windows file locking in self-update binary replacement (swamp-club#1967)

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -1260,6 +1260,14 @@ export async function runCli(args: string[]): Promise<void> {
   const { rewriteDirectTypeArgs } = await import("./arg_rewriter.ts");
   args = rewriteDirectTypeArgs(args);
 
+  // Windows: clean up stale .old binary from a previous self-update
+  if (Deno.build.os === "windows") {
+    const { cleanupStaleBinary } = await import(
+      "../infrastructure/update/http_update_checker.ts"
+    );
+    await cleanupStaleBinary(Deno.execPath());
+  }
+
   // Capture start time for telemetry
   const startTime = new Date();
 

--- a/src/domain/update/update_service.ts
+++ b/src/domain/update/update_service.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { dirname, join } from "@std/path";
 import type { Platform } from "./platform.ts";
 import { validateRedirectUrl } from "./integrity.ts";
 import { UserError } from "../errors.ts";
@@ -150,17 +151,42 @@ export class UpdateService {
   /**
    * Check whether the process can write to the binary path.
    * Throws a UserError with remediation advice if not.
+   *
+   * On Windows the running binary is locked and cannot be opened for writing,
+   * so we probe directory writability instead — the rename-then-replace
+   * strategy only needs write access to the containing directory.
    */
   async checkWritePermission(): Promise<void> {
+    const permissionHint = Deno.build.os === "windows"
+      ? "Try running the terminal as Administrator."
+      : "Re-run with: sudo swamp update";
+
+    if (Deno.build.os === "windows") {
+      const probeFile = join(
+        dirname(this.binaryPath),
+        `.swamp.tmp.${crypto.randomUUID()}`,
+      );
+      try {
+        await Deno.writeTextFile(probeFile, "");
+        await Deno.remove(probeFile);
+      } catch (error) {
+        if (error instanceof Deno.errors.PermissionDenied) {
+          throw new UserError(
+            `Cannot update ${this.binaryPath}: permission denied. ${permissionHint}`,
+          );
+        }
+        // Other errors (e.g. disk full) are not permission issues
+      }
+      return;
+    }
+
     try {
-      // Try opening the file for writing without truncating — this tests
-      // actual write permission without modifying the file.
       const file = await Deno.open(this.binaryPath, { write: true });
       file.close();
     } catch (error) {
       if (error instanceof Deno.errors.PermissionDenied) {
         throw new UserError(
-          `Cannot update ${this.binaryPath}: permission denied. Re-run with: sudo swamp update`,
+          `Cannot update ${this.binaryPath}: permission denied. ${permissionHint}`,
         );
       }
       // Other errors (e.g. NotFound) are fine — the file may not exist yet

--- a/src/domain/update/update_service_test.ts
+++ b/src/domain/update/update_service_test.ts
@@ -280,30 +280,36 @@ Deno.test("update fetches checksum and passes it to downloadAndInstall", async (
 
 // --- Pre-flight permission check tests ---
 
-Deno.test("update rejects with UserError when binary path is not writable", async () => {
-  const tempDir = await Deno.makeTempDir();
-  const readOnlyFile = `${tempDir}/swamp`;
-  await Deno.writeTextFile(readOnlyFile, "binary");
-  await Deno.chmod(readOnlyFile, 0o444);
+Deno.test({
+  name: "update rejects with UserError when binary path is not writable",
+  // chmod mode bits are POSIX-only; on Windows the write-permission check
+  // probes directory writability instead (tested via Windows CI).
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    const tempDir = await Deno.makeTempDir();
+    const readOnlyFile = `${tempDir}/swamp`;
+    await Deno.writeTextFile(readOnlyFile, "binary");
+    await Deno.chmod(readOnlyFile, 0o444);
 
-  const redirectUrl =
-    "https://artifacts.swamp-club.com/swamp/20260208.000000.0-sha.def56789/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz";
-  const service = new UpdateService(
-    createMockChecker(redirectUrl),
-    "20260207.123456.0-sha.abc12345",
-    readOnlyFile,
-  );
+    const redirectUrl =
+      "https://artifacts.swamp-club.com/swamp/20260208.000000.0-sha.def56789/binary/darwin/aarch64/swamp-stable-binary-darwin-aarch64.tar.gz";
+    const service = new UpdateService(
+      createMockChecker(redirectUrl),
+      "20260207.123456.0-sha.abc12345",
+      readOnlyFile,
+    );
 
-  const error = await assertRejects(
-    () => service.update(platform),
-    UserError,
-  );
-  assertStringIncludes(error.message, "permission denied");
-  assertStringIncludes(error.message, "sudo swamp update");
+    const error = await assertRejects(
+      () => service.update(platform),
+      UserError,
+    );
+    assertStringIncludes(error.message, "permission denied");
+    assertStringIncludes(error.message, "sudo swamp update");
 
-  // Cleanup
-  await Deno.chmod(readOnlyFile, 0o644);
-  await Deno.remove(tempDir, { recursive: true });
+    // Cleanup
+    await Deno.chmod(readOnlyFile, 0o644);
+    await Deno.remove(tempDir, { recursive: true });
+  },
 });
 
 Deno.test("update proceeds when binary path is writable", async () => {

--- a/src/infrastructure/update/http_update_checker.ts
+++ b/src/infrastructure/update/http_update_checker.ts
@@ -73,18 +73,40 @@ async function removeQuarantine(path: string): Promise<void> {
   }
 }
 
+function permissionDeniedMessage(targetPath: string): string {
+  if (Deno.build.os === "windows") {
+    return `Cannot update ${targetPath}: permission denied. Try running the terminal as Administrator.`;
+  }
+  return `Cannot update ${targetPath}: permission denied. Re-run with: sudo swamp update`;
+}
+
+/**
+ * Best-effort cleanup of a stale `.old` binary left by a previous update.
+ * Exported so the CLI startup path can call it on Windows.
+ */
+export async function cleanupStaleBinary(binaryPath: string): Promise<void> {
+  const oldPath = binaryPath + ".old";
+  try {
+    await Deno.remove(oldPath);
+  } catch {
+    // File doesn't exist or is still locked — either is fine
+  }
+}
+
 /**
  * Replace a binary at `targetPath` with the file at `sourcePath`.
  *
- * Uses atomic rename to create a new inode at the target path. Running
- * processes keep their vnode reference to the old inode — no SIGKILL on
- * macOS (code-signed binaries stay valid), no ETXTBSY on Linux (rename
- * operates on directory entries, not file data).
+ * On POSIX (macOS, Linux): atomic rename creates a new inode at the target
+ * path. Running processes keep their vnode reference to the old inode —
+ * no SIGKILL on macOS, no ETXTBSY on Linux.
  *
- * Strategy:
- * 1. Try `Deno.rename()` — atomic, replaces the target in one syscall.
- * 2. If rename fails with EXDEV (cross-filesystem), copy to a temp file
- *    in the target directory (guaranteeing same-filesystem), then rename.
+ * On Windows: running executables are locked and cannot be overwritten,
+ * but CAN be renamed. Strategy: rename the running binary to `.old`,
+ * then rename the new binary into place. If placement fails, rollback
+ * by renaming `.old` back. The `.old` file is cleaned up on next launch.
+ *
+ * POSIX fallback: if rename fails with EXDEV (cross-filesystem), copy to
+ * a temp file in the target directory (same filesystem), then rename.
  */
 async function replaceBinary(
   sourcePath: string,
@@ -106,13 +128,16 @@ async function replaceBinary(
     // readDir may fail on permission errors — not fatal
   }
 
+  if (Deno.build.os === "windows") {
+    await replaceBinaryWindows(sourcePath, targetPath);
+    return;
+  }
+
   try {
     await Deno.rename(sourcePath, targetPath);
   } catch (error) {
     if (error instanceof Deno.errors.PermissionDenied) {
-      throw new UserError(
-        `Cannot update ${targetPath}: permission denied. Re-run with: sudo swamp update`,
-      );
+      throw new UserError(permissionDeniedMessage(targetPath));
     }
     // EXDEV: source and target on different filesystems — rename won't work.
     // Copy to a temp file in the target directory, then atomic rename.
@@ -131,14 +156,79 @@ async function replaceBinary(
           // Best-effort cleanup
         }
         if (innerError instanceof Deno.errors.PermissionDenied) {
-          throw new UserError(
-            `Cannot update ${targetPath}: permission denied. Re-run with: sudo swamp update`,
-          );
+          throw new UserError(permissionDeniedMessage(targetPath));
         }
         throw innerError;
       }
     } else {
       throw error;
+    }
+  }
+}
+
+async function replaceBinaryWindows(
+  sourcePath: string,
+  targetPath: string,
+): Promise<void> {
+  const oldPath = targetPath + ".old";
+
+  // Clean up stale .old from a previous update
+  await cleanupStaleBinary(targetPath);
+
+  // Rename the running binary out of the way — Windows allows renaming
+  // a locked file, just not overwriting or deleting it.
+  let targetExisted = false;
+  try {
+    await Deno.rename(targetPath, oldPath);
+    targetExisted = true;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      // Target doesn't exist yet (fresh install) — proceed directly
+    } else if (error instanceof Deno.errors.PermissionDenied) {
+      throw new UserError(permissionDeniedMessage(targetPath));
+    } else {
+      throw error;
+    }
+  }
+
+  // Place the new binary at the target path.
+  // Try rename first; fall back to copy if EXDEV (cross-volume, e.g.
+  // %TEMP% on D: and swamp installed on C:).
+  try {
+    await Deno.rename(sourcePath, targetPath);
+  } catch (renameError) {
+    const code = renameError instanceof Error
+      ? (renameError as Error & { code?: string }).code
+      : undefined;
+    if (code === "EXDEV") {
+      try {
+        await Deno.copyFile(sourcePath, targetPath);
+      } catch (copyError) {
+        if (targetExisted) {
+          try {
+            await Deno.rename(oldPath, targetPath);
+          } catch {
+            // Rollback failed — .old file still exists for manual recovery
+          }
+        }
+        if (copyError instanceof Deno.errors.PermissionDenied) {
+          throw new UserError(permissionDeniedMessage(targetPath));
+        }
+        throw copyError;
+      }
+    } else {
+      // Rollback: restore the old binary so the user isn't left without one
+      if (targetExisted) {
+        try {
+          await Deno.rename(oldPath, targetPath);
+        } catch {
+          // Rollback failed — .old file still exists for manual recovery
+        }
+      }
+      if (renameError instanceof Deno.errors.PermissionDenied) {
+        throw new UserError(permissionDeniedMessage(targetPath));
+      }
+      throw renameError;
     }
   }
 }

--- a/src/infrastructure/update/http_update_checker_test.ts
+++ b/src/infrastructure/update/http_update_checker_test.ts
@@ -25,7 +25,10 @@ import {
 import { join } from "@std/path";
 import { TarStream } from "@std/tar/tar-stream";
 import { Platform } from "../../domain/update/platform.ts";
-import { HttpUpdateChecker } from "./http_update_checker.ts";
+import {
+  cleanupStaleBinary,
+  HttpUpdateChecker,
+} from "./http_update_checker.ts";
 import { computeChecksum } from "../../domain/models/checksum.ts";
 
 Deno.test("stable URL is constructed correctly for darwin aarch64", () => {
@@ -347,4 +350,40 @@ Deno.test({
       await Deno.remove(tempDir, { recursive: true });
     }
   },
+});
+
+// --- cleanupStaleBinary tests ---
+
+Deno.test("cleanupStaleBinary: removes .old file when it exists", async () => {
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-cleanup-test-" });
+  try {
+    const binaryPath = join(tempDir, "swamp");
+    const oldPath = binaryPath + ".old";
+    await Deno.writeTextFile(oldPath, "stale binary");
+
+    await cleanupStaleBinary(binaryPath);
+
+    let exists = true;
+    try {
+      await Deno.stat(oldPath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        exists = false;
+      }
+    }
+    assertEquals(exists, false, ".old file should be removed");
+  } finally {
+    await Deno.remove(tempDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("cleanupStaleBinary: succeeds silently when no .old file exists", async () => {
+  const tempDir = await Deno.makeTempDir({ prefix: "swamp-cleanup-test-" });
+  try {
+    const binaryPath = join(tempDir, "swamp");
+    // No .old file created — should not throw
+    await cleanupStaleBinary(binaryPath);
+  } finally {
+    await Deno.remove(tempDir, { recursive: true }).catch(() => {});
+  }
 });


### PR DESCRIPTION
## Summary

- Add Windows-specific rename-then-replace strategy in `replaceBinary()` — rename the running binary to `.old` (Windows allows renaming locked files), place the new binary at the original path, rollback `.old` on failure
- Include EXDEV (cross-volume) fallback for when `%TEMP%` is on a different drive than the installation directory
- Adapt `UpdateService.checkWritePermission()` to probe directory writability on Windows instead of opening the locked binary
- Add startup cleanup in `runCli()` to delete stale `.old` files on Windows
- Make all `PermissionDenied` error messages platform-aware ("Run as Administrator" on Windows instead of "sudo")

## Test plan

- [x] `cleanupStaleBinary` removes `.old` file when it exists
- [x] `cleanupStaleBinary` succeeds silently when no `.old` file exists
- [x] Existing POSIX tests pass unchanged (12 tests in http_update_checker_test.ts)
- [x] Existing update service tests pass (21 tests in update_service_test.ts)
- [x] `deno check`, `deno lint`, `deno fmt` clean
- [x] Full verification workflow: build (9/9), reviews (VERDICT: pass), skills (guard-skipped)

Closes swamp-club#1967

🤖 Generated with [Claude Code](https://claude.com/claude-code)