### PR TITLE
fix(serve): map LockTimeoutError to lock_timeout error code at serve boundary

### DIFF
--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -321,6 +321,7 @@ export function requestServerResponse<T>(
           reject(
             new UserError(
               formatServerError(message.error),
+              message.error.code,
             ),
           );
           return;
@@ -715,6 +716,7 @@ async function* singleConnectionStream(
           }
           throw new UserError(
             formatServerError(message.error),
+            message.error.code,
           );
         }
         if (message.type === "run.elsewhere") {

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -165,6 +165,7 @@ import { InstanceHeartbeatService } from "./instance_heartbeat.ts";
 
 export {
   exceptionTypeForClient,
+  lockTimeoutErrorForClient,
   sanitizeErrorForClient,
 } from "./handlers/shared.ts";
 export type { ConnectionContext } from "./handlers/shared.ts";

--- a/src/serve/connection_test.ts
+++ b/src/serve/connection_test.ts
@@ -22,12 +22,14 @@ import {
   exceptionTypeForClient,
   extractRequestId,
   handleMessage,
+  lockTimeoutErrorForClient,
   sanitizeErrorForClient,
   validateServerRequest,
 } from "./connection.ts";
 import type { ConnectionContext } from "./connection.ts";
 import { initializeLogging } from "../infrastructure/logging/logger.ts";
 import { UserError } from "../domain/errors.ts";
+import { LockTimeoutError } from "../domain/datastore/distributed_lock.ts";
 import type { Principal } from "../domain/access/principal.ts";
 import type { ServeAuthConfig } from "../domain/access/serve_auth_config.ts";
 import { PolicySnapshot } from "../domain/access/policy_snapshot.ts";
@@ -2699,6 +2701,68 @@ Deno.test("exceptionTypeForClient: returns name when constructor is Error but na
 Deno.test("exceptionTypeForClient: returns undefined for anonymous Error subclass", () => {
   const AnonError = (() => class extends Error {})();
   assertEquals(exceptionTypeForClient(new AnonError("anon")), undefined);
+});
+
+// ── lockTimeoutErrorForClient tests ──────────────────────────────────────
+
+Deno.test("lockTimeoutErrorForClient: returns lock_timeout code with retryable details", () => {
+  const err = new LockTimeoutError("data/mytype/my-model/.lock", null, 30000);
+  const result = lockTimeoutErrorForClient(err);
+  assertEquals(result.code, "lock_timeout");
+  assertEquals(result.details.retryable, true);
+  assertEquals(result.details.exceptionType, "LockTimeoutError");
+});
+
+Deno.test("lockTimeoutErrorForClient: preserves safe lockKey in message", () => {
+  const err = new LockTimeoutError(".datastore.lock", null, 60000);
+  const result = lockTimeoutErrorForClient(err);
+  assertStringIncludes(result.message, '".datastore.lock"');
+  assertStringIncludes(result.message, "60000ms");
+});
+
+Deno.test("lockTimeoutErrorForClient: includes holder info when present", () => {
+  const holder = {
+    holder: "user@hostname",
+    hostname: "hostname",
+    pid: 12345,
+    acquiredAt: "2026-09-01T00:00:00Z",
+    ttlMs: 30000,
+  };
+  const err = new LockTimeoutError(".datastore.lock", holder, 60000);
+  const result = lockTimeoutErrorForClient(err);
+  assertStringIncludes(result.message, "user@hostname");
+  assertStringIncludes(result.message, "pid 12345");
+});
+
+Deno.test("lockTimeoutErrorForClient: sanitizes absolute filesystem path in lockKey", () => {
+  const err = new LockTimeoutError(
+    "/Users/stack72/code/.swamp/data/mytype/my-model/.lock",
+    null,
+    5000,
+  );
+  const result = lockTimeoutErrorForClient(err);
+  assertStringIncludes(result.message, '"model lock"');
+  assertEquals(result.message.includes("/Users/"), false);
+});
+
+Deno.test("lockTimeoutErrorForClient: sanitizes Windows path in lockKey", () => {
+  const err = new LockTimeoutError(
+    "C:\\Users\\stack72\\.swamp\\data\\mytype\\.lock",
+    null,
+    5000,
+  );
+  const result = lockTimeoutErrorForClient(err);
+  assertStringIncludes(result.message, '"model lock"');
+});
+
+Deno.test("lockTimeoutErrorForClient: sanitizes .swamp internal path in lockKey", () => {
+  const err = new LockTimeoutError(
+    "some/path/.swamp/data/type/id/.lock",
+    null,
+    5000,
+  );
+  const result = lockTimeoutErrorForClient(err);
+  assertStringIncludes(result.message, '"model lock"');
 });
 
 // ── data.query validation tests ─────────────────────────────────────────

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -103,11 +103,13 @@ import {
   type ConnectionContext,
   exceptionTypeForClient,
   isAdminOnlyModelType,
+  lockTimeoutErrorForClient,
   sanitizeErrorForClient,
   send,
   sendError,
   subscribeUntilDetach,
 } from "./shared.ts";
+import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
 
 const logger = getSwampLogger(["serve", "connection"]);
 
@@ -270,6 +272,9 @@ export async function handleModelMethodRun(
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") {
         sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      } else if (error instanceof LockTimeoutError) {
+        const lt = lockTimeoutErrorForClient(error);
+        sendError(socket, requestId, lt.code, lt.message, lt.details);
       } else {
         const message = sanitizeErrorForClient(error);
         const exType = exceptionTypeForClient(error);
@@ -504,6 +509,14 @@ export async function handleModelMethodRun(
           kind: "error",
           code: "cancelled",
           message: "Operation was cancelled",
+        });
+      } else if (error instanceof LockTimeoutError) {
+        const lt = lockTimeoutErrorForClient(error);
+        buffer.finish({
+          kind: "error",
+          code: lt.code,
+          message: lt.message,
+          details: lt.details,
         });
       } else {
         const exType = exceptionTypeForClient(error);

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -23,7 +23,7 @@
 
 import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastoreConfig } from "../../domain/datastore/datastore_config.ts";
-import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
+import type { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { DatastoreSyncService } from "../../domain/datastore/datastore_sync_service.ts";
 import type { ControlPlaneStore } from "../../domain/datastore/control_plane_store.ts";

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -23,6 +23,7 @@
 
 import type { RepositoryContext } from "../../infrastructure/persistence/repository_factory.ts";
 import type { DatastoreConfig } from "../../domain/datastore/datastore_config.ts";
+import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { DatastoreSyncService } from "../../domain/datastore/datastore_sync_service.ts";
 import type { ControlPlaneStore } from "../../domain/datastore/control_plane_store.ts";
@@ -79,6 +80,33 @@ export function exceptionTypeForClient(error: unknown): string | undefined {
     if (error.name && error.name !== "Error") return error.name;
   }
   return undefined;
+}
+
+function isPathLike(value: string): boolean {
+  return ABSOLUTE_PATH_PATTERN.test(value) ||
+    WINDOWS_PATH_PATTERN.test(value) ||
+    SWAMP_INTERNAL_PATH_PATTERN.test(value);
+}
+
+export interface LockTimeoutClientError {
+  code: "lock_timeout";
+  message: string;
+  details: { retryable: true; exceptionType: "LockTimeoutError" };
+}
+
+export function lockTimeoutErrorForClient(
+  error: LockTimeoutError,
+): LockTimeoutClientError {
+  const safeLockKey = isPathLike(error.lockKey) ? "model lock" : error.lockKey;
+  const message = error.holder
+    ? `Lock contention on "${safeLockKey}" held by ${error.holder.holder} ` +
+      `(pid ${error.holder.pid}) — timed out after ${error.waitedMs}ms`
+    : `Lock contention on "${safeLockKey}" — timed out after ${error.waitedMs}ms`;
+  return {
+    code: "lock_timeout",
+    message,
+    details: { retryable: true, exceptionType: "LockTimeoutError" },
+  };
 }
 
 export const MAX_PREDICATE_LENGTH = 4096;

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -122,11 +122,13 @@ import {
   authorizeOrReject,
   type ConnectionContext,
   exceptionTypeForClient,
+  lockTimeoutErrorForClient,
   sanitizeErrorForClient,
   send,
   sendError,
   subscribeUntilDetach,
 } from "./shared.ts";
+import { LockTimeoutError } from "../../domain/datastore/distributed_lock.ts";
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
 import { join } from "@std/path";
 import {
@@ -236,6 +238,9 @@ export async function handleWorkflowRun(
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") {
         sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      } else if (error instanceof LockTimeoutError) {
+        const lt = lockTimeoutErrorForClient(error);
+        sendError(socket, requestId, lt.code, lt.message, lt.details);
       } else {
         const message = sanitizeErrorForClient(error);
         const exType = exceptionTypeForClient(error);
@@ -357,6 +362,14 @@ export async function handleWorkflowRun(
           kind: "error",
           code: "cancelled",
           message: "Operation was cancelled",
+        });
+      } else if (error instanceof LockTimeoutError) {
+        const lt = lockTimeoutErrorForClient(error);
+        buffer.finish({
+          kind: "error",
+          code: lt.code,
+          message: lt.message,
+          details: lt.details,
         });
       } else {
         const exType = exceptionTypeForClient(error);
@@ -1170,6 +1183,9 @@ export async function handleWorkflowResume(
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") {
         sendError(socket, requestId, "cancelled", "Operation was cancelled");
+      } else if (error instanceof LockTimeoutError) {
+        const lt = lockTimeoutErrorForClient(error);
+        sendError(socket, requestId, lt.code, lt.message, lt.details);
       } else {
         const message = sanitizeErrorForClient(error);
         sendError(socket, requestId, "workflow_resume_failed", message);
@@ -1346,6 +1362,14 @@ export async function handleWorkflowResume(
           kind: "error",
           code: "cancelled",
           message: "Operation was cancelled",
+        });
+      } else if (error instanceof LockTimeoutError) {
+        const lt = lockTimeoutErrorForClient(error);
+        buffer.finish({
+          kind: "error",
+          code: lt.code,
+          message: lt.message,
+          details: lt.details,
         });
       } else {
         buffer.finish({


### PR DESCRIPTION
## Summary

- Add `lockTimeoutErrorForClient` helper in `shared.ts` that extracts safe, path-free fields from `LockTimeoutError` and maps it to the `lock_timeout` error code with `retryable: true` in details
- Detect `LockTimeoutError` before the generic catch in all 6 serve handler catch blocks (model run inline/detached, workflow run inline/detached, workflow resume inline/detached) — sends `lock_timeout` instead of `method_execution_failed`/`workflow_execution_failed`
- Propagate server error code to `UserError.code` in `remote_run.ts` so `exitCodeForError` returns 75 (EX_TEMPFAIL) for lock timeouts via `--server`

Closes swamp-club#1993

## Test plan

- [x] Unit tests for `lockTimeoutErrorForClient` — safe lockKey, holder info, absolute path sanitization, Windows path sanitization, `.swamp` path sanitization
- [x] All 211 connection_test.ts tests pass
- [x] All 11064 unit tests pass
- [x] Type check, lint, fmt all pass
- [x] Compile + binary check pass
- [x] Code review: VERDICT pass
- [x] Adversarial review: VERDICT pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)