### PR TITLE
fix(datastore): suppress misleading lock contention warning for namespaced repos

### DIFF
--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -1246,7 +1246,10 @@ export async function acquireModelLocks(
     // separate entries — prevents the second registration from
     // overwriting the first (which would orphan the first lock).
     const coordinatorKey = `${lockFileKey}#${crypto.randomUUID().slice(0, 8)}`;
-    await registerDatastoreSyncNamed(coordinatorKey, { lock });
+    await registerDatastoreSyncNamed(coordinatorKey, {
+      lock,
+      namespace: config.namespace,
+    });
     lockKeys.push(coordinatorKey);
 
     // Re-check global lock after acquiring each per-model lock to close TOCTOU race.
@@ -1451,9 +1454,9 @@ export async function flushSinglePhasePush(
     if (lockMs > 5_000 && !config.namespace) {
       write(
         yellow(
-          `Lock acquisition took ${lockMs}ms — multiple repos sharing this ` +
-            "datastore without namespaces serialize all writes behind a " +
-            "single global lock. Run 'swamp datastore namespace set " +
+          `Lock acquisition took ${lockMs}ms — if multiple repos share ` +
+            "this datastore without namespaces, all writes serialize " +
+            "behind a single lock. Run 'swamp datastore namespace set " +
             "<name>' to scope each repo to its own lock and index",
         ),
       );
@@ -1570,9 +1573,9 @@ export async function flushTwoPhasePush(
     if (lockMs > 5_000 && !config.namespace) {
       write(
         yellow(
-          `Lock acquisition took ${lockMs}ms — multiple repos sharing this ` +
-            "datastore without namespaces serialize all writes behind a " +
-            "single global lock. Run 'swamp datastore namespace set " +
+          `Lock acquisition took ${lockMs}ms — if multiple repos share ` +
+            "this datastore without namespaces, all writes serialize " +
+            "behind a single lock. Run 'swamp datastore namespace set " +
             "<name>' to scope each repo to its own lock and index",
         ),
       );

--- a/src/infrastructure/persistence/datastore_sync_coordinator.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator.ts
@@ -313,10 +313,10 @@ export async function registerDatastoreSyncNamed(
       const lockMs = Date.now() - lockStart;
       if (lockMs > 5_000 && !namespace) {
         logger.warn(
-          "Lock acquisition took {ms}ms — multiple repos sharing this " +
-            "datastore without namespaces serialize all writes behind a " +
-            "single global lock. Run 'swamp datastore namespace set " +
-            "<name>' to scope each repo to its own lock and index",
+          "Lock acquisition took {ms}ms — if multiple repos share this " +
+            "datastore without namespaces, all writes serialize behind a " +
+            "single lock. Run 'swamp datastore namespace set <name>' to " +
+            "scope each repo to its own lock and index",
           { ms: lockMs },
         );
       }

--- a/src/infrastructure/persistence/datastore_sync_coordinator_test.ts
+++ b/src/infrastructure/persistence/datastore_sync_coordinator_test.ts
@@ -18,6 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { configure, type LogRecord } from "@logtape/logtape";
 import { initializeLogging } from "../logging/logger.ts";
 import {
   flushDatastoreSync,
@@ -612,6 +613,110 @@ Deno.test("registerDatastoreSyncNamed: no namespace means pull/push omit it", as
   await flushDatastoreSyncNamed("no-ns");
 
   assertEquals(pushOptions?.namespace, undefined);
+});
+
+// --- Slow-lock warning namespace guard (#1981) ---
+
+Deno.test("registerDatastoreSyncNamed: slow lock with namespace suppresses contention warning", async () => {
+  const captured: LogRecord[] = [];
+  await configure({
+    sinks: {
+      capture: (record: LogRecord) => {
+        captured.push(record);
+      },
+    },
+    loggers: [
+      {
+        category: ["datastore", "lock"],
+        lowestLevel: "warning",
+        sinks: ["capture"],
+      },
+    ],
+    reset: true,
+  });
+
+  const originalNow = Date.now;
+  let lockAcquired = false;
+  const baseTime = originalNow.call(Date);
+  Date.now = () => lockAcquired ? baseTime + 6_000 : baseTime;
+
+  try {
+    const lock = new FakeLock();
+    const origAcquire = lock.acquire.bind(lock);
+    lock.acquire = async () => {
+      await origAcquire();
+      lockAcquired = true;
+    };
+    captured.length = 0;
+
+    await registerDatastoreSyncNamed("ns-warn-suppressed", {
+      lock,
+      namespace: "my-namespace",
+    });
+
+    const warnings = captured.filter((r) => r.level === "warning");
+    assertEquals(
+      warnings.length,
+      0,
+      "No contention warning should fire when namespace is set",
+    );
+
+    await flushDatastoreSyncNamed("ns-warn-suppressed");
+  } finally {
+    Date.now = originalNow;
+    await initializeLogging({ _reset: true });
+  }
+});
+
+Deno.test("registerDatastoreSyncNamed: slow lock without namespace emits contention warning", async () => {
+  const captured: LogRecord[] = [];
+  await configure({
+    sinks: {
+      capture: (record: LogRecord) => {
+        captured.push(record);
+      },
+    },
+    loggers: [
+      {
+        category: ["datastore", "lock"],
+        lowestLevel: "warning",
+        sinks: ["capture"],
+      },
+    ],
+    reset: true,
+  });
+
+  const originalNow = Date.now;
+  let lockAcquired = false;
+  const baseTime = originalNow.call(Date);
+  Date.now = () => lockAcquired ? baseTime + 6_000 : baseTime;
+
+  try {
+    const lock = new FakeLock();
+    const origAcquire = lock.acquire.bind(lock);
+    lock.acquire = async () => {
+      await origAcquire();
+      lockAcquired = true;
+    };
+    captured.length = 0;
+
+    await registerDatastoreSyncNamed("no-ns-warn", { lock });
+
+    const warnings = captured.filter((r) => r.level === "warning");
+    assertEquals(
+      warnings.length,
+      1,
+      "Contention warning should fire when namespace is not set and lock is slow",
+    );
+    const msg = warnings[0].message.map((p) => String(p)).join("");
+    assertStringIncludes(msg, "Lock acquisition took");
+    assertStringIncludes(msg, "namespace set");
+
+    await flushDatastoreSyncNamed("no-ns-warn");
+  } finally {
+    Date.now = originalNow;
+    await initializeLogging({ _reset: true });
+  }
 });
 
 // --- Stream-0 regression net: SIGINT releases locks within 5s deadline ---


### PR DESCRIPTION
## Summary

- **Pass namespace to `registerDatastoreSyncNamed` in `acquireModelLocks`** so the `!namespace` guard correctly suppresses the contention warning for namespaced repos. Previously the per-model lock registration omitted namespace, causing the warning to fire regardless of namespace configuration.
- **Reword warning text** from asserting "multiple repos sharing this datastore" to the conditional "if multiple repos share this datastore" — the slow lock acquire could be caused by S3 latency or sole-writer stale locks, not just cross-repo contention.

## Test plan

- [x] Two new unit tests in `datastore_sync_coordinator_test.ts`:
  - Slow lock with namespace set → no warning emitted
  - Slow lock without namespace → warning emitted with correct text
- [x] All 26 coordinator tests pass
- [x] All 61 repo_context tests pass
- [x] `deno check`, `deno lint`, `deno fmt` clean
- [x] Full verification workflow passed (build + reviews)

Closes swamp-club#1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)