### PR TITLE
fix(datastore): wire hydrateFile hook into workflow step execution path (swamp-club#1984)

### DIFF
--- a/design/enablers/datastores.md
+++ b/design/enablers/datastores.md
@@ -1062,6 +1062,9 @@ wraps `DatastoreSyncService.hydrateFile` with path normalization
 - Wired in `requireInitializedRepo`, `requireInitializedRepoUnlocked`, and
   `requireInitializedRepoReadOnly` (the read-only variant creates a lightweight
   sync service without a lock, solely for single-file downloads).
+- Wired in `WorkflowExecutionService` → `DefaultStepExecutor` via the
+  `RepositoryContext.hydrateFile` field, so workflow steps on serve can hydrate
+  lazy content during `readResource` calls.
 - Returns `true` if the file was downloaded, `false` if it does not exist on the
   remote.
 - Implementations MUST write atomically (tmp + rename) to avoid partial reads

--- a/src/cli/commands/workflow_resume.ts
+++ b/src/cli/commands/workflow_resume.ts
@@ -417,6 +417,7 @@ export const workflowResumeCommand = withRemoteOptions(
       ephemeral.repo,
       ephemeral.catalog,
       resolvePulledExtensionsRoot(repoDir),
+      repoContext.hydrateFile,
     );
 
     const abort = new AbortController();

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -433,6 +433,7 @@ export const workflowRunCommand = new Command()
             ephRepo,
             ephCatalog,
             resolvePulledExtensionsRoot(dir),
+            repoContext.hydrateFile,
           );
         },
         catalogStore: repoContext.catalogStore,

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -64,7 +64,10 @@ import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_outp
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { type Namespace, SOLO_NAMESPACE } from "../data/namespace.ts";
 import type { CatalogStore } from "../../infrastructure/persistence/catalog_store.ts";
-import type { MarkDirtyHook } from "../datastore/datastore_sync_service.ts";
+import type {
+  HydrateFileHook,
+  MarkDirtyHook,
+} from "../datastore/datastore_sync_service.ts";
 import { DataQueryService } from "../data/data_query_service.ts";
 import { CompositeUnifiedDataRepository } from "../data/composite_data_repository.ts";
 import { CompositeDataQueryService } from "../data/composite_data_query_service.ts";
@@ -418,6 +421,7 @@ export class DefaultStepExecutor implements StepExecutor {
     directTypeResolver?: DirectTypeResolver,
     private readonly markDirty?: MarkDirtyHook,
     private readonly stepLockHook?: StepLockHook,
+    private readonly hydrateFile?: HydrateFileHook,
   ) {
     this._directTypeResolver = directTypeResolver;
   }
