### PR TITLE
fix(serve): surface exception type in method/workflow execution errors

### DIFF
--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -65,6 +65,20 @@ export function writeRemoteIndicator(serverUrl: string): void {
   console.error(gutterLine("Remote", STATUS_COLORS.warn, serverUrl));
 }
 
+function formatServerError(
+  error: { code: string; message: string; details?: unknown },
+): string {
+  const exType = error.details != null &&
+      typeof error.details === "object" &&
+      "exceptionType" in error.details &&
+      typeof (error.details as Record<string, unknown>).exceptionType ===
+        "string"
+    ? (error.details as Record<string, unknown>).exceptionType as string
+    : undefined;
+  const qualifier = exType !== undefined ? ` (${exType})` : "";
+  return `Server reported ${error.code}${qualifier}: ${error.message}`;
+}
+
 /** How long to keep draining after sending `cancel` before giving up. */
 const CANCEL_DRAIN_MS = 10_000;
 
@@ -304,7 +318,7 @@ export function requestServerResponse<T>(
           } catch { /* already closed */ }
           reject(
             new UserError(
-              `Server reported ${message.error.code}: ${message.error.message}`,
+              formatServerError(message.error),
             ),
           );
           return;
@@ -698,7 +712,7 @@ async function* singleConnectionStream(
             throw new DOMException("Run was cancelled", "AbortError");
           }
           throw new UserError(
-            `Server reported ${message.error.code}: ${message.error.message}`,
+            formatServerError(message.error),
           );
         }
         if (message.type === "run.elsewhere") {

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -163,7 +163,10 @@ import {
 import { findActiveRunByRunId } from "./active_run_tracker.ts";
 import { InstanceHeartbeatService } from "./instance_heartbeat.ts";
 
-export { sanitizeErrorForClient } from "./handlers/shared.ts";
+export {
+  exceptionTypeForClient,
+  sanitizeErrorForClient,
+} from "./handlers/shared.ts";
 export type { ConnectionContext } from "./handlers/shared.ts";
 
 const MAX_ACTIVE_REQUESTS = 100;

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
+  exceptionTypeForClient,
   extractRequestId,
   handleMessage,
   sanitizeErrorForClient,
@@ -2649,6 +2650,55 @@ Deno.test("sanitizeErrorForClient: passes UserError with model type slashes", ()
 Deno.test("sanitizeErrorForClient: handles non-Error values", () => {
   assertEquals(sanitizeErrorForClient("simple string"), "simple string");
   assertEquals(sanitizeErrorForClient(42), "42");
+});
+
+// ── exceptionTypeForClient tests ─────────────────────────────────────────
+
+Deno.test("exceptionTypeForClient: returns constructor name for custom Error subclass", () => {
+  class LockTimeoutError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "LockTimeoutError";
+    }
+  }
+  assertEquals(
+    exceptionTypeForClient(new LockTimeoutError("timed out")),
+    "LockTimeoutError",
+  );
+});
+
+Deno.test("exceptionTypeForClient: returns name for TypeError", () => {
+  assertEquals(exceptionTypeForClient(new TypeError("bad")), "TypeError");
+});
+
+Deno.test("exceptionTypeForClient: returns name for RangeError", () => {
+  assertEquals(exceptionTypeForClient(new RangeError("out")), "RangeError");
+});
+
+Deno.test("exceptionTypeForClient: returns undefined for plain Error", () => {
+  assertEquals(exceptionTypeForClient(new Error("plain")), undefined);
+});
+
+Deno.test("exceptionTypeForClient: returns UserError name", () => {
+  assertEquals(exceptionTypeForClient(new UserError("oops")), "UserError");
+});
+
+Deno.test("exceptionTypeForClient: returns undefined for non-Error values", () => {
+  assertEquals(exceptionTypeForClient("a string"), undefined);
+  assertEquals(exceptionTypeForClient(42), undefined);
+  assertEquals(exceptionTypeForClient(null), undefined);
+  assertEquals(exceptionTypeForClient(undefined), undefined);
+});
+
+Deno.test("exceptionTypeForClient: returns name when constructor is Error but name differs", () => {
+  const err = new Error("test");
+  err.name = "CustomName";
+  assertEquals(exceptionTypeForClient(err), "CustomName");
+});
+
+Deno.test("exceptionTypeForClient: returns undefined for anonymous Error subclass", () => {
+  const AnonError = (() => class extends Error {})();
+  assertEquals(exceptionTypeForClient(new AnonError("anon")), undefined);
 });
 
 // ── data.query validation tests ─────────────────────────────────────────

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -101,6 +101,7 @@ import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config
 import {
   authorizeOrReject,
   type ConnectionContext,
+  exceptionTypeForClient,
   isAdminOnlyModelType,
   sanitizeErrorForClient,
   send,
@@ -271,7 +272,14 @@ export async function handleModelMethodRun(
         sendError(socket, requestId, "cancelled", "Operation was cancelled");
       } else {
         const message = sanitizeErrorForClient(error);
-        sendError(socket, requestId, "method_execution_failed", message);
+        const exType = exceptionTypeForClient(error);
+        sendError(
+          socket,
+          requestId,
+          "method_execution_failed",
+          message,
+          exType !== undefined ? { exceptionType: exType } : undefined,
+        );
       }
       await telemetry?.finish(
         error instanceof Error ? error : new Error(String(error)),
@@ -498,10 +506,14 @@ export async function handleModelMethodRun(
           message: "Operation was cancelled",
         });
       } else {
+        const exType = exceptionTypeForClient(error);
         buffer.finish({
           kind: "error",
           code: "method_execution_failed",
           message: sanitizeErrorForClient(error),
+          ...(exType !== undefined && {
+            details: { exceptionType: exType },
+          }),
         });
       }
     } finally {

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -70,6 +70,17 @@ export function sanitizeErrorForClient(error: unknown): string {
   return raw;
 }
 
+// Exception class names (e.g. "LockTimeoutError") are safe to surface — they
+// carry no user data or paths, unlike the message which may contain either.
+export function exceptionTypeForClient(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    const ctorName = error.constructor.name;
+    if (ctorName && ctorName !== "Error") return ctorName;
+    if (error.name && error.name !== "Error") return error.name;
+  }
+  return undefined;
+}
+
 export const MAX_PREDICATE_LENGTH = 4096;
 
 export const MAX_QUERY_RESULTS = 10_000;
