### PR TITLE
feat(expressions): CEL-evaluate dynamic vault.get() arguments

### DIFF
--- a/.claude/skills/swamp/references/model/reference.md
+++ b/.claude/skills/swamp/references/model/reference.md
@@ -108,7 +108,8 @@ swamp model create aws/ec2/vpc my-vpc \
 ```
 
 Use `${{ vault.get() }}` expressions for secrets — never resolve a secret and
-pass the literal value (see **swamp-vault** skill for details):
+pass the literal value (see **swamp-vault** skill for details). Arguments can be
+literal or CEL expressions (bare tokens with `.` are CEL-evaluated):
 
 ```bash
 swamp model create @user/my-api api-client \

--- a/.claude/skills/swamp/references/model/references/examples.md
+++ b/.claude/skills/swamp/references/model/references/examples.md
@@ -26,7 +26,8 @@
 | `self.globalArguments.<field>`                               | This model's own global argument          | CIDR block, region, etc.      |
 | `inputs.<name>`                                              | Runtime input value                       | `production`, `true`, etc.    |
 | `env.<VAR_NAME>`                                             | Environment variable                      | AWS region, credentials       |
-| `vault.get("<vault>", "<key>")`                              | Vault secret                              | API key, password             |
+| `vault.get("<vault>", "<key>")`                              | Vault secret (literal args)               | API key, password             |
+| `vault.get(inputs.vault, inputs.key)`                        | Vault secret (dynamic CEL args)           | Per-target secret             |
 
 ### CEL Path Patterns by Model Type
 

--- a/.claude/skills/swamp/references/workflow/reference.md
+++ b/.claude/skills/swamp/references/workflow/reference.md
@@ -1040,6 +1040,16 @@ apiKey: ${{ vault.get(vault-name, secret-key) }}
 dbPassword: ${{ vault.get(prod-secrets, DB_PASSWORD) }}
 ```
 
+Arguments can also be CEL expressions — bare tokens containing `.` are
+CEL-evaluated before the vault lookup:
+
+```yaml
+# Per-target secret from workflow inputs:
+apiKey: ${{ vault.get(inputs.vaultName, inputs.secretKey) }}
+# Mixed: literal vault, dynamic key:
+password: ${{ vault.get('prod-vault', inputs.passwordKey) }}
+```
+
 Vault expressions are resolved **per-step at execution time** — a step that
 writes to a vault makes the new value available to subsequent steps. Example
 token-refresh-then-use pattern:

--- a/design/enablers/expressions.md
+++ b/design/enablers/expressions.md
@@ -494,6 +494,45 @@ globalArguments:
   keyData: ${{ vault.get('aws', 'machineKeyData') }}
 ```
 
+### Dynamic Vault Arguments
+
+vault.get() arguments can be CEL expressions when passed as bare tokens (without
+quotes). Bare-token arguments containing a `.` (member access) are CEL-evaluated
+against the expression context before the vault lookup:
+
+```yaml
+# Resolve vault name and key from workflow inputs:
+globalArguments:
+  apiKey: ${{ vault.get(inputs.vaultName, inputs.secretKey) }}
+```
+
+```yaml
+# Mixed: literal vault name, dynamic key from inputs:
+globalArguments:
+  password: ${{ vault.get('prod-vault', inputs.passwordKey) }}
+```
+
+Quoted arguments are always used verbatim. Bare tokens without a `.` (e.g.
+`my-vault`) are also used verbatim for backwards compatibility — they cannot be
+confused with CEL expressions.
+
+If a dynamic argument references an input that is missing or evaluates to a
+non-string value, the vault lookup fails with a clear error at runtime — it does
+not silently use the expression text as a literal key.
+
+**Security note:** In local execution, dynamic vault.get() arguments allow
+workflow inputs to select any registered vault and key. This is acceptable
+because the local user already has filesystem access to vault configurations. In
+remote execution (serve dispatch), the `hasDynamicRefs` flag on the
+`VaultExtractionResult` bypasses the per-dispatch secret allowlist, and
+`DENIED_VAULT_NAMES` / `DENIED_SECRET_KEY_PREFIXES` still block infrastructure
+secrets.
+
+**Known limitation:** `vault.get(self.item.vaultName, self.item.key)` inside a
+`forEach` step cannot resolve because the forEach iteration context is not
+available during runtime vault resolution. Use workflow inputs or an extension
+method for per-target secrets in forEach steps.
+
 ### Shell Safety
 
 When vault secrets are used in the `run` field of a `command/shell` model, the

