### PR TITLE
feat(worker): add --token-file and --server-token-file flags (swamp-club#1862)

### DIFF
--- a/src/cli/commands/worker_connect.ts
+++ b/src/cli/commands/worker_connect.ts
@@ -43,6 +43,29 @@ import "../../domain/models/models.ts";
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
 
+export async function readTokenFile(
+  path: string,
+  flagName: string,
+): Promise<string> {
+  let raw: string;
+  try {
+    raw = await Deno.readTextFile(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      throw new UserError(`${flagName} file not found: ${path}`);
+    }
+    if (err instanceof Deno.errors.PermissionDenied) {
+      throw new UserError(`${flagName} file not readable: ${path}`);
+    }
+    throw err;
+  }
+  const value = raw.replace(/\r?\n$/, "");
+  if (value === "") {
+    throw new UserError(`${flagName} file is empty: ${path}`);
+  }
+  return value;
+}
+
 function parseCommaSeparatedLabels(envValue: string): Record<string, string> {
   const labels: Record<string, string> = {};
   for (const pair of envValue.split(",")) {
@@ -93,6 +116,10 @@ export const workerConnectCommand = new Command()
     "swamp worker connect wss://orch:4000 --token <token> --concurrency auto",
   )
   .example(
+    "Connect with secrets from a Kubernetes Secret mount",
+    "swamp worker connect wss://orch:9090 --token-file /tokens/worker-token --server-token-file /tokens/server-token",
+  )
+  .example(
     "Connect to a token-authenticated orchestrator",
     "swamp worker connect wss://orch:9090 --server-token admin.secret --token worker-pool.enrollment-secret",
   )
@@ -106,8 +133,16 @@ export const workerConnectCommand = new Command()
     "Enrollment token (<name>.<secret>) (env: SWAMP_WORKER_TOKEN)",
   )
   .option(
+    "--token-file <path:string>",
+    "Path to a file containing the enrollment token; mutually exclusive with --token (env: SWAMP_WORKER_TOKEN_FILE)",
+  )
+  .option(
     "--server-token <token:string>",
     "Server access token for authenticating the WebSocket connection (<name>.<secret>) (env: SWAMP_SERVER_TOKEN)",
+  )
+  .option(
+    "--server-token-file <path:string>",
+    "Path to a file containing the server access token; mutually exclusive with --server-token (env: SWAMP_SERVER_TOKEN_FILE)",
   )
   .option(
     "--label <label:string>",
@@ -158,14 +193,35 @@ export const workerConnectCommand = new Command()
       );
     }
 
-    const serverToken = (options.serverToken as string | undefined) ??
+    const serverTokenValue = (options.serverToken as string | undefined) ??
       Deno.env.get("SWAMP_SERVER_TOKEN");
+    const serverTokenFilePath =
+      (options.serverTokenFile as string | undefined) ??
+        Deno.env.get("SWAMP_SERVER_TOKEN_FILE");
+    if (serverTokenValue && serverTokenFilePath) {
+      throw new UserError(
+        "--server-token and --server-token-file are mutually exclusive",
+      );
+    }
+    const serverToken = serverTokenFilePath
+      ? await readTokenFile(serverTokenFilePath, "--server-token-file")
+      : serverTokenValue;
 
-    const token = (options.token as string | undefined) ??
+    const tokenValue = (options.token as string | undefined) ??
       Deno.env.get("SWAMP_WORKER_TOKEN");
+    const tokenFilePath = (options.tokenFile as string | undefined) ??
+      Deno.env.get("SWAMP_WORKER_TOKEN_FILE");
+    if (tokenValue && tokenFilePath) {
+      throw new UserError(
+        "--token and --token-file are mutually exclusive",
+      );
+    }
+    const token = tokenFilePath
+      ? await readTokenFile(tokenFilePath, "--token-file")
+      : tokenValue;
     if (token === undefined) {
       throw new UserError(
-        "Missing enrollment token — pass --token or set SWAMP_WORKER_TOKEN",
+        "Missing enrollment token — pass --token, --token-file, or set SWAMP_WORKER_TOKEN",
       );
     }
 

--- a/src/cli/commands/worker_connect_test.ts
+++ b/src/cli/commands/worker_connect_test.ts
@@ -17,8 +17,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import { readTokenFile } from "./worker_connect.ts";
+import { UserError } from "../../domain/errors.ts";
 
 // Import models barrel to trigger self-registration
 import "../../domain/models/models.ts";