@@ -434,6 +438,7 @@ export class DefaultStepExecutor implements StepExecutor {
       dataBaseDir?: string;
       catalogStore: CatalogStore;
       markDirty?: MarkDirtyHook;
+      hydrateFile?: HydrateFileHook;
       namespace?: Namespace;
     },
   ): Promise<DefaultStepExecutor> {
@@ -455,6 +460,7 @@ export class DefaultStepExecutor implements StepExecutor {
       dataBaseDir: ctx.dataBaseDir,
       catalogStore: ctx.catalogStore,
       markDirty: this.markDirty,
+      hydrateFile: this.hydrateFile,
       namespace: ctx.namespace,
       ephemeralRepo: ctx.ephemeralRepo,
       ephemeralCatalog: ctx.ephemeralCatalog,
@@ -474,6 +480,7 @@ export class DefaultStepExecutor implements StepExecutor {
       dataBaseDir?: string;
       catalogStore: CatalogStore;
       markDirty?: MarkDirtyHook;
+      hydrateFile?: HydrateFileHook;
       namespace?: Namespace;
       ephemeralRepo?: UnifiedDataRepository;
       ephemeralCatalog?: CatalogStore;
@@ -485,7 +492,7 @@ export class DefaultStepExecutor implements StepExecutor {
       opts.dataBaseDir,
       opts.catalogStore,
       opts.markDirty,
-      undefined,
+      opts.hydrateFile,
       opts.namespace ?? SOLO_NAMESPACE,
     );
     const unifiedDataRepo: UnifiedDataRepository = opts.ephemeralRepo
@@ -1565,6 +1572,7 @@ export class WorkflowExecutionService {
     private readonly ephemeralRepo?: UnifiedDataRepository,
     private readonly ephemeralCatalog?: CatalogStore,
     private readonly pulledExtensionsRoot?: string,
+    private readonly hydrateFile?: HydrateFileHook,
   ) {
     this.executor = executor ??
       new DefaultStepExecutor(
@@ -1572,6 +1580,7 @@ export class WorkflowExecutionService {
         directTypeResolver,
         markDirty,
         stepLockHook,
+        hydrateFile,
       );
     this.dataBaseDir = dataBaseDir;
     this.catalogStore = catalogStore;
@@ -1586,7 +1595,7 @@ export class WorkflowExecutionService {
       dataBaseDir,
       catalogStore,
       markDirty,
-      undefined,
+      hydrateFile,
       namespace,
     );
     this.dataRepo = ephemeralRepo
@@ -3434,6 +3443,7 @@ export class WorkflowExecutionService {
       this.ephemeralRepo,
       this.ephemeralCatalog,
       this.pulledExtensionsRoot,
+      this.hydrateFile,
     );
 
     let childRun: WorkflowRun | undefined;

--- a/src/domain/workflows/execution_service_test.ts
+++ b/src/domain/workflows/execution_service_test.ts
@@ -20,6 +20,7 @@
 import {
   assert,
   assertEquals,
+  assertExists,
   assertNotEquals,
   assertRejects,
   assertStringIncludes,
@@ -5576,6 +5577,145 @@ Deno.test({
         executor.executedSteps.includes("main/cleanup"),
         "cleanup step should have been executed after cancellation",
       );
+    });
+  },
+});
+
+Deno.test({
+  name:
+    "DefaultStepExecutor: hydrateFile hook fires when step reads lazy-hydrated resource",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const { z } = await import("zod");
+    const { ModelType } = await import("../models/model_type.ts");
+    const { modelRegistry } = await import("../models/model.ts");
+    const { Definition } = await import("../definitions/definition.ts");
+    const { YamlDefinitionRepository } = await import(
+      "../../infrastructure/persistence/yaml_definition_repository.ts"
+    );
+    const { FileSystemUnifiedDataRepository } = await import(
+      "../../infrastructure/persistence/unified_data_repository.ts"
+    );
+    const { Data } = await import("../data/data.ts");
+    const { initializeLogging } = await import(
+      "../../infrastructure/logging/logger.ts"
+    );
+    await initializeLogging({});
+
+    await withTempDir(async (tempDir) => {
+      const typeName = `@test-issue1984/hydrate-${
+        crypto.randomUUID().slice(0, 8)
+      }`;
+      const modelType = ModelType.create(typeName);
+      let readResult: Record<string, unknown> | null = null;
+
+      modelRegistry.register({
+        type: modelType,
+        version: "2026.01.01.1",
+        globalArguments: z.object({}),
+        resources: {
+          cursor: {
+            description: "cursor state",
+            schema: z.object({ lastSeen: z.number() }),
+            lifetime: "infinite",
+            garbageCollection: 5,
+          },
+        },
+        methods: {
+          run: {
+            description: "reads a resource to test hydration",
+            arguments: z.object({}),
+            execute: async (_args, context) => {
+              readResult = await context.readResource!("cursor");
+              return {};
+            },
+          },
+        },
+      });
+
+      const catalogStore = new CatalogStore(join(tempDir, "_catalog.db"));
+      try {
+        const definitionRepo = new YamlDefinitionRepository(tempDir);
+        const instance = Definition.create({
+          name: "hydrate-instance",
+          type: modelType.normalized,
+        });
+        await definitionRepo.save(modelType, instance);
+
+        const setupRepo = new FileSystemUnifiedDataRepository(
+          tempDir,
+          undefined,
+          catalogStore,
+        );
+        const cursorData = { lastSeen: 42 };
+        const content = new TextEncoder().encode(JSON.stringify(cursorData));
+        const data = Data.create({
+          name: "cursor",
+          contentType: "application/json",
+          lifetime: "infinite",
+          garbageCollection: 5,
+          tags: { type: "resource" },
+          ownerDefinition: {
+            ownerType: "model-method" as const,
+            ownerRef: instance.id,
+          },
+        });
+        await setupRepo.save(modelType, instance.id, data, content);
+
+        const contentPath = setupRepo.getContentPath(
+          modelType,
+          instance.id,
+          "cursor",
+          1,
+        );
+        await Deno.remove(contentPath);
+
+        let hookCalled = false;
+        const hydrateFile = async (absPath: string): Promise<boolean> => {
+          hookCalled = true;
+          await Deno.mkdir(join(absPath, ".."), { recursive: true });
+          await Deno.writeFile(absPath, content);
+          return true;
+        };
+
+        const executor = new DefaultStepExecutor(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          hydrateFile,
+        );
+
+        const step = Step.create({
+          name: "hydrate-step",
+          task: StepTask.model("hydrate-instance", "run"),
+        });
+        const ctx: StepExecutionContext = {
+          workflowId: createWorkflowId(
+            "00000000-0000-0000-0000-000000000000",
+          ),
+          workflowRunId: "00000000-0000-0000-0000-000000000000",
+          workflowName: "hydration-test",
+          jobName: "job1",
+          stepName: "hydrate-step",
+          repoDir: tempDir,
+          signal: new AbortController().signal,
+          step,
+          catalogStore,
+        };
+
+        await executor.execute(step, ctx);
+
+        assert(hookCalled, "hydrateFile hook should have been called");
+        assertExists(readResult, "readResource should return data");
+        assertEquals(
+          (readResult as Record<string, unknown>).lastSeen,
+          42,
+        );
+      } finally {
+        catalogStore.close();
+      }
     });
   },
 });

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -381,6 +381,7 @@ export interface RepositoryContext {
   catalogStore: CatalogStore;
   dataQueryService: DataQueryService;
   markDirty?: MarkDirtyHook;
+  hydrateFile?: HydrateFileHook;
   autoDefinitionsDir: string;
 }
 
@@ -513,6 +514,7 @@ export function createRepositoryContext(
     catalogStore,
     dataQueryService,
     markDirty,
+    hydrateFile,
     autoDefinitionsDir: autoDefDir,
   };
 }