--- a/design/primitives/vaults.md
+++ b/design/primitives/vaults.md
@@ -291,6 +291,12 @@ before CEL evaluation (`resolveVaultExpressions` in
 when no secret bag is present). There is no `vault.put` expression — writes go
 through `swamp vault put` or sensitive-field marking (below).
 
+Arguments can be quoted literals or bare-token CEL expressions. Bare tokens
+containing `.` (e.g. `inputs.vaultName`) are CEL-evaluated against the runtime
+context before the vault lookup. See
+[expressions.md § Dynamic Vault Arguments](../enablers/expressions.md#dynamic-vault-arguments)
+for details, security notes, and known limitations.
+
 ## CLI Surface
 
 Vault commands live in `src/cli/commands/vault_*.ts`. Beyond `create`, `put`,

--- a/src/domain/expressions/expression_evaluation_service.ts
+++ b/src/domain/expressions/expression_evaluation_service.ts
@@ -38,6 +38,7 @@ import {
   type ExpressionContext,
   ModelResolver,
   type ModelResolverRepositories,
+  type VaultArgCelOptions,
 } from "./model_resolver.ts";
 import { CyclicDependencyError } from "./errors.ts";
 import type { SecretRedactor } from "../secrets/mod.ts";
@@ -429,11 +430,13 @@ export class ExpressionEvaluationService {
    *
    * @param definition - The definition (may contain remaining ${{ vault.get(...) }} or ${{ env.* }} expressions)
    * @param redactor - Optional SecretRedactor to register resolved secret values for redaction
+   * @param expressionContext - Optional context for CEL-evaluating dynamic vault.get() arguments
    * @returns The definition with sentinels and the VaultSecretBag for resolving them
    */
   async resolveRuntimeExpressionsInDefinition(
     definition: Definition,
     redactor?: SecretRedactor,
+    expressionContext?: ExpressionContext,
   ): Promise<RuntimeResolutionResult> {
     const logger = getLogger(["swamp", "expressions"]);
     const secretBag = new VaultSecretBag();
@@ -461,6 +464,7 @@ export class ExpressionEvaluationService {
       runtimeExpressions,
       redactor,
       secretBag,
+      expressionContext,
     );
 
     return { definition: resolvedDefinition, secretBag };
@@ -475,11 +479,13 @@ export class ExpressionEvaluationService {
    *
    * @param data - The data (may contain remaining runtime expressions)
    * @param redactor - Optional SecretRedactor to register resolved secret values for redaction
+   * @param expressionContext - Optional context for CEL-evaluating dynamic vault.get() arguments
    * @returns The data with all runtime expressions resolved (sentinels replaced with raw values)
    */
   async resolveRuntimeExpressionsInData(
     data: unknown,
     redactor?: SecretRedactor,
+    expressionContext?: ExpressionContext,
   ): Promise<unknown> {
     const expressions = extractExpressions(data);
     const runtimeExpressions = expressions.filter((expr) =>
@@ -489,6 +495,10 @@ export class ExpressionEvaluationService {
     if (runtimeExpressions.length === 0) {
       return data;
     }
+
+    const celOptions: VaultArgCelOptions | undefined = expressionContext
+      ? { celEvaluator: this.celEvaluator, context: expressionContext }
+      : undefined;
 
     const secretBag = new VaultSecretBag();
     const evaluatedValues = new Map<string, unknown>();
@@ -501,6 +511,7 @@ export class ExpressionEvaluationService {
           expr.celExpression,
           redactor,
           secretBag,
+          celOptions,
         );
       }
 
@@ -515,10 +526,15 @@ export class ExpressionEvaluationService {
         continue;
       }
 
-      const value = this.celEvaluator.evaluate(resolvedCelExpr, {
+      const celContext: Record<string, unknown> = {
         model: {},
         env: buildEnvContext(),
-      });
+      };
+      if (expressionContext?.inputs) {
+        celContext.inputs = expressionContext.inputs;
+      }
+
+      const value = this.celEvaluator.evaluate(resolvedCelExpr, celContext);
       evaluatedValues.set(expr.raw, value);
     }
 
@@ -540,7 +556,8 @@ export class ExpressionEvaluationService {
    *      inputs.*, model.*, data.*, etc. against the supplied context.
    *   2. {@link resolveRuntimeExpressionsInData} — env and vault. Vault
    *      values are resolved to raw strings and registered with the
-   *      optional redactor for log scrubbing.
+   *      optional redactor for log scrubbing. The expression context is
+   *      forwarded so dynamic vault.get() arguments can be CEL-evaluated.
    *
    * Used at execution-time seams that consume workflow-level data where
    * CEL must materialize before runtime resolution walks the now-CEL-
@@ -552,7 +569,11 @@ export class ExpressionEvaluationService {
     redactor?: SecretRedactor,
   ): Promise<unknown> {
     const afterCel = await this.evaluateData(data, context);
-    return await this.resolveRuntimeExpressionsInData(afterCel, redactor);
+    return await this.resolveRuntimeExpressionsInData(
+      afterCel,
+      redactor,
+      context,
+    );
   }
 
   /**
@@ -589,16 +610,23 @@ export class ExpressionEvaluationService {
     runtimeExpressions: ExpressionLocation[],
     redactor?: SecretRedactor,
     secretBag?: VaultSecretBag,
+    expressionContext?: ExpressionContext,
   ): Promise<Definition> {
     const logger = getLogger(["swamp", "expressions"]);
     const evaluatedValues = new Map<string, unknown>();
+
+    const celOptions: VaultArgCelOptions | undefined = expressionContext
+      ? { celEvaluator: this.celEvaluator, context: expressionContext }
+      : undefined;
+
     for (const expr of runtimeExpressions) {
       // Resolve vault references first (if any) — vault.get() arguments
       // may contain characters that are not valid CEL identifiers (e.g.
       // hyphens in vault names like "dwh-infra-1password"), so vault
       // resolution must happen BEFORE CEL validation. resolveVaultExpressions
       // replaces vault.get(...) calls with sentinel string literals that
-      // are always valid CEL.
+      // are always valid CEL. When celOptions is provided, bare-token
+      // arguments are CEL-evaluated before the vault lookup.
       let resolvedCelExpr = expr.celExpression;
       if (containsVaultExpression(expr.celExpression)) {
         logger.debug`Resolving vault expression at ${expr.path}`;
@@ -606,6 +634,7 @@ export class ExpressionEvaluationService {
           expr.celExpression,
           redactor,
           secretBag,
+          celOptions,
         );
         logger.debug`Resolved vault expression at ${expr.path}`;
       }
@@ -629,10 +658,15 @@ export class ExpressionEvaluationService {
         continue;
       }
 
-      const value = this.celEvaluator.evaluate(resolvedCelExpr, {
+      const celContext: Record<string, unknown> = {
         model: {},
         env: buildEnvContext(),
-      });
+      };
+      if (expressionContext?.inputs) {
+        celContext.inputs = expressionContext.inputs;
+      }
+
+      const value = this.celEvaluator.evaluate(resolvedCelExpr, celContext);
       evaluatedValues.set(expr.raw, value);
     }
 

--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -41,6 +41,26 @@ import type { SecretRedactor } from "../secrets/mod.ts";
 import type { VaultSecretBag } from "../vaults/vault_secret_bag.ts";
 
 /**
+ * Minimal CEL evaluator interface for resolving dynamic vault.get()
+ * arguments. Defined in the domain layer so ModelResolver does not
+ * depend on the infrastructure CelEvaluator directly.
+ */
+export interface CelArgEvaluator {
+  evaluate(expression: string, context: Record<string, unknown>): unknown;
+}
+
+/**
+ * Options for CEL-evaluating bare-token vault.get() arguments at runtime.
+ * When provided, unquoted arguments that are syntactically valid CEL
+ * (e.g. `inputs.vaultName`) are evaluated against the context before the
+ * vault lookup. Quoted arguments are always used verbatim.
+ */
+export interface VaultArgCelOptions {
+  celEvaluator: CelArgEvaluator;
+  context: ExpressionContext;
+}
+
+/**
  * Builds env context from Deno environment variables.
  *
  * Returns the **entire** process environment as a flat string map. Values are
@@ -1119,15 +1139,25 @@ export class ModelResolver {
    * allowing callers to resolve sentinels later — either to raw values
    * (non-shell contexts) or to environment variable references (shell commands).
    *
+   * When `celOptions` is provided, unquoted (bare-token) arguments are
+   * CEL-evaluated against the supplied context before the vault lookup.
+   * This enables `vault.get(inputs.vaultName, inputs.secretKey)` where the
+   * argument values are determined at runtime. Quoted arguments are always
+   * used verbatim. If a bare token is not syntactically valid CEL (e.g.
+   * `my-vault` containing a hyphen), it is used verbatim for backwards
+   * compatibility.
+   *
    * @param value - The string that may contain vault expressions
    * @param redactor - Optional SecretRedactor to register resolved secret values for redaction
    * @param secretBag - VaultSecretBag to store sentinel-to-value mappings
+   * @param celOptions - Optional CEL evaluator and context for resolving dynamic arguments
    * @returns The string with vault.get() calls replaced by sentinel tokens wrapped as CEL strings
    */
   async resolveVaultExpressions(
     value: string,
     redactor?: SecretRedactor,
     secretBag?: VaultSecretBag,
+    celOptions?: VaultArgCelOptions,
   ): Promise<string> {
     // Pattern to match vault.get(vaultName, secretKey) expressions.
     // Handles both quoted and unquoted arguments. Quoted arguments may
@@ -1152,8 +1182,26 @@ export class ModelResolver {
       // Groups: [1]=quote1, [2]=quoted vault, [3]=unquoted vault,
       //         [4]=quote2, [5]=quoted key,   [6]=unquoted key
       const fullMatch = match[0];
-      const vaultName = match[2] ?? match[3];
-      const secretKey = match[5] ?? match[6];
+      const rawVaultName = match[2] ?? match[3];
+      const rawSecretKey = match[5] ?? match[6];
+      const vaultNameIsQuoted = match[2] !== undefined;
+      const secretKeyIsQuoted = match[5] !== undefined;
+
+      const vaultName = this.resolveVaultArg(
+        rawVaultName,
+        vaultNameIsQuoted,
+        "vault name",
+        fullMatch,
+        celOptions,
+      );
+      const secretKey = this.resolveVaultArg(
+        rawSecretKey,
+        secretKeyIsQuoted,
+        "secret key",
+        fullMatch,
+        celOptions,
+      );
+
       try {
         const secretValue = await vaultService.get(
           vaultName,
@@ -1193,5 +1241,51 @@ export class ModelResolver {
     }
 
     return resolvedValue;
+  }
+
+  /**
+   * Resolves a single vault.get() argument. Quoted arguments are always
+   * returned verbatim. Bare-token arguments are CEL-evaluated when
+   * `celOptions` is provided and the token looks like a CEL member
+   * access (contains `.`, e.g. `inputs.vaultName`). Simple bare tokens
+   * without `.` (e.g. `my-vault`) are used verbatim for backwards
+   * compatibility.
+   */
+  private resolveVaultArg(
+    raw: string,
+    isQuoted: boolean,
+    argLabel: string,
+    fullMatch: string,
+    celOptions?: VaultArgCelOptions,
+  ): string {
+    if (isQuoted || !celOptions) {
+      return raw;
+    }
+
+    // A bare token containing a dot is clearly intended as a CEL member
+    // access expression (inputs.x, self.item.vault, etc.). Tokens
+    // without a dot are likely literal names (my-vault, myvault) — use
+    // verbatim for backwards compatibility.
+    if (!raw.includes(".")) {
+      return raw;
+    }
+
+    const { celEvaluator, context } = celOptions;
+
+    try {
+      const result = celEvaluator.evaluate(raw, context);
+      if (typeof result !== "string") {
+        throw new Error(
+          `vault.get() ${argLabel} must resolve to a string, ` +
+            `got ${typeof result}: ${JSON.stringify(result)}`,
+        );
+      }
+      return result;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Failed to resolve dynamic ${argLabel} in ${fullMatch}: ${msg}`,
+      );
+    }
   }
 }

--- a/src/domain/expressions/model_resolver_test.ts
+++ b/src/domain/expressions/model_resolver_test.ts
@@ -20,7 +20,15 @@
 import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
-import { ModelResolver } from "./model_resolver.ts";
+import {
+  type CelArgEvaluator,
+  type ExpressionContext,
+  ModelResolver,
+} from "./model_resolver.ts";
+import type { VaultService } from "../vaults/vault_service.ts";
+import { MockVaultProvider } from "../vaults/mock_vault_provider.ts";
+import { VaultSecretBag } from "../vaults/vault_secret_bag.ts";
+import { CelEvaluator } from "../../infrastructure/cel/cel_evaluator.ts";
 import { Definition } from "../definitions/definition.ts";
 import { Data } from "../data/data.ts";
 import { ModelType } from "../models/model_type.ts";
@@ -1770,4 +1778,170 @@ Deno.test("data.latest() with exact data name skips specName ambiguity check (sw
     assertEquals(result.attributes.ipv4, "10.0.0.1");
     catalog.close();
   });
+});
+
+// ============================================================================
+// resolveVaultExpressions — dynamic CEL argument resolution
+// ============================================================================
+
+function createVaultResolver(
+  secrets: Record<string, Record<string, string>>,
+): ModelResolver {
+  // Build a stub VaultService whose get() delegates to MockVaultProviders.
+  // We can't use the real VaultService.registerVault() because it calls
+  // createVaultProvider() which requires a registered vault type. Instead
+  // we create a minimal duck-typed service that satisfies the ModelResolver.
+  const providers = new Map<string, MockVaultProvider>();
+  for (const [vaultName, vaultSecrets] of Object.entries(secrets)) {
+    providers.set(vaultName, new MockVaultProvider(vaultName, vaultSecrets));
+  }
+  const vaultService = {
+    async get(
+      vaultName: string,
+      secretKey: string,
+    ): Promise<string> {
+      const provider = providers.get(vaultName);
+      if (!provider) {
+        throw new Error(`Vault '${vaultName}' not found in test setup`);
+      }
+      return await provider.get(secretKey);
+    },
+  } as unknown as VaultService;
+
+  const defRepo = {
+    findAllGlobal: () => Promise.resolve([]),
+  } as unknown as YamlDefinitionRepository;
+  return new ModelResolver(defRepo, { vaultService });
+}
+
+function makeCelOptions(
+  inputs: Record<string, unknown>,
+): { celEvaluator: CelArgEvaluator; context: ExpressionContext } {
+  return {
+    celEvaluator: new CelEvaluator(),
+    context: {
+      model: {},
+      env: {},
+      inputs,
+    },
+  };
+}
+
+Deno.test("resolveVaultExpressions: quoted args used verbatim (existing behaviour)", async () => {
+  const resolver = createVaultResolver({
+    "my-vault": { "api-key": "secret-123" },
+  });
+  const secretBag = new VaultSecretBag();
+  const result = await resolver.resolveVaultExpressions(
+    `vault.get('my-vault', 'api-key')`,
+    undefined,
+    secretBag,
+  );
+  assertEquals(result.startsWith('"__SWAMP_VSEC_'), true);
+  assertEquals(secretBag.resolveRaw(result.slice(1, -1)), "secret-123");
+});
+
+Deno.test("resolveVaultExpressions: bare-token args CEL-evaluated from inputs", async () => {
+  const resolver = createVaultResolver({
+    "prod-vault": { "db-password": "prod-pass-42" },
+  });
+  const secretBag = new VaultSecretBag();
+  const celOptions = makeCelOptions({
+    vaultName: "prod-vault",
+    secretKey: "db-password",
+  });
+  const result = await resolver.resolveVaultExpressions(
+    `vault.get(inputs.vaultName, inputs.secretKey)`,
+    undefined,
+    secretBag,
+    celOptions,
+  );
+  assertEquals(result.startsWith('"__SWAMP_VSEC_'), true);
+  assertEquals(secretBag.resolveRaw(result.slice(1, -1)), "prod-pass-42");
+});
+
+Deno.test("resolveVaultExpressions: mixed literal/dynamic args", async () => {
+  const resolver = createVaultResolver({
+    "infra": { "prod-key": "infra-secret" },
+  });
+  const secretBag = new VaultSecretBag();
+  const celOptions = makeCelOptions({ secretKey: "prod-key" });
+  const result = await resolver.resolveVaultExpressions(
+    `vault.get('infra', inputs.secretKey)`,
+    undefined,
+    secretBag,
+    celOptions,
+  );
+  assertEquals(result.startsWith('"__SWAMP_VSEC_'), true);
+  assertEquals(secretBag.resolveRaw(result.slice(1, -1)), "infra-secret");
+});
+
+Deno.test("resolveVaultExpressions: bare-token fallback for non-CEL tokens", async () => {
+  const resolver = createVaultResolver({
+    "my-vault": { "my-key": "fallback-secret" },
+  });
+  const secretBag = new VaultSecretBag();
+  const celOptions = makeCelOptions({});
+  // "my-vault" contains a hyphen — not valid CEL — should fall back to verbatim
+  const result = await resolver.resolveVaultExpressions(
+    `vault.get(my-vault, my-key)`,
+    undefined,
+    secretBag,
+    celOptions,
+  );
+  assertEquals(result.startsWith('"__SWAMP_VSEC_'), true);
+  assertEquals(secretBag.resolveRaw(result.slice(1, -1)), "fallback-secret");
+});
+
+Deno.test("resolveVaultExpressions: hard error for valid CEL with missing input", async () => {
+  const resolver = createVaultResolver({
+    "any-vault": { "any-key": "value" },
+  });
+  const secretBag = new VaultSecretBag();
+  const celOptions = makeCelOptions({});
+  await assertRejects(
+    () =>
+      resolver.resolveVaultExpressions(
+        `vault.get(inputs.missingVault, 'key')`,
+        undefined,
+        secretBag,
+        celOptions,
+      ),
+    Error,
+    "Failed to resolve dynamic vault name",
+  );
+});
+
+Deno.test("resolveVaultExpressions: non-string CEL result throws", async () => {
+  const resolver = createVaultResolver({
+    "any-vault": { "any-key": "value" },
+  });
+  const secretBag = new VaultSecretBag();
+  const celOptions = makeCelOptions({ vaultNum: 42 });
+  await assertRejects(
+    () =>
+      resolver.resolveVaultExpressions(
+        `vault.get(inputs.vaultNum, 'key')`,
+        undefined,
+        secretBag,
+        celOptions,
+      ),
+    Error,
+    "must resolve to a string",
+  );
+});
+
+Deno.test("resolveVaultExpressions: without celOptions bare tokens used verbatim", async () => {
+  const resolver = createVaultResolver({
+    "my-vault": { "my-key": "plain-secret" },
+  });
+  const secretBag = new VaultSecretBag();
+  // No celOptions — bare tokens should be used verbatim (backwards compat)
+  const result = await resolver.resolveVaultExpressions(
+    `vault.get(my-vault, my-key)`,
+    undefined,
+    secretBag,
+  );
+  assertEquals(result.startsWith('"__SWAMP_VSEC_'), true);
+  assertEquals(secretBag.resolveRaw(result.slice(1, -1)), "plain-secret");
 });

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -832,10 +832,13 @@ export class DefaultStepExecutor implements StepExecutor {
 
     // Resolve runtime expressions (vault and env) at runtime (never persisted).
     // Vault secrets become sentinel tokens; the secretBag maps sentinels to raw values.
+    // The expression context is passed so that dynamic vault.get() arguments
+    // (e.g. vault.get(inputs.vaultName, inputs.secretKey)) can be CEL-evaluated.
     const runtimeResult = await expressionEvaluator
       .resolveRuntimeExpressionsInDefinition(
         evaluatedDefinition,
         ctx.secretRedactor,
+        ctx.expressionContext,
       );
     evaluatedDefinition = runtimeResult.definition;
     const secretBag = runtimeResult.secretBag;

--- a/src/libswamp/models/run.ts
+++ b/src/libswamp/models/run.ts
@@ -45,6 +45,10 @@ import type { UnifiedDataRepository } from "../../domain/data/repositories.ts";
 import type { OutputRepository } from "../../domain/models/repositories.ts";
 import type { VaultService } from "../../domain/vaults/vault_service.ts";
 import type { ExpressionEvaluationService } from "../../domain/expressions/expression_evaluation_service.ts";
+import {
+  buildEnvContext,
+  type ExpressionContext,
+} from "../../domain/expressions/model_resolver.ts";
 import type { SecretRedactor } from "../../domain/secrets/mod.ts";
 import type { DataQueryService } from "../../domain/data/data_query_service.ts";
 import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
@@ -594,13 +598,21 @@ export async function* modelMethodRun(
 
           // Resolve runtime expressions (vault and env).
           // Vault secrets become sentinel tokens; the secretBag maps sentinels to raw values.
+          // The expression context is passed so that dynamic vault.get() arguments
+          // (e.g. vault.get(inputs.vaultName, inputs.secretKey)) can be CEL-evaluated.
           const runtimeSpan = getTracer().startSpan(
             "swamp.model.method.resolve_runtime",
           );
+          const runtimeContext: ExpressionContext = {
+            model: {},
+            inputs,
+            env: buildEnvContext(),
+          };
           const runtimeResult = await evaluationService
             .resolveRuntimeExpressionsInDefinition(
               evaluatedDefinition,
               redactor,
+              runtimeContext,
             );
           evaluatedDefinition = runtimeResult.definition;
           const secretBag = runtimeResult.secretBag;


### PR DESCRIPTION
## Summary

- CEL-evaluate bare-token `vault.get()` arguments so per-target secrets can be expressed in workflow YAML — `vault.get(inputs.vaultName, inputs.secretKey)` now resolves the expressions before lookup
- Bare tokens containing `.` (member access) are CEL-evaluated; quoted arguments and simple bare tokens without dots remain verbatim for backwards compatibility
- Missing or non-string inputs produce clear errors instead of silently looking up literal key names

Closes swamp-club#1786

## Changes

- `src/domain/expressions/model_resolver.ts` — added `CelArgEvaluator` domain interface and `resolveVaultArg()` helper; `resolveVaultExpressions()` accepts optional `VaultArgCelOptions`
- `src/domain/expressions/expression_evaluation_service.ts` — threaded `ExpressionContext` through runtime resolution methods; enriched post-vault CEL context with `inputs`
- `src/domain/workflows/execution_service.ts` — passes expression context to vault resolution in workflow step execution
- `src/libswamp/models/run.ts` — passes inputs context to vault resolution in direct model run
- `design/enablers/expressions.md`, `design/primitives/vaults.md` — documented dynamic vault arguments, security notes, and forEach limitation
- `.claude/skills/swamp/references/` — added dynamic vault.get() examples to workflow and model skill references

## Test plan

- [x] 7 unit tests for `resolveVaultExpressions()`: dynamic args, mixed args, bare-token fallback, missing input error, non-string error, backwards compat
- [x] 29 existing expression evaluation service tests pass
- [x] 13 existing vault reference extractor tests pass
- [x] Manual E2E: compiled binary, created scratch repo with vault, verified `vault.get(inputs.vaultName, inputs.secretKey)` resolves correct secret values with different inputs
- [x] Verification: build (9/9), reviews (code + adversarial + ux), skills — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Randy Bias <randybias@gmail.com>