@@ -66,4 +68,87 @@ Deno.test("workerConnectCommand: --server-token option exists", async () => {
   const serverTokenOpt = options.find((o) => o.name === "server-token");
   assertEquals(serverTokenOpt !== undefined, true);
   assertEquals(serverTokenOpt?.required ?? false, false);
+});
+
+Deno.test("workerConnectCommand: --token-file option exists", async () => {
+  const { workerConnectCommand } = await import("./worker_connect.ts");
+  const options = workerConnectCommand.getOptions();
+  const opt = options.find((o) => o.name === "token-file");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("workerConnectCommand: --server-token-file option exists", async () => {
+  const { workerConnectCommand } = await import("./worker_connect.ts");
+  const options = workerConnectCommand.getOptions();
+  const opt = options.find((o) => o.name === "server-token-file");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("readTokenFile: reads token and trims trailing newline", async () => {
+  const tmpFile = await Deno.makeTempFile({ prefix: "swamp-token-test-" });
+  try {
+    await Deno.writeTextFile(tmpFile, "pool.secret-value\n");
+    const result = await readTokenFile(tmpFile, "--token-file");
+    assertEquals(result, "pool.secret-value");
+  } finally {
+    await Deno.remove(tmpFile).catch(() => {});
+  }
+});
+
+Deno.test("readTokenFile: reads token without trailing newline", async () => {
+  const tmpFile = await Deno.makeTempFile({ prefix: "swamp-token-test-" });
+  try {
+    await Deno.writeTextFile(tmpFile, "pool.secret-value");
+    const result = await readTokenFile(tmpFile, "--token-file");
+    assertEquals(result, "pool.secret-value");
+  } finally {
+    await Deno.remove(tmpFile).catch(() => {});
+  }
+});
+
+Deno.test("readTokenFile: throws UserError for missing file", async () => {
+  const err = await assertRejects(
+    () => readTokenFile("/tmp/swamp-nonexistent-token-file", "--token-file"),
+    UserError,
+  );
+  assertStringIncludes(err.message, "--token-file file not found");
+});
+
+Deno.test("readTokenFile: throws UserError for empty file", async () => {
+  const tmpFile = await Deno.makeTempFile({ prefix: "swamp-token-test-" });
+  try {
+    await Deno.writeTextFile(tmpFile, "");
+    const err = await assertRejects(
+      () => readTokenFile(tmpFile, "--token-file"),
+      UserError,
+    );
+    assertStringIncludes(err.message, "--token-file file is empty");
+  } finally {
+    await Deno.remove(tmpFile).catch(() => {});
+  }
+});
+
+Deno.test("readTokenFile: trims trailing CRLF", async () => {
+  const tmpFile = await Deno.makeTempFile({ prefix: "swamp-token-test-" });
+  try {
+    await Deno.writeTextFile(tmpFile, "pool.secret-value\r\n");
+    const result = await readTokenFile(tmpFile, "--token-file");
+    assertEquals(result, "pool.secret-value");
+  } finally {
+    await Deno.remove(tmpFile).catch(() => {});
+  }
+});
+
+Deno.test("readTokenFile: throws UserError for file with only a newline", async () => {
+  const tmpFile = await Deno.makeTempFile({ prefix: "swamp-token-test-" });
+  try {
+    await Deno.writeTextFile(tmpFile, "\n");
+    const err = await assertRejects(
+      () => readTokenFile(tmpFile, "--token-file"),
+      UserError,
+    );
+    assertStringIncludes(err.message, "--token-file file is empty");
+  } finally {
+    await Deno.remove(tmpFile).catch(() => {});
+  }
 });

--- a/src/cli/commands/worker_daemon.ts
+++ b/src/cli/commands/worker_daemon.ts
@@ -22,6 +22,7 @@ import { isAbsolute, resolve } from "@std/path";
 import { createContext, type GlobalOptions } from "../context.ts";
 import { groupCommandAction } from "../group_action.ts";
 import { UserError } from "../../domain/errors.ts";
+import { readTokenFile } from "./worker_connect.ts";
 import { resolveServiceMode } from "../../infrastructure/daemon/service_scheduler_factory.ts";
 import { createWorkerDaemonScheduler } from "../../infrastructure/daemon/worker_daemon_scheduler_factory.ts";
 import {
@@ -87,6 +88,16 @@ export function collectWorkerEnv(options: AnyOptions): Record<string, string> {
     env["SWAMP_SERVER_TOKEN"] = serverToken;
   }
 
+  const serverTokenFile = options.serverTokenFile as string | undefined;
+  if (serverTokenFile) {
+    env["SWAMP_SERVER_TOKEN_FILE"] = serverTokenFile;
+  }
+
+  const tokenFile = options.tokenFile as string | undefined;
+  if (tokenFile) {
+    env["SWAMP_WORKER_TOKEN_FILE"] = tokenFile;
+  }
+
   const labels = options.label as string[] | undefined;
   if (labels && labels.length > 0) {
     env["SWAMP_WORKER_LABELS"] = labels.join(",");
@@ -123,8 +134,16 @@ const daemonEnableCommand = new Command()
     "Enrollment token (<name>.<secret>)",
   )
   .option(
+    "--token-file <path:string>",
+    "Path to a file containing the enrollment token; mutually exclusive with --token",
+  )
+  .option(
     "--server-token <token:string>",
     "Server access token for authenticating the WebSocket connection (<name>.<secret>)",
+  )
+  .option(
+    "--server-token-file <path:string>",
+    "Path to a file containing the server access token; mutually exclusive with --server-token",
   )
   .option(
     "--label <label:string>",
@@ -153,6 +172,10 @@ const daemonEnableCommand = new Command()
     "swamp worker daemon enable wss://orch:9090 --token tok.secret --label tier=ci --cache-dir /var/lib/swamp-worker",
   )
   .example(
+    "Enable with secrets from a Kubernetes Secret mount",
+    "swamp worker daemon enable wss://orch:9090 --token-file /tokens/worker-token --server-token-file /tokens/server-token --label tier=ci",
+  )
+  .example(
     "Enable with a token-authenticated orchestrator",
     "swamp worker daemon enable wss://orch:9090 --token tok.secret --server-token admin.secret --label tier=ci",
   )
@@ -173,10 +196,29 @@ const daemonEnableCommand = new Command()
           "  swamp worker daemon enable wss://orchestrator:9090 --token <token>",
       );
     }
-    if (!options.token) {
+    if (options.token && options.tokenFile) {
       throw new UserError(
-        "Missing enrollment token — pass --token:\n\n" +
+        "--token and --token-file are mutually exclusive",
+      );
+    }
+    if (options.serverToken && options.serverTokenFile) {
+      throw new UserError(
+        "--server-token and --server-token-file are mutually exclusive",
+      );
+    }
+    if (!options.token && !options.tokenFile) {
+      throw new UserError(
+        "Missing enrollment token — pass --token or --token-file:\n\n" +
           "  swamp worker daemon enable wss://orchestrator:9090 --token <name>.<secret>",
+      );
+    }
+    if (options.tokenFile) {
+      await readTokenFile(options.tokenFile as string, "--token-file");
+    }
+    if (options.serverTokenFile) {
+      await readTokenFile(
+        options.serverTokenFile as string,
+        "--server-token-file",
       );
     }
 

--- a/src/cli/commands/worker_daemon_test.ts
+++ b/src/cli/commands/worker_daemon_test.ts
@@ -80,6 +80,26 @@ Deno.test("collectWorkerEnv: returns empty when no options", () => {
   assertEquals(Object.keys(env).length, 0);
 });
 
+Deno.test("collectWorkerEnv: includes SWAMP_WORKER_TOKEN_FILE when provided", () => {
+  const env = collectWorkerEnv({
+    url: "wss://orch:9090",
+    tokenFile: "/tokens/worker-token",
+  });
+  assertEquals(env["SWAMP_WORKER_TOKEN_FILE"], "/tokens/worker-token");
+  assertEquals(env["SWAMP_WORKER_TOKEN"], undefined);
+});
+
+Deno.test("collectWorkerEnv: includes SWAMP_SERVER_TOKEN_FILE when provided", () => {
+  const env = collectWorkerEnv({
+    url: "wss://orch:9090",
+    tokenFile: "/tokens/worker-token",
+    serverTokenFile: "/tokens/server-token",
+  });
+  assertEquals(env["SWAMP_SERVER_TOKEN_FILE"], "/tokens/server-token");
+  assertEquals(env["SWAMP_SERVER_TOKEN"], undefined);
+  assertEquals(env["SWAMP_WORKER_TOKEN_FILE"], "/tokens/worker-token");
+});
+
 Deno.test("validateCacheDir: rejects non-existent absolute path", async () => {
   const err = await assertRejects(
     () => validateCacheDir("/tmp/swamp-nonexistent-dir-abc123"),


### PR DESCRIPTION
## Summary

- Add `--token-file` and `--server-token-file` flags to `swamp worker connect` and `swamp worker daemon enable`, allowing secrets to be read from mounted files (e.g. Kubernetes Secret volumes) instead of passing them on argv or in env vars
- Each flag is mutually exclusive with its inline value counterpart (`--token`/`--server-token`) and has a corresponding env var (`SWAMP_WORKER_TOKEN_FILE`, `SWAMP_SERVER_TOKEN_FILE`)
- Follows the existing `--cert-file`/`--key-file` pattern from `swamp serve`; trims trailing `\r?\n` from file contents (kubectl `--from-file` quirk)

Closes swamp-club#1862

## Test plan

- [x] Unit tests for `readTokenFile` (happy path, missing file, empty file, LF trimming, CRLF trimming)
- [x] Unit tests for mutual exclusivity validation (`--token` + `--token-file`, `--server-token` + `--server-token-file`)
- [x] Unit tests for `collectWorkerEnv` forwarding of `SWAMP_WORKER_TOKEN_FILE` and `SWAMP_SERVER_TOKEN_FILE`
- [x] Manual smoke tests: flag parsing, mutual exclusivity, file errors, connection with file-based tokens
- [x] Verification: build (lint/fmt/type-check/test/compile), 3 agent reviews (code/adversarial/UX), skill review — all pass