### PR TITLE
fix(install): handle auth login timeout gracefully during installation (swamp-club#1742)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -506,7 +506,17 @@ function Main {
         } else {
             Write-Host ""
             $installedBinary = Join-Path $Destination $BinExe
-            & $installedBinary auth login
+            try {
+                & $installedBinary auth login
+                if ($LASTEXITCODE -ne 0) { throw "auth login exited with code $LASTEXITCODE" }
+            } catch {
+                Write-Warn ""
+                Write-Warn "Account setup didn't finish - no worries!"
+                Write-Warn "Run this when you're ready to pick up where you left off:"
+                Write-Warn ""
+                Write-Warn "    swamp auth login"
+                Write-Warn ""
+            }
         }
         Write-Host ""
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -143,7 +143,14 @@ main() {
         ;;
       *)
         echo
-        "$dest/$bin" auth login </dev/tty
+        if ! "$dest/$bin" auth login </dev/tty; then
+          warn ""
+          warn "Account setup didn't finish — no worries!"
+          warn "Run this when you're ready to pick up where you left off:"
+          warn ""
+          warn "    swamp auth login"
+          warn ""
+        fi
         ;;
     esac
     echo

--- a/src/libswamp/auth/login.ts
+++ b/src/libswamp/auth/login.ts
@@ -34,6 +34,8 @@ import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 
 export const CLI_CLIENT_ID = "swamp-cli";
 
+const DEFAULT_MIN_DEVICE_AUTH_EXPIRY_MS = 300_000;
+
 /** Data returned on successful authentication. */
 export interface AuthLoginData {
   username: string;
@@ -64,6 +66,7 @@ export interface AuthLoginInput {
   useBrowserFlow: boolean;
   username?: string;
   password?: string;
+  minDeviceAuthExpiryMs?: number;
 }
 
 /** Device authorization response from swamp-club. */
@@ -359,8 +362,10 @@ export async function* authLogin(
           AbortSignal.timeout(10_000),
         );
 
-        const expiryMs = deviceAuth.expiresIn * 1000;
-        const signal = AbortSignal.timeout(Math.max(expiryMs, 60_000));
+        const minExpiryMs = input.minDeviceAuthExpiryMs ??
+          DEFAULT_MIN_DEVICE_AUTH_EXPIRY_MS;
+        const expiryMs = Math.max(deviceAuth.expiresIn * 1000, minExpiryMs);
+        const signal = AbortSignal.timeout(expiryMs);
 
         yield {
           kind: "device_verification",

--- a/src/libswamp/auth/login_test.ts
+++ b/src/libswamp/auth/login_test.ts
@@ -412,7 +412,10 @@ Deno.test("authLogin: device flow times out when expiresIn elapses", async () =>
       }),
     pollDeviceToken: () => Promise.reject(new DeviceAuthPendingError()),
   });
-  const input = makeInput({ useBrowserFlow: true });
+  const input = makeInput({
+    useBrowserFlow: true,
+    minDeviceAuthExpiryMs: 1,
+  });
 
   const events = await collect<AuthLoginEvent>(
     authLogin(createLibSwampContext(), deps, input),
@@ -423,6 +426,39 @@ Deno.test("authLogin: device flow times out when expiresIn elapses", async () =>
   if (last.kind === "error") {
     assertEquals(last.error.message, "Device authorization timed out");
   }
+});
+
+Deno.test("authLogin: device flow applies minimum expiry floor over short server value", async () => {
+  let pollCount = 0;
+  const deps = makeDeps({
+    startDeviceAuth: () =>
+      Promise.resolve({
+        deviceCode: "device-abc-123",
+        userCode: "ABCD-1234",
+        verificationUri: "https://swamp-club.com/device",
+        expiresIn: 0.001,
+        interval: 0.001,
+      }),
+    pollDeviceToken: () => {
+      pollCount++;
+      if (pollCount >= 3) {
+        return Promise.resolve({ accessToken: "session-token-abc" });
+      }
+      return Promise.reject(new DeviceAuthPendingError());
+    },
+  });
+  const input = makeInput({
+    useBrowserFlow: true,
+    minDeviceAuthExpiryMs: 500,
+  });
+
+  const events = await collect<AuthLoginEvent>(
+    authLogin(createLibSwampContext(), deps, input),
+  );
+
+  const kinds = events.map((e) => e.kind);
+  assertEquals(kinds.includes("completed"), true);
+  assertEquals(pollCount >= 3, true);
 });
 
 Deno.test("authLogin: slow_down increases polling interval", async () => {


### PR DESCRIPTION
## Summary

- Add a 5-minute minimum floor to the device auth polling deadline so new users creating accounts have enough time to complete signup
- Make auth login failure non-fatal in both install scripts (`install.sh` and `install.ps1`) — on timeout, encourage the user to finish connecting via `swamp auth login` instead of showing misleading partial-installation cleanup instructions
- Add injectable `minDeviceAuthExpiryMs` field to `AuthLoginInput` for test control of the floor

Fixes swamp-club#1742

## Test plan

- [x] Existing timeout test updated to use injectable floor — passes in 2ms
- [x] New test verifies floor lets polling succeed over short server `expiresIn`
- [x] All 14 auth login tests pass
- [x] Full verification workflow: lint, fmt, type-check, vuln-scan, tests, compile, code review (pass), adversarial review (pass), UX review (pass), skill review (pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>