--- a/src/serve/deps.ts
+++ b/src/serve/deps.ts
@@ -199,6 +199,7 @@ export async function createWorkflowRunDeps(
         ephRepo,
         ephCatalog,
         resolvePulledExtensionsRoot(dir),
+        repoContext.hydrateFile,
       );
     },
     catalogStore: repoContext.catalogStore,

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -1113,6 +1113,7 @@ export async function handleWorkflowResume(
         ephemeral.repo,
         ephemeral.catalog,
         resolvePulledExtensionsRoot(ctx.repoDir),
+        ctx.repoContext.hydrateFile,
       );
 
       const resumeGenerator = async function* (): AsyncGenerator<
@@ -1296,6 +1297,7 @@ export async function handleWorkflowResume(
         ephemeral.repo,
         ephemeral.catalog,
         resolvePulledExtensionsRoot(ctx.repoDir),
+        ctx.repoContext.hydrateFile,
       );
 
       const doResume = async () => {


### PR DESCRIPTION
## Summary

- Thread `HydrateFileHook` through `WorkflowExecutionService` → `DefaultStepExecutor` → `FileSystemUnifiedDataRepository`, mirroring the existing `markDirty` pattern
- Add `hydrateFile` to `RepositoryContext` interface so construction sites can access it
- Update all 6 construction sites (4 external + child service + internal repo) to pass the hook
- Add end-to-end wiring test proving the hook fires during workflow step `readResource` calls

Fixes swamp-club#1984

## Context

`readResource` inside serve-scheduled workflow steps returned stale/null data for lazily-hydrated resources. The `HydrateFileHook` (introduced in #1448) was wired into CLI commands via `repo_context.ts` → `createRepositoryContext`, but `WorkflowExecutionService` and `DefaultStepExecutor.buildDeps` created their own `FileSystemUnifiedDataRepository` instances with `hydrateFile=undefined`. On serve with MongoDB datastore + lazy hydration, `getContent()` couldn't download missing `raw` files on demand.

## Test plan

- [x] New test: `DefaultStepExecutor: hydrateFile hook fires when step reads lazy-hydrated resource` — registers model, saves data, deletes raw file, executes step with hydrateFile mock, asserts hook called and correct data returned
- [x] All 86 existing execution_service tests pass
- [x] Full verification: lint, fmt, type-check, tests, compile, code review (pass), adversarial review (pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Magistr <umag@users.noreply.github.com>