### PR TITLE
fix(security): scope remote dispatch asset listing to declared additionalFiles (swamp-club#1910)

### DIFF
--- a/design/enablers/remote-execution.md
+++ b/design/enablers/remote-execution.md
@@ -762,10 +762,14 @@ binary's registry — enrollment already guaranteed version lockstep, and a
 sentinel for a type the worker does not know is a loud
 binaries-disagree error. Co-located extension assets — files resolved through
 `context.extensionFile(relPath)` — are *not* inlined into the single-file JS
-bundle; the worker prefetches the (small) asset tree via
-`GET /bundle/{fingerprint}/files` + `GET /bundle/{fingerprint}/file/{relPath}`
-before executing, because `extensionFile()` is synchronous and must resolve a
-local path. Assets cache under the fingerprint like the bundle itself.
+bundle; the worker prefetches only the files declared in the manifest's
+`additionalFiles` via `GET /bundle/{fingerprint}/files` +
+`GET /bundle/{fingerprint}/file/{relPath}` before executing, because
+`extensionFile()` is synchronous and must resolve a local path. Both routes
+are gated to the declared set — undeclared files under the extension's
+`filesRoot` are never listed or served, preventing accidental exposure of
+unrelated repository content to remote workers. Assets cache under the
+fingerprint like the bundle itself.
 
 ### Pre-flight checks are skipped for remote steps; reports run at the orchestrator
 

--- a/src/domain/extensions/model_kind_adapter.ts
+++ b/src/domain/extensions/model_kind_adapter.ts
@@ -55,6 +55,7 @@ import type {
   ValidationResult,
 } from "./kind_adapter.ts";
 import { emitExtensionLoadWarning } from "../../infrastructure/logging/extension_load_warnings.ts";
+import { parseExtensionManifest } from "./extension_manifest.ts";
 
 const logger = getLogger(["swamp", "models", "loader"]);
 
@@ -398,16 +399,21 @@ function validateUserCollective(rawType: string): string | undefined {
   return undefined;
 }
 
-const extensionFilesRootCache = new Map<string, string | undefined>();
+interface ExtensionAssets {
+  filesRoot: string;
+  additionalFiles: string[];
+}
 
-function resolveExtensionFilesRoot(
+const extensionAssetsCache = new Map<string, ExtensionAssets | undefined>();
+
+function resolveExtensionAssets(
   sourcePath: string,
   repoDir: string | null,
-): string | undefined {
+): ExtensionAssets | undefined {
   let currentDir = dirname(sourcePath);
   const root = resolve("/");
   while (true) {
-    const cached = extensionFilesRootCache.get(currentDir);
+    const cached = extensionAssetsCache.get(currentDir);
     if (cached !== undefined) return cached;
 
     const manifestPath = join(currentDir, "manifest.yaml");
@@ -419,8 +425,20 @@ function resolveExtensionFilesRoot(
       ) || normalized.includes(
         `/${SWAMP_DATA_DIR}/config/pulled-extensions/`,
       );
-      const result = isPulled ? join(currentDir, "files") : currentDir;
-      extensionFilesRootCache.set(currentDir, result);
+      const filesRoot = isPulled ? join(currentDir, "files") : currentDir;
+
+      let additionalFiles: string[] = [];
+      try {
+        const content = Deno.readTextFileSync(manifestPath);
+        const manifest = parseExtensionManifest(content);
+        additionalFiles = manifest.additionalFiles;
+      } catch {
+        logger
+          .warn`Failed to parse manifest at ${manifestPath} for additionalFiles; defaulting to empty`;
+      }
+
+      const result: ExtensionAssets = { filesRoot, additionalFiles };
+      extensionAssetsCache.set(currentDir, result);
       return result;
     } catch {
       // Not here; walk up.
@@ -525,10 +543,12 @@ export const modelKindAdapter: KindAdapter = {
   ): void {
     const userModel = validated as z.infer<typeof UserModelSchema>;
     const modelDef = convertToModelDefinition(userModel);
-    modelDef.extensionFilesRoot = resolveExtensionFilesRoot(
+    const assets = resolveExtensionAssets(
       context.absolutePath,
       context.repoDir,
     );
+    modelDef.extensionFilesRoot = assets?.filesRoot;
+    modelDef.extensionAdditionalFiles = assets?.additionalFiles;
     modelDef.extensionName = context.extensionName;
     modelDef.sourceFingerprint = context.sourceFingerprint;
 
@@ -578,10 +598,12 @@ export const modelKindAdapter: KindAdapter = {
   ): void {
     const userModel = validated as z.infer<typeof UserModelSchema>;
     const modelDef = convertToModelDefinition(userModel);
-    modelDef.extensionFilesRoot = resolveExtensionFilesRoot(
+    const assets = resolveExtensionAssets(
       context.absolutePath,
       context.repoDir,
     );
+    modelDef.extensionFilesRoot = assets?.filesRoot;
+    modelDef.extensionAdditionalFiles = assets?.additionalFiles;
     modelDef.extensionName = context.extensionName;
     modelDef.sourceFingerprint = context.sourceFingerprint;
 

--- a/src/domain/models/model.ts
+++ b/src/domain/models/model.ts
@@ -877,6 +877,14 @@ export interface ModelDefinition<
   extensionFilesRoot?: string;
 
   /**
+   * Declared `additionalFiles` entries from the extension manifest.
+   * Only these files are shipped to remote workers via the data plane.
+   * Undefined for built-in model types and source-loaded directories
+   * without a `manifest.yaml`.
+   */
+  extensionAdditionalFiles?: string[];
+
+  /**
    * Scoped name of the extension that provides this model type (e.g.
    * `@keeb/network`). Populated by the extension loader at registration
    * time. Undefined for built-in types and user-authored models in

--- a/src/serve/bundle_registry.ts
+++ b/src/serve/bundle_registry.ts
@@ -36,6 +36,12 @@ export interface RegisteredBundle {
    * Undefined for built-in models, which carry no assets.
    */
   filesRoot?: string;
+  /**
+   * Declared `additionalFiles` from the extension manifest. Only these
+   * files are served to workers; an empty or undefined list means no
+   * co-located assets are shipped.
+   */
+  additionalFiles?: string[];
 }
 
 export class BundleRegistry {

--- a/src/serve/data_plane.ts
+++ b/src/serve/data_plane.ts
@@ -528,10 +528,7 @@ export class DataPlane {
     }
 
     if (segments.length === 3 && segments[2] === "files") {
-      if (bundle.filesRoot === undefined) {
-        return json({ files: [] });
-      }
-      return this.#listAssetFiles(bundle.filesRoot);
+      return this.#listDeclaredAssetFiles(bundle);
     }
 
     if (segments.length >= 4 && segments[2] === "file") {
@@ -541,13 +538,19 @@ export class DataPlane {
       const relPath = segments.slice(3).map(decodeURIComponent).join("/");
       const root = resolve(bundle.filesRoot);
       const target = resolve(join(root, normalize(relPath)));
-      // The asset must stay within the extension's files root.
       if (
         isAbsolute(relPath) || relPath.includes("..") ||
         (!target.startsWith(root + "/") && target !== root &&
           !target.startsWith(root + "\\"))
       ) {
         return errorResponse(400, "Asset path escapes the bundle root");
+      }
+      const allowed = bundle.additionalFiles;
+      if (!allowed || !allowed.includes(relPath)) {
+        return errorResponse(
+          404,
+          "Asset not declared in manifest additionalFiles",
+        );
       }
       return this.#serveAssetFile(target, fingerprint, relPath);
     }
@@ -556,49 +559,36 @@ export class DataPlane {
   }
 
   /**
-   * Recursive relative listing of a bundle's co-located files, so a worker
-   * can prefetch the whole (small) asset tree before executing — the
-   * `extensionFile()` context member is synchronous and must resolve to a
-   * local path.
+   * Return only files explicitly declared in the manifest's
+   * `additionalFiles`, verified to exist on disk. Undeclared files —
+   * including `.git/`, `.env`, and other repository content — are never
+   * listed, closing the confidentiality exposure in issue #1910.
    */
-  #listAssetFiles(filesRoot: string): Response {
-    const MAX_WALK_DEPTH = 20;
-    const MAX_FILES = 10_000;
+  #listDeclaredAssetFiles(
+    bundle: import("./bundle_registry.ts").RegisteredBundle,
+  ): Response {
+    const { filesRoot, additionalFiles } = bundle;
+    if (!filesRoot || !additionalFiles || additionalFiles.length === 0) {
+      return json({ files: [] });
+    }
+    const root = resolve(filesRoot);
     const files: string[] = [];
-    const visited = new Set<string>();
-
-    const walk = (dir: string, prefix: string, depth: number) => {
-      if (depth > MAX_WALK_DEPTH || files.length >= MAX_FILES) return;
-
-      let realDir: string;
+    for (const relPath of additionalFiles) {
+      const target = resolve(join(root, relPath));
+      if (
+        !target.startsWith(root + "/") && target !== root &&
+        !target.startsWith(root + "\\")
+      ) {
+        continue;
+      }
       try {
-        realDir = Deno.realPathSync(dir);
-      } catch {
-        return;
-      }
-      if (visited.has(realDir)) return;
-      visited.add(realDir);
-
-      for (const entry of Deno.readDirSync(dir)) {
-        if (entry.isSymlink) continue;
-        const rel = prefix.length === 0
-          ? entry.name
-          : `${prefix}/${entry.name}`;
-        if (entry.isDirectory) {
-          walk(join(dir, entry.name), rel, depth + 1);
-        } else if (entry.isFile) {
-          files.push(rel);
-          if (files.length >= MAX_FILES) return;
+        const stat = Deno.lstatSync(target);
+        if (stat.isFile) {
+          files.push(relPath);
         }
+      } catch {
+        // File declared but missing on disk — skip silently.
       }
-    };
-    try {
-      walk(filesRoot, "", 0);
-    } catch (error) {
-      if (error instanceof Deno.errors.NotFound) {
-        return json({ files: [] });
-      }
-      throw error;
     }
     return json({ files });
   }

--- a/src/serve/data_plane_test.ts
+++ b/src/serve/data_plane_test.ts
@@ -474,6 +474,7 @@ Deno.test("DataPlane: co-located assets serve from the bundle root only", async 
     h.bundles.register("fp-with-files", {
       js: "export {};",
       filesRoot: assetsRoot,
+      additionalFiles: ["templates/report.html"],
     });
 
     const asset = await h.plane.handle(
@@ -537,63 +538,89 @@ Deno.test("DataPlane: DELETE /data/resource requires active dispatch", async () 
   });
 });
 
-// ── listAssetFiles hardening tests ──────────────────────────────────────
+// ── declared-asset-files security tests (issue #1910) ─────────────────
 
-Deno.test("DataPlane: /bundle/{fp}/files skips symlinks", async () => {
+Deno.test("DataPlane: /bundle/{fp}/files lists only declared additionalFiles", async () => {
   await withHarness(async ({ plane, bundles }) => {
-    const tempDir = await Deno.makeTempDir({ prefix: "bundle-files-test" });
+    const tempDir = await Deno.makeTempDir({ prefix: "bundle-declared-test" });
     try {
-      await Deno.writeTextFile(join(tempDir, "real.txt"), "content");
-      await Deno.symlink(
-        join(tempDir, "real.txt"),
-        join(tempDir, "link.txt"),
-        { type: "file" },
-      );
-      bundles.register("fp-1", { js: "export {};", filesRoot: tempDir });
-      const resp = await plane.handle(request("/bundle/fp-1/files"));
+      await Deno.writeTextFile(join(tempDir, "declared.txt"), "ok");
+      await Deno.writeTextFile(join(tempDir, "undeclared.txt"), "secret");
+      await Deno.writeTextFile(join(tempDir, ".env"), "KEY=val");
+      await Deno.mkdir(join(tempDir, ".git"), { recursive: true });
+      await Deno.writeTextFile(join(tempDir, ".git", "config"), "repo");
+      bundles.register("fp-decl", {
+        js: "export {};",
+        filesRoot: tempDir,
+        additionalFiles: ["declared.txt"],
+      });
+      const resp = await plane.handle(request("/bundle/fp-decl/files"));
       const body = await resp!.json();
-      assertEquals(body.files, ["real.txt"]);
+      assertEquals(body.files, ["declared.txt"]);
     } finally {
       await Deno.remove(tempDir, { recursive: true }).catch(() => {});
     }
   });
 });
 
-Deno.test("DataPlane: /bundle/{fp}/files respects max depth", async () => {
+Deno.test("DataPlane: /bundle/{fp}/files returns empty when no additionalFiles declared", async () => {
   await withHarness(async ({ plane, bundles }) => {
-    const tempDir = await Deno.makeTempDir({ prefix: "bundle-depth-test" });
+    const tempDir = await Deno.makeTempDir({ prefix: "bundle-empty-test" });
     try {
-      let dir = tempDir;
-      for (let i = 0; i < 25; i++) {
-        dir = join(dir, `d${i}`);
-        await Deno.mkdir(dir);
-        await Deno.writeTextFile(join(dir, "f.txt"), "content");
-      }
-      bundles.register("fp-2", { js: "export {};", filesRoot: tempDir });
-      const resp = await plane.handle(request("/bundle/fp-2/files"));
+      await Deno.writeTextFile(join(tempDir, "file.txt"), "content");
+      bundles.register("fp-empty", {
+        js: "export {};",
+        filesRoot: tempDir,
+      });
+      const resp = await plane.handle(request("/bundle/fp-empty/files"));
       const body = await resp!.json();
-      const maxDepth = Math.max(
-        ...body.files.map((f: string) => f.split("/").length),
-      );
-      // MAX_WALK_DEPTH is 20, so files at depth 21+ should be excluded
-      assertEquals(maxDepth <= 21, true);
+      assertEquals(body.files, []);
     } finally {
       await Deno.remove(tempDir, { recursive: true }).catch(() => {});
     }
   });
 });
 
-Deno.test("DataPlane: /bundle/{fp}/files caps total file count", async () => {
+Deno.test("DataPlane: /bundle/{fp}/files skips declared files missing on disk", async () => {
   await withHarness(async ({ plane, bundles }) => {
-    const tempDir = await Deno.makeTempDir({ prefix: "bundle-cap-test" });
+    const tempDir = await Deno.makeTempDir({ prefix: "bundle-missing-test" });
     try {
-      for (let i = 0; i < 50; i++) {
-        await Deno.writeTextFile(join(tempDir, `f${i}.txt`), "x");
-      }
-      bundles.register("fp-3", { js: "export {};", filesRoot: tempDir });
-      const resp = await plane.handle(request("/bundle/fp-3/files"));
+      await Deno.writeTextFile(join(tempDir, "exists.txt"), "ok");
+      bundles.register("fp-miss", {
+        js: "export {};",
+        filesRoot: tempDir,
+        additionalFiles: ["exists.txt", "gone.txt"],
+      });
+      const resp = await plane.handle(request("/bundle/fp-miss/files"));
       const body = await resp!.json();
-      assertEquals(body.files.length, 50);
+      assertEquals(body.files, ["exists.txt"]);
+    } finally {
+      await Deno.remove(tempDir, { recursive: true }).catch(() => {});
+    }
+  });
+});
+
+Deno.test("DataPlane: /bundle/{fp}/file rejects undeclared file access", async () => {
+  await withHarness(async ({ plane, bundles }) => {
+    const tempDir = await Deno.makeTempDir({ prefix: "bundle-reject-test" });
+    try {
+      await Deno.writeTextFile(join(tempDir, "declared.txt"), "ok");
+      await Deno.writeTextFile(join(tempDir, ".env"), "SECRET=val");
+      bundles.register("fp-reject", {
+        js: "export {};",
+        filesRoot: tempDir,
+        additionalFiles: ["declared.txt"],
+      });
+      const allowed = await plane.handle(
+        request("/bundle/fp-reject/file/declared.txt"),
+      );
+      assertEquals(allowed?.status, 200);
+      assertEquals(await allowed?.text(), "ok");
+
+      const denied = await plane.handle(
+        request("/bundle/fp-reject/file/.env"),
+      );
+      assertEquals(denied?.status, 404);
     } finally {
       await Deno.remove(tempDir, { recursive: true }).catch(() => {});
     }

--- a/src/serve/dispatch_service.ts
+++ b/src/serve/dispatch_service.ts
@@ -30,6 +30,7 @@
  * fails the run.
  */
 
+import { join } from "@std/path";
 import {
   createLibSwampContext,
   createWorkerModelRunDeps,
@@ -716,12 +717,41 @@ export class DispatchService {
       return `${BUILTIN_BUNDLE_PREFIX}${modelDef.type.normalized}`;
     }
     const js = await modelDef.bundleSourceFactory();
-    const fingerprint = await sha256Hex(js);
+    const fingerprint = await this.#bundleFingerprint(
+      js,
+      modelDef.extensionFilesRoot,
+      modelDef.extensionAdditionalFiles,
+    );
     this.#options.bundles.register(fingerprint, {
       js,
       filesRoot: modelDef.extensionFilesRoot,
+      additionalFiles: modelDef.extensionAdditionalFiles,
     });
     return fingerprint;
+  }
+
+  async #bundleFingerprint(
+    js: string,
+    filesRoot: string | undefined,
+    additionalFiles: string[] | undefined,
+  ): Promise<string> {
+    if (!filesRoot || !additionalFiles || additionalFiles.length === 0) {
+      return sha256Hex(js);
+    }
+    const parts: string[] = [js];
+    for (const relPath of [...additionalFiles].sort()) {
+      const absPath = join(filesRoot, relPath);
+      try {
+        const content = await Deno.readFile(absPath);
+        const hash = await sha256Hex(
+          new TextDecoder().decode(content),
+        );
+        parts.push(`${relPath}:${hash}`);
+      } catch {
+        parts.push(`${relPath}:missing`);
+      }
+    }
+    return sha256Hex(parts.join("\0"));
   }
 
   #pendingTransition(


### PR DESCRIPTION
## Summary

- Scope the data plane's asset listing (`GET /bundle/{fp}/files`) and individual file serving (`GET /bundle/{fp}/file/{relPath}`) to only manifest-declared `additionalFiles` entries — undeclared files under `extensionFilesRoot` are never listed or served
- Include `additionalFiles` contents in the bundle fingerprint so workers re-fetch when a declared asset changes on disk
- Thread `additionalFiles` from manifest parse through `ModelDefinition` → `BundleRegistry` → `DataPlane`

Closes swamp-club#1910

## What changed

| File | Change |
|------|--------|
| `src/domain/extensions/model_kind_adapter.ts` | `resolveExtensionFilesRoot()` → `resolveExtensionAssets()`: also parses the manifest to extract `additionalFiles` |
| `src/domain/models/model.ts` | Add `extensionAdditionalFiles` field to `ModelDefinition` |
| `src/serve/bundle_registry.ts` | Add `additionalFiles` field to `RegisteredBundle` |
| `src/serve/dispatch_service.ts` | Thread `additionalFiles` into bundle registry; include asset contents in fingerprint hash |
| `src/serve/data_plane.ts` | Replace recursive `#listAssetFiles()` walk with `#listDeclaredAssetFiles()`; gate file-serving route against allowlist |
| `src/serve/data_plane_test.ts` | 4 new security tests replacing 3 old hardening tests |
| `design/enablers/remote-execution.md` | Document the additionalFiles-only policy |

## Security impact

Before: a remotely dispatched local model whose nearest `manifest.yaml` was the repo root caused the data plane to walk and serve up to 10,000 files from the repository — including `.git/`, `.env`, and other sensitive content.

After: only files explicitly declared in `additionalFiles` are listed and served. Empty `additionalFiles` (the common case) means zero files ship. The bundle fingerprint now includes asset contents, so changed assets invalidate the worker cache.

## Test plan

- [x] Unit tests: declared-only listing, empty returns, missing-file skips, undeclared access rejection
- [x] End-to-end: compiled patched binary, set up serve + worker + dispatch, confirmed worker cache contains only `bundle.js` — no repository files leaked
- [x] All 906 serve tests pass, 654 extension tests pass, 937 model tests pass
- [x] Verification: build 9/9, reviews all passed
- [x] Attestation posted: `10fc022c-4809-4a5b-a533-830db2f7c7e0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)