@@ -337,8 +348,13 @@ export function sendError(
   id: string,
   code: string,
   message: string,
+  details?: unknown,
 ): void {
-  send(socket, { type: "error", id, error: { code, message } });
+  send(socket, {
+    type: "error",
+    id,
+    error: { code, message, ...(details !== undefined && { details }) },
+  });
 }
 
 export function createSocketSubscriber(
@@ -358,7 +374,13 @@ export function createSocketSubscriber(
       if (terminal.kind === "done") {
         send(socket, { type: "done", id: requestId });
       } else {
-        sendError(socket, requestId, terminal.code, terminal.message);
+        sendError(
+          socket,
+          requestId,
+          terminal.code,
+          terminal.message,
+          terminal.details,
+        );
       }
     },
     onDetach() {

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -121,6 +121,7 @@ import {
 import {
   authorizeOrReject,
   type ConnectionContext,
+  exceptionTypeForClient,
   sanitizeErrorForClient,
   send,
   sendError,
@@ -237,7 +238,14 @@ export async function handleWorkflowRun(
         sendError(socket, requestId, "cancelled", "Operation was cancelled");
       } else {
         const message = sanitizeErrorForClient(error);
-        sendError(socket, requestId, "workflow_execution_failed", message);
+        const exType = exceptionTypeForClient(error);
+        sendError(
+          socket,
+          requestId,
+          "workflow_execution_failed",
+          message,
+          exType !== undefined ? { exceptionType: exType } : undefined,
+        );
       }
     } finally {
       if (registeredRunId && ctx.cancelRegistry) {
@@ -351,10 +359,14 @@ export async function handleWorkflowRun(
           message: "Operation was cancelled",
         });
       } else {
+        const exType = exceptionTypeForClient(error);
         buffer.finish({
           kind: "error",
           code: "workflow_execution_failed",
           message: sanitizeErrorForClient(error),
+          ...(exType !== undefined && {
+            details: { exceptionType: exType },
+          }),
         });
       }
     } finally {

--- a/src/serve/run_event_buffer.ts
+++ b/src/serve/run_event_buffer.ts
@@ -21,7 +21,7 @@ import type { SerializedEvent } from "./protocol.ts";
 
 export type BufferTerminal =
   | { kind: "done" }
-  | { kind: "error"; code: string; message: string };
+  | { kind: "error"; code: string; message: string; details?: unknown };
 
 export interface RunEventSubscriber {
   onEvent(seq: number, event: SerializedEvent): void;

--- a/src/serve/serializer_test.ts
+++ b/src/serve/serializer_test.ts
@@ -223,6 +223,28 @@ Deno.test("deserializeEvent: error events round-trip losslessly through the wire
   assertEquals(error.details, { stepName: "build", attempt: 2 });
 });
 
+Deno.test("deserializeEvent: exceptionType in details survives serialization round-trip", () => {
+  const original = {
+    kind: "error",
+    error: {
+      code: "method_execution_failed",
+      message: "An internal error occurred",
+      details: { exceptionType: "LockTimeoutError" },
+      cause: new Error("underlying"),
+    },
+  };
+  const wire = JSON.parse(JSON.stringify(serializeEvent(original)));
+  const restored = deserializeEvent(wire);
+  const error = restored.error as {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+  assertEquals(error.code, "method_execution_failed");
+  assertEquals(error.message, "An internal error occurred");
+  assertEquals(error.details, { exceptionType: "LockTimeoutError" });
+});
+
 Deno.test("deserializeEvent: run events round-trip renderer-equivalent through JSON", () => {
   const corpus: Array<{ kind: string; [key: string]: unknown }> = [
     { kind: "started", workflowName: "deploy", runId: "r-1" },


### PR DESCRIPTION
## Summary

- Add `exceptionTypeForClient()` helper that extracts the error constructor name (e.g. `LockTimeoutError`) from exceptions at the RPC boundary
- Populate `SerializedError.details` with `{ exceptionType }` on both inline and detached (buffered) execution paths for method and workflow runs
- Update client-side `remote_run.ts` to format errors as `method_execution_failed (LockTimeoutError): An internal error occurred` instead of just the opaque message
- Add `details` field to `BufferTerminal` type and forward it through `createSocketSubscriber.onTerminal`

Closes swamp-club#1985

## Test plan

- [x] Unit tests for `exceptionTypeForClient` covering Error subclasses, plain Error, UserError, non-Error values, and anonymous Error subclasses
- [x] Serializer round-trip test confirming `details.exceptionType` survives wire serialization
- [x] All 205 connection tests pass
- [x] All 18 serializer tests pass
- [x] Type checking passes on all changed files
- [x] Full verification workflow: lint, fmt, type-check, tests, deps audit, compile, code review, adversarial review — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>