### PR TITLE
fix(describe): surface Zod v3 diagnostic instead of empty arguments (swamp-club#1950)

### DIFF
--- a/.claude/skills/swamp/references/extension-publish/references/publishing.md
+++ b/.claude/skills/swamp/references/extension-publish/references/publishing.md
@@ -429,7 +429,7 @@ swamp extension push manifest.yaml --repo-dir /path/to/repo --json
    driver, datastore, and report files (using the project's `deno.json` config
    if present, otherwise default rules). Include files are excluded.
 8. **Bare specifier check** — scans source files for bare import specifiers
-   (e.g. `from "zod"` instead of `from "npm:zod@3"`). The server-side scorer
+   (e.g. `from "zod"` instead of `from "npm:zod@4"`). The server-side scorer
    cannot resolve bare specifiers, so a warning is added to the review warnings
    prompting the user to confirm before push.
 9. **Bundle TypeScript** — compiles each entry point (models, vaults, drivers,

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -21,6 +21,7 @@ import { getLogger } from "@logtape/logtape";
 import { stripAnsiCode } from "@std/fmt/colors";
 import { dirname, join, resolve } from "@std/path";
 import * as zodModule from "zod";
+import { UserError } from "../errors.ts";
 
 const logger = getLogger(["swamp", "models", "bundle"]);
 
@@ -119,7 +120,7 @@ export function rejectZodV3Imports(js: string): void {
     /import\s+(?:\{[^}]+\}|\*\s+as\s+\w+)\s+from\s*["'](?:npm:)?zod@3[^"']*["']/;
   const match = v3Pattern.exec(js);
   if (match) {
-    throw new Error(
+    throw new UserError(
       `Extension imports Zod v3 (${match[0].trim()}). ` +
         `Swamp requires Zod v4 — update your zod dependency to v4 and ` +
         `rebuild. See https://zod.dev/v4 for migration guidance.`,
@@ -128,12 +129,12 @@ export function rejectZodV3Imports(js: string): void {
 }
 
 export function rewriteZodImports(js: string): string {
-  rejectZodV3Imports(js);
-
   // Match: import { ... } from "npm:zod...", "zod", or 'zod'
   // Handles both npm: prefixed specifiers (existing extensions) and
   // bare "zod" specifiers (when externalized via deno.json import map).
-  // Only matches zod 4.x or unversioned — zod 3.x is rejected above.
+  // Only matches zod 4.x or unversioned — zod 3.x is detected separately
+  // at bundle-creation time via rejectZodV3Imports (not here, because
+  // rewriteZodImports is also called at runtime on cached bundles).
   const namedImportPattern =
     /import\s*\{([^}]+)\}\s*from\s*["'](?:npm:)?zod(?:@4[^"']*)?["']\s*;?/g;
   js = js.replace(namedImportPattern, (_match, imports: string) => {
@@ -706,6 +707,7 @@ export async function bundleExtension(
     // Rewrite externalized zod imports to use globalThis.__swamp_zod
     // so extensions share swamp's Zod instance in the compiled binary.
     if (!options?.selfContained) {
+      rejectZodV3Imports(js);
       js = rewriteZodImports(js);
     }
 

--- a/src/domain/models/bundle.ts
+++ b/src/domain/models/bundle.ts
@@ -109,12 +109,31 @@ export function sanitizeDataUrlError(error: unknown): string {
   );
 }
 
+/**
+ * Detects Zod v3 imports in bundled JS and throws with upgrade guidance.
+ * Swamp ships Zod v4 — extensions using v3 will have broken schema
+ * introspection and should upgrade.
+ */
+export function rejectZodV3Imports(js: string): void {
+  const v3Pattern =
+    /import\s+(?:\{[^}]+\}|\*\s+as\s+\w+)\s+from\s*["'](?:npm:)?zod@3[^"']*["']/;
+  const match = v3Pattern.exec(js);
+  if (match) {
+    throw new Error(
+      `Extension imports Zod v3 (${match[0].trim()}). ` +
+        `Swamp requires Zod v4 — update your zod dependency to v4 and ` +
+        `rebuild. See https://zod.dev/v4 for migration guidance.`,
+    );
+  }
+}
+
 export function rewriteZodImports(js: string): string {
+  rejectZodV3Imports(js);
+
   // Match: import { ... } from "npm:zod...", "zod", or 'zod'
   // Handles both npm: prefixed specifiers (existing extensions) and
   // bare "zod" specifiers (when externalized via deno.json import map).
-  // Only matches zod 4.x or unversioned — zod 3.x must NOT be rewritten
-  // since globalThis.__swamp_zod provides zod 4.
+  // Only matches zod 4.x or unversioned — zod 3.x is rejected above.
   const namedImportPattern =
     /import\s*\{([^}]+)\}\s*from\s*["'](?:npm:)?zod(?:@4[^"']*)?["']\s*;?/g;
   js = js.replace(namedImportPattern, (_match, imports: string) => {

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -313,13 +313,10 @@ Deno.test("rejectZodV3Imports: allows unversioned zod import", () => {
   rejectZodV3Imports(input);
 });
 
-Deno.test("rewriteZodImports: throws on zod@3 before rewriting", () => {
+Deno.test("rewriteZodImports: leaves zod@3 imports untouched", () => {
   const input = `import { z } from "npm:zod@3.22.4";`;
-  assertThrows(
-    () => rewriteZodImports(input),
-    Error,
-    "Zod v3",
-  );
+  const result = rewriteZodImports(input);
+  assertEquals(result, input);
 });
 
 // --- uint8ArrayToBase64 unit tests ---

--- a/src/domain/models/bundle_test.ts
+++ b/src/domain/models/bundle_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { join } from "@std/path";
 import { z } from "zod";
 import {
@@ -26,6 +26,7 @@ import {
   fixCjsEsmInterop,
   installZodGlobal,
   isExpectedBundleFailure,
+  rejectZodV3Imports,
   rewriteZodImports,
   sanitizeDataUrlError,
   sourceHasBareSpecifiers,
@@ -280,6 +281,45 @@ Deno.test("rewriteZodImports handles single-quoted specifiers", () => {
   const input = `import { z } from 'npm:zod@4';`;
   const result = rewriteZodImports(input);
   assertEquals(result, `const { z } = globalThis.__swamp_zod;`);
+});
+
+// --- rejectZodV3Imports unit tests ---
+
+Deno.test("rejectZodV3Imports: throws on zod@3 named import", () => {
+  const input = `import { z } from "npm:zod@3.23.8";`;
+  assertThrows(
+    () => rejectZodV3Imports(input),
+    Error,
+    "Zod v3",
+  );
+});
+
+Deno.test("rejectZodV3Imports: throws on zod@3 star import", () => {
+  const input = `import * as zod from "npm:zod@3";`;
+  assertThrows(
+    () => rejectZodV3Imports(input),
+    Error,
+    "Swamp requires Zod v4",
+  );
+});
+
+Deno.test("rejectZodV3Imports: allows zod@4 import", () => {
+  const input = `import { z } from "npm:zod@4.3.6";`;
+  rejectZodV3Imports(input);
+});
+
+Deno.test("rejectZodV3Imports: allows unversioned zod import", () => {
+  const input = `import { z } from "zod";`;
+  rejectZodV3Imports(input);
+});
+
+Deno.test("rewriteZodImports: throws on zod@3 before rewriting", () => {
+  const input = `import { z } from "npm:zod@3.22.4";`;
+  assertThrows(
+    () => rewriteZodImports(input),
+    Error,
+    "Zod v3",
+  );
 });
 
 // --- uint8ArrayToBase64 unit tests ---

--- a/src/domain/models/zod_type_coercion.ts
+++ b/src/domain/models/zod_type_coercion.ts
@@ -22,11 +22,10 @@ import type { z } from "zod";
 /**
  * Internal Zod definition structure for schema introspection.
  *
- * Extension authors may import Zod v3 (`npm:zod@3`) or Zod v4 (`npm:zod@4`).
- * The two versions name the type field differently (`typeName` in v3,
- * `type` in v4) and store object shape differently (`shape()` function in
- * v3, `shape` value in v4). Both fields are read here so the helpers work
- * regardless of which Zod version the extension imports.
+ * Extensions must use Zod v4 — v3 imports are rejected at bundle time.
+ * The v3 field variants (`typeName`, `shape` as function) are retained
+ * here for backwards compatibility with already-installed extensions
+ * that were bundled before the v3 gate was added.
  */
 interface ZodDef {
   type?: string;

--- a/src/libswamp/types/describe_test.ts
+++ b/src/libswamp/types/describe_test.ts
@@ -211,3 +211,46 @@ Deno.test("typeDescribe: dataOutputSpecs is undefined when type has no specs", a
   >;
   assertEquals(completed.data.dataOutputSpecs, undefined);
 });
+
+Deno.test("typeDescribe: Zod v3 method arguments surface upgrade diagnostic", async () => {
+  const v3ArgsSchema = {
+    _def: {
+      typeName: "ZodObject",
+      shape: () => ({
+        clusterId: { _def: { typeName: "ZodString" } },
+        namespace: { _def: { typeName: "ZodString" } },
+      }),
+    },
+  } as unknown as z.ZodTypeAny;
+
+  const modelDef: ModelDefinition = {
+    type: makeModelType(),
+    version: "1.0.0",
+    methods: {
+      probe: {
+        description: "Probe the cluster",
+        arguments: v3ArgsSchema,
+        execute: () => Promise.resolve({}),
+      },
+    },
+  };
+
+  const deps = makeDeps({
+    resolveModelType: () => Promise.resolve(modelDef),
+  });
+
+  const events = await collect<TypeDescribeEvent>(
+    typeDescribe(createLibSwampContext(), deps, makeModelType()),
+  );
+
+  const completed = events[1] as Extract<
+    TypeDescribeEvent,
+    { kind: "completed" }
+  >;
+  assertEquals(completed.kind, "completed");
+
+  const args = completed.data.methods[0].arguments as Record<string, unknown>;
+  assertEquals(args.$error, "unsupported_zod_version");
+  assertStringIncludes(args.message as string, "Zod v3");
+  assertStringIncludes(args.message as string, "Upgrade to Zod v4");
+});

--- a/src/libswamp/types/schema_helpers.ts
+++ b/src/libswamp/types/schema_helpers.ts
@@ -170,15 +170,36 @@ function manualZodToJsonSchema(schema: z.ZodTypeAny): object {
 
 /**
  * Converts a Zod schema to JSON Schema format.
- * Falls back to a manual converter if Zod's built-in toJSONSchema() fails.
+ * Falls back to a manual converter if Zod's built-in toJSONSchema() fails
+ * on known v4 edge cases (z.record, z.uuid, z.iso.datetime).
+ * Returns a diagnostic object when the schema appears to be from Zod v3.
  */
 export function zodToJsonSchema(schema: z.ZodTypeAny): object {
   try {
     const result = z.toJSONSchema(schema);
     return stripDefaultsFromRequired(result);
   } catch {
+    const v3Diagnostic = detectZodV3Schema(schema);
+    if (v3Diagnostic) return v3Diagnostic;
     return manualZodToJsonSchema(schema);
   }
+}
+
+function detectZodV3Schema(
+  schema: z.ZodTypeAny,
+): object | undefined {
+  const def = schema as unknown as {
+    _def?: { type?: string; typeName?: string };
+  };
+  if (def._def && !def._def.type && def._def.typeName) {
+    return {
+      $error: "unsupported_zod_version",
+      message:
+        `This schema was created with Zod v3. Upgrade to Zod v4 to see ` +
+        `method arguments. See https://zod.dev/v4 for migration guidance.`,
+    };
+  }
+  return undefined;
 }
 
 /**

--- a/src/libswamp/types/schema_helpers_test.ts
+++ b/src/libswamp/types/schema_helpers_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { z } from "zod";
 import {
   buildDataOutputSpecs,
@@ -170,4 +170,24 @@ Deno.test("buildDataOutputSpecs: builds specs from resources and files", () => {
 Deno.test("buildDataOutputSpecs: returns empty array when no specs", () => {
   const result = buildDataOutputSpecs(undefined, undefined);
   assertEquals(result.length, 0);
+});
+
+Deno.test("zodToJsonSchema: returns diagnostic for Zod v3 schema", () => {
+  const fakeV3Schema = {
+    _def: { typeName: "ZodObject" },
+  } as unknown as z.ZodTypeAny;
+
+  const result = zodToJsonSchema(fakeV3Schema) as Record<string, unknown>;
+  assertEquals(result.$error, "unsupported_zod_version");
+  assertStringIncludes(result.message as string, "Zod v3");
+  assertStringIncludes(result.message as string, "Upgrade to Zod v4");
+});
+
+Deno.test("zodToJsonSchema: returns diagnostic for Zod v3 string schema", () => {
+  const fakeV3Schema = {
+    _def: { typeName: "ZodString" },
+  } as unknown as z.ZodTypeAny;
+
+  const result = zodToJsonSchema(fakeV3Schema) as Record<string, unknown>;
+  assertEquals(result.$error, "unsupported_zod_version");
 });

--- a/src/presentation/renderers/model_get.ts
+++ b/src/presentation/renderers/model_get.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { bold, cyan, dim } from "@std/fmt/colors";
+import { bold, cyan, dim, yellow } from "@std/fmt/colors";
 import type {
   EventHandlers,
   MethodDescribeData,
@@ -64,7 +64,12 @@ export function formatSchemaAttributes(
   schema: object,
   indent: string,
 ): string[] {
-  const s = schema as JsonSchemaObject;
+  const s = schema as JsonSchemaObject & { $error?: string; message?: string };
+  if (s.$error) {
+    return [
+      `${indent}${yellow("⚠")} ${dim(s.message ?? "Schema unavailable")}`,
+    ];
+  }
   if (!s.properties) return [];
 
   const required = new Set(s.required ?? []);

--- a/src/presentation/renderers/type_describe.ts
+++ b/src/presentation/renderers/type_describe.ts
@@ -81,7 +81,8 @@ interface JsonSchemaLike {
 }
 
 function compactSchema(schema: object): object {
-  const s = schema as JsonSchemaLike;
+  const s = schema as JsonSchemaLike & { $error?: string };
+  if (s.$error) return schema;
   if (!s.properties) return {};
   const result: Record<string, unknown> = {};
   const props: Record<string, object> = {};


### PR DESCRIPTION
## Summary

- `zodToJsonSchema` now detects Zod v3 schemas and returns a diagnostic object (`$error: "unsupported_zod_version"`) instead of silent `{}`, so `swamp model type describe` tells the extension author to upgrade rather than showing empty arguments
- New `rejectZodV3Imports` in `bundle.ts` catches `zod@3` imports at bundle time for locally-authored extensions, preventing new v3 extensions from being created
- Updated stale `zod@3` reference in publishing skill docs and `zod_type_coercion.ts` comment to reflect v4-only policy

Closes swamp-club#1950

## Test plan

- [x] 2 unit tests: `zodToJsonSchema` returns diagnostic object for v3 schemas
- [x] 1 integration test: `typeDescribe` flow with v3 method schema surfaces diagnostic in output
- [x] 5 bundle tests: `rejectZodV3Imports` catches v3 named/star imports, allows v4 and unversioned
- [x] All 11,016 existing tests pass (no regression)
- [x] Full verification: lint, fmt, type-check, tests, compile, code review, adversarial review, UX review — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Randy Bias <randybias@gmail.com>