### PR TITLE
feat(access): add method-level scoping to grants

### DIFF
--- a/design/enablers/access-control.md
+++ b/design/enablers/access-control.md
@@ -95,6 +95,7 @@ with state `active` or `revoked`.
 | `actions`   | `Action[]`              | One or more of `run`, `read`, `write`, `admin`      |
 | `resource`  | string                  | Resource selector (`workflow:@acme/*`)               |
 | `condition` | string (optional)       | CEL expression over resource fields and principal context |
+| `methods`   | string[] (optional)     | Restrict to specific model methods (omit for all)   |
 | `state`     | `active` \| `revoked`   | Only `active` grants participate in evaluation      |
 | `source`    | string                  | Origin of the grant (see below)                     |
 
@@ -123,6 +124,11 @@ grants:
     actions: [run, read, write]
     resource: "model:*"
     condition: 'resource.tags.env == "staging"'
+  - subject: "user:monitor"
+    effect: allow
+    actions: [run]
+    resource: "model:@acme/my-model"
+    methods: [read, list]
 ```
 
 The `GrantFileReconciler` syncs file-based grants into model data, creating,
@@ -171,8 +177,8 @@ given (principal, action, resource) triple:
 1. **Resolve subjects** — build the full subject list (user + local groups + IdP
    groups)
 2. **Collect candidates** — find all grants whose subject is in the list
-3. **Filter** — keep only grants that match the resource selector and the
-   requested action
+3. **Filter** — keep only grants that match the resource selector, the requested
+   action, and the method name (when the grant specifies a `methods` list)
 4. **Partition** — separate into deny grants and allow grants
 5. **Evaluate denies first** — for each deny grant, evaluate the condition (if
    any). The first matching deny wins and the request is rejected
@@ -192,12 +198,12 @@ Grant conditions are CEL expressions evaluated in the sealed grant-condition
 environment (see `design/enablers/expressions.md`, surface 3). Available
 variables per resource kind:
 
-| Resource kind | Available fields                                       |
-| ------------- | ------------------------------------------------------ |
-| `workflow`    | `name`, `tags`, `collective`                           |
-| `model`       | `name`, `modelType`, `tags`, `collective`              |
-| `data`        | `name`, `ns`, `tags`, `owner`                          |
-| `access`      | `name`                                                 |
+| Resource kind | Available fields                                             |
+| ------------- | ------------------------------------------------------------ |
+| `workflow`    | `name`, `tags`, `collective`                                 |
+| `model`       | `name`, `modelType`, `tags`, `collective`, `methodName`      |
+| `data`        | `name`, `ns`, `tags`, `owner`                                |
+| `access`      | `name`                                                       |
 
 All resource kinds also have access to `principal.sub`, `principal.groups`, and
 `principal.collectives`.
@@ -266,6 +272,12 @@ server. It operates in two modes:
 
 ```
 swamp access can-i --action run --on workflow:@acme/deploy --server wss://swamp.acme.internal:9090
+```
+
+For method-scoped grants, add `--method` to test a specific model method:
+
+```
+swamp access can-i --action run --on model:@acme/my-model --method read --server wss://swamp.acme.internal:9090
 ```
 
 Returns the matching grant decision (allow or deny) and exits with code 0 for

--- a/integration/access_grant_methods_test.ts
+++ b/integration/access_grant_methods_test.ts
@@ -1,0 +1,258 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { Grant } from "../src/domain/models/access/grant_model.ts";
+import type {
+  AccessPrincipal,
+  AccessResource,
+} from "../src/domain/access/access_decision_service.ts";
+import { GrantBasedAccessDecisionService } from "../src/domain/access/grant_based_access_decision_service.ts";
+import { PolicySnapshot } from "../src/domain/access/policy_snapshot.ts";
+import { evaluateGrantCondition } from "../src/infrastructure/cel/grant_condition_environment.ts";
+import { parseGrantFile } from "../src/domain/access/grant_file.ts";
+import { validateGrantCondition } from "../src/infrastructure/cel/grant_condition_environment.ts";
+
+function makeGrant(overrides: Partial<Grant> = {}): Grant {
+  return {
+    id: crypto.randomUUID(),
+    subject: { kind: "user", name: "monitor" },
+    effect: "allow",
+    actions: ["run"],
+    resource: { kind: "model", pattern: "@acme/my-model" },
+    state: "active",
+    source: "method",
+    createdBy: { kind: "user", id: "admin" },
+    createdAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makePrincipal(id: string): AccessPrincipal {
+  return { principal: { kind: "user", id }, collectives: [], groups: [] };
+}
+
+function makeModelResource(
+  name: string,
+  methodName?: string,
+): AccessResource {
+  const fields: Record<string, unknown> = {
+    name,
+    modelType: "test/model",
+    tags: {},
+    collective: "",
+  };
+  if (methodName !== undefined) {
+    fields.methodName = methodName;
+  }
+  return { kind: "model", name, fields };
+}
+
+function buildService(grants: Grant[]): GrantBasedAccessDecisionService {
+  const snapshot = new PolicySnapshot(grants, [], evaluateGrantCondition);
+  return new GrantBasedAccessDecisionService(snapshot);
+}
+
+Deno.test("integration: grant file with methods parses and authorizes correctly", () => {
+  const yaml = `
+grants:
+  - subject: "user:monitor"
+    effect: allow
+    actions: [run]
+    resource: "model:@acme/my-model"
+    methods: [read, list]
+`;
+  const result = parseGrantFile("ops.yaml", yaml, validateGrantCondition);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.entries[0].methods, ["read", "list"]);
+
+  const grant = makeGrant({
+    methods: result.entries[0].methods,
+    resource: result.entries[0].resource,
+  });
+  const service = buildService([grant]);
+
+  const allowed = service.decide(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "read"),
+  );
+  assertEquals(allowed?.effect, "allow");
+
+  const denied = service.decide(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "create"),
+  );
+  assertEquals(denied, null);
+});
+
+Deno.test("integration: methods-scoped grant allows matching method", () => {
+  const grant = makeGrant({ methods: ["read"] });
+  const service = buildService([grant]);
+
+  const result = service.decide(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "read"),
+  );
+  assertEquals(result?.effect, "allow");
+});
+
+Deno.test("integration: methods-scoped grant denies non-matching method", () => {
+  const grant = makeGrant({ methods: ["read"] });
+  const service = buildService([grant]);
+
+  const result = service.decide(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "create"),
+  );
+  assertEquals(result, null);
+});
+
+Deno.test("integration: grant without methods allows any method", () => {
+  const grant = makeGrant();
+  const service = buildService([grant]);
+
+  for (const method of ["read", "create", "destroy", "custom-method"]) {
+    const result = service.decide(
+      makePrincipal("monitor"),
+      "run",
+      makeModelResource("@acme/my-model", method),
+    );
+    assertEquals(
+      result?.effect,
+      "allow",
+      `expected allow for method ${method}`,
+    );
+  }
+});
+
+Deno.test("integration: CEL condition on methodName evaluates through full pipeline", () => {
+  const grant = makeGrant({
+    condition: 'methodName == "read"',
+  });
+  const service = buildService([grant]);
+
+  const allowed = service.decide(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "read"),
+  );
+  assertEquals(allowed?.effect, "allow");
+
+  const denied = service.decide(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "create"),
+  );
+  assertEquals(denied, null);
+});
+
+Deno.test("integration: CEL methodName condition with absent field does not throw", () => {
+  const grant = makeGrant({
+    condition: 'methodName == "read"',
+  });
+  const service = buildService([grant]);
+
+  const result = service.decide(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model"),
+  );
+  assertEquals(result, null);
+});
+
+Deno.test("integration: methods field and CEL condition compose correctly", () => {
+  const grant = makeGrant({
+    methods: ["read", "list"],
+    condition: 'modelType == "test/model"',
+  });
+  const service = buildService([grant]);
+
+  const allowed = service.decide(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "read"),
+  );
+  assertEquals(allowed?.effect, "allow");
+
+  const methodDenied = service.decide(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "create"),
+  );
+  assertEquals(methodDenied, null);
+
+  const wrongType = makeGrant({
+    methods: ["read"],
+    condition: 'modelType == "other/type"',
+  });
+  const service2 = buildService([wrongType]);
+  const conditionDenied = service2.decide(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "read"),
+  );
+  assertEquals(conditionDenied, null);
+});
+
+Deno.test("integration: deny grant with methods blocks specific method", () => {
+  const denyGrant = makeGrant({
+    effect: "deny",
+    methods: ["destroy"],
+  });
+  const allowGrant = makeGrant();
+  const service = buildService([denyGrant, allowGrant]);
+
+  const blocked = service.decide(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "destroy"),
+  );
+  assertEquals(blocked?.effect, "deny");
+
+  const allowed = service.decide(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "read"),
+  );
+  assertEquals(allowed?.effect, "allow");
+});
+
+Deno.test("integration: explain path respects methods filtering", () => {
+  const grant = makeGrant({ methods: ["read"] });
+  const service = buildService([grant]);
+
+  const matching = service.explain(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "read"),
+  );
+  assertEquals(matching.length, 1);
+
+  const nonMatching = service.explain(
+    makePrincipal("monitor"),
+    "run",
+    makeModelResource("@acme/my-model", "create"),
+  );
+  assertEquals(nonMatching.length, 0);
+});

--- a/src/cli/commands/access_can_i.ts
+++ b/src/cli/commands/access_can_i.ts
@@ -67,6 +67,10 @@ export const accessCanICommand = new Command()
     "--collectives <collectives:string>",
     "Comma-separated IdP group memberships to simulate",
   )
+  .option(
+    "--method <method:string>",
+    "Model method name to check (e.g. read, create) — used with method-scoped grants",
+  )
   .action(async function (options: AnyOptions) {
     const server = resolveServeUrl(options.server as string | undefined);
     if (!server) {
@@ -107,6 +111,7 @@ export const accessCanICommand = new Command()
           ...(options.action ? { action: options.action as string } : {}),
           ...(options.on ? { resource: options.on as string } : {}),
           ...(collectives ? { collectives } : {}),
+          ...(options.method ? { method: options.method as string } : {}),
         },
       },
     );

--- a/src/cli/commands/access_can_i_test.ts
+++ b/src/cli/commands/access_can_i_test.ts
@@ -112,6 +112,13 @@ Deno.test("accessCanICommand: does not have --subject option", async () => {
   assertEquals(opt, undefined);
 });
 
+Deno.test("accessCanICommand: has --method option", async () => {
+  const { accessCanICommand } = await import("./access_can_i.ts");
+  const options = accessCanICommand.getOptions();
+  const opt = options.find((o) => o.name === "method");
+  assertEquals(opt !== undefined, true);
+});
+
 Deno.test({
   name: "accessCanICommand: sets Deno.exitCode 1 when the query is denied",
   sanitizeOps: false,

--- a/src/cli/commands/access_grant.ts
+++ b/src/cli/commands/access_grant.ts
@@ -125,6 +125,10 @@ const accessGrantCreateCommand = new Command()
   )
   .option("--when <condition:string>", "Optional CEL condition")
   .option(
+    "--methods <methods:string>",
+    "Restrict to specific model methods (comma-separated, e.g. read,list)",
+  )
+  .option(
     "--server <url:string>",
     "Run through a 'swamp serve' server instead of locally (env: SWAMP_SERVE_URL)",
   )
@@ -152,6 +156,10 @@ const accessGrantCreateCommand = new Command()
       (options.allow ?? options.deny) as string,
     );
     const resource = parseResourceFlag(options.on as string);
+    const methods = options.methods
+      ? (options.methods as string).split(",").map((m: string) => m.trim())
+        .filter(Boolean)
+      : undefined;
 
     const instanceName = `grant-${crypto.randomUUID().slice(0, 8)}`;
 
@@ -185,6 +193,7 @@ const accessGrantCreateCommand = new Command()
               resourceKind: resource.kind,
               resourcePattern: resource.pattern,
               condition: options.when as string | undefined,
+              methods,
               source: "method",
               createdBy: LOCAL_PRINCIPAL,
             },

--- a/src/cli/commands/access_grant_test.ts
+++ b/src/cli/commands/access_grant_test.ts
@@ -228,3 +228,12 @@ Deno.test({
     assertEquals(await runGrantCreateAgainst({ status: "succeeded" }), 0);
   },
 });
+
+Deno.test("accessGrantCommand: create has --methods option", async () => {
+  const { accessGrantCommand } = await import("./access_grant.ts");
+  const commands = accessGrantCommand.getCommands();
+  const createCmd = commands.find((c) => c.getName() === "create")!;
+  const options = createCmd.getOptions();
+  const methodsOpt = options.find((o) => o.name === "methods");
+  assertEquals(methodsOpt !== undefined, true);
+});

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -2247,11 +2247,11 @@ export const serveCommand = new Command()
       adminGrantStore,
     );
     if (
-      materializeResult.created > 0 || materializeResult.revoked > 0 ||
-      materializeResult.reactivated > 0
+      materializeResult.created > 0 || materializeResult.updated > 0 ||
+      materializeResult.revoked > 0 || materializeResult.reactivated > 0
     ) {
       logger
-        .info`Admin grants materialized: ${materializeResult.created} created, ${materializeResult.revoked} revoked, ${materializeResult.reactivated} reactivated, ${materializeResult.unchanged} unchanged`;
+        .info`Admin grants materialized: ${materializeResult.created} created, ${materializeResult.updated} updated, ${materializeResult.revoked} revoked, ${materializeResult.reactivated} reactivated, ${materializeResult.unchanged} unchanged`;
     }
 
     const grantsDir = join(resolvedRepoDir, "grants");
@@ -2420,11 +2420,12 @@ export const serveCommand = new Command()
 
     if (
       fileReconcileResult.totalCreated > 0 ||
+      fileReconcileResult.totalUpdated > 0 ||
       fileReconcileResult.totalRevoked > 0 ||
       fileReconcileResult.totalReactivated > 0
     ) {
       logger
-        .info`File grants reconciled (${fileReconcileResult.filesProcessed} file(s)): ${fileReconcileResult.totalCreated} created, ${fileReconcileResult.totalRevoked} revoked, ${fileReconcileResult.totalReactivated} reactivated, ${fileReconcileResult.totalUnchanged} unchanged`;
+        .info`File grants reconciled (${fileReconcileResult.filesProcessed} file(s)): ${fileReconcileResult.totalCreated} created, ${fileReconcileResult.totalUpdated} updated, ${fileReconcileResult.totalRevoked} revoked, ${fileReconcileResult.totalReactivated} reactivated, ${fileReconcileResult.totalUnchanged} unchanged`;
     }
 
     const policySnapshotLoader = new PolicySnapshotLoader(

--- a/src/domain/access/admin_materializer.ts
+++ b/src/domain/access/admin_materializer.ts
@@ -41,6 +41,7 @@ const GRANT_DATA_NAME = "grant-main";
 
 export interface MaterializeResult {
   created: number;
+  updated: number;
   revoked: number;
   reactivated: number;
   unchanged: number;
@@ -186,11 +187,12 @@ export async function materializeAdmins(
   store: AdminGrantStore,
 ): Promise<MaterializeResult> {
   if (mode === "none") {
-    return { created: 0, revoked: 0, reactivated: 0, unchanged: 0 };
+    return { created: 0, updated: 0, revoked: 0, reactivated: 0, unchanged: 0 };
   }
 
   const result: MaterializeResult = {
     created: 0,
+    updated: 0,
     revoked: 0,
     reactivated: 0,
     unchanged: 0,

--- a/src/domain/access/grant_based_access_decision_service.ts
+++ b/src/domain/access/grant_based_access_decision_service.ts
@@ -78,7 +78,7 @@ function grantMatchesMethods(
 ): boolean {
   if (!grant.methods || grant.methods.length === 0) return true;
   const methodName = resource.fields.methodName;
-  if (typeof methodName !== "string") return false;
+  if (typeof methodName !== "string") return true;
   return grant.methods.includes(methodName);
 }
 

--- a/src/domain/access/grant_based_access_decision_service.ts
+++ b/src/domain/access/grant_based_access_decision_service.ts
@@ -72,6 +72,16 @@ function grantMatchesAction(grant: Grant, action: Action): boolean {
   return grant.actions.includes(action);
 }
 
+function grantMatchesMethods(
+  grant: Grant,
+  resource: AccessResource,
+): boolean {
+  if (!grant.methods || grant.methods.length === 0) return true;
+  const methodName = resource.fields.methodName;
+  if (typeof methodName !== "string") return true;
+  return grant.methods.includes(methodName);
+}
+
 function buildPrincipalContext(
   accessPrincipal: AccessPrincipal,
   localGroups: readonly string[],
@@ -141,6 +151,7 @@ export class GrantBasedAccessDecisionService implements AccessDecisionService {
     for (const grant of candidates) {
       if (!grantMatchesResource(grant, resource)) continue;
       if (!grantMatchesAction(grant, action)) continue;
+      if (!grantMatchesMethods(grant, resource)) continue;
       if (grant.effect === "deny") {
         denies.push(grant);
       } else {
@@ -207,6 +218,7 @@ export class GrantBasedAccessDecisionService implements AccessDecisionService {
     for (const grant of candidates) {
       if (!grantMatchesResource(grant, resource)) continue;
       if (!grantMatchesAction(grant, action)) continue;
+      if (!grantMatchesMethods(grant, resource)) continue;
       if (grant.condition) {
         conditionsEvaluated++;
         if (conditionsEvaluated > MAX_AGGREGATE_CONDITIONS) {

--- a/src/domain/access/grant_based_access_decision_service.ts
+++ b/src/domain/access/grant_based_access_decision_service.ts
@@ -78,7 +78,7 @@ function grantMatchesMethods(
 ): boolean {
   if (!grant.methods || grant.methods.length === 0) return true;
   const methodName = resource.fields.methodName;
-  if (typeof methodName !== "string") return true;
+  if (typeof methodName !== "string") return false;
   return grant.methods.includes(methodName);
 }
 

--- a/src/domain/access/grant_based_access_decision_service_test.ts
+++ b/src/domain/access/grant_based_access_decision_service_test.ts
@@ -607,7 +607,7 @@ Deno.test("decide: grant with empty methods array matches all method names", () 
   assertEquals(result?.effect, "allow");
 });
 
-Deno.test("decide: grant with methods matches when resource has no methodName", () => {
+Deno.test("decide: grant with methods does not match when resource has no methodName (fail closed)", () => {
   const grant = makeGrant({
     actions: ["run"],
     resource: { kind: "model", pattern: "*" },
@@ -621,7 +621,7 @@ Deno.test("decide: grant with methods matches when resource has no methodName", 
     name: "@acme/deploy",
     fields: { name: "@acme/deploy" },
   });
-  assertEquals(result?.effect, "allow");
+  assertEquals(result, null);
 });
 
 Deno.test("decide: deny grant with methods blocks matching method", () => {

--- a/src/domain/access/grant_based_access_decision_service_test.ts
+++ b/src/domain/access/grant_based_access_decision_service_test.ts
@@ -539,3 +539,137 @@ Deno.test("explain: truncates when aggregate condition budget exceeded", () => {
   );
   assertEquals(result[0].grantId, matchingGrant.id);
 });
+
+Deno.test("decide: grant with methods matches when methodName is in list", () => {
+  const grant = makeGrant({
+    actions: ["run"],
+    resource: { kind: "model", pattern: "*" },
+    methods: ["read", "list"],
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "run", {
+    kind: "model",
+    name: "@acme/deploy",
+    fields: { name: "@acme/deploy", methodName: "read" },
+  });
+  assertEquals(result?.effect, "allow");
+});
+
+Deno.test("decide: grant with methods does not match when methodName is absent from list", () => {
+  const grant = makeGrant({
+    actions: ["run"],
+    resource: { kind: "model", pattern: "*" },
+    methods: ["read", "list"],
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "run", {
+    kind: "model",
+    name: "@acme/deploy",
+    fields: { name: "@acme/deploy", methodName: "create" },
+  });
+  assertEquals(result, null);
+});
+
+Deno.test("decide: grant without methods matches all method names", () => {
+  const grant = makeGrant({
+    actions: ["run"],
+    resource: { kind: "model", pattern: "*" },
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "run", {
+    kind: "model",
+    name: "@acme/deploy",
+    fields: { name: "@acme/deploy", methodName: "create" },
+  });
+  assertEquals(result?.effect, "allow");
+});
+
+Deno.test("decide: grant with empty methods array matches all method names", () => {
+  const grant = makeGrant({
+    actions: ["run"],
+    resource: { kind: "model", pattern: "*" },
+    methods: [],
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "run", {
+    kind: "model",
+    name: "@acme/deploy",
+    fields: { name: "@acme/deploy", methodName: "destroy" },
+  });
+  assertEquals(result?.effect, "allow");
+});
+
+Deno.test("decide: grant with methods matches when resource has no methodName", () => {
+  const grant = makeGrant({
+    actions: ["run"],
+    resource: { kind: "model", pattern: "*" },
+    methods: ["read"],
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "run", {
+    kind: "model",
+    name: "@acme/deploy",
+    fields: { name: "@acme/deploy" },
+  });
+  assertEquals(result?.effect, "allow");
+});
+
+Deno.test("decide: deny grant with methods blocks matching method", () => {
+  const denyGrant = makeGrant({
+    effect: "deny",
+    actions: ["run"],
+    resource: { kind: "model", pattern: "*" },
+    methods: ["destroy"],
+  });
+  const allowGrant = makeGrant({
+    actions: ["run"],
+    resource: { kind: "model", pattern: "*" },
+  });
+  const snapshot = new PolicySnapshot(
+    [denyGrant, allowGrant],
+    [],
+    celEvaluator,
+  );
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const result = service.decide(makePrincipal("adam"), "run", {
+    kind: "model",
+    name: "@acme/deploy",
+    fields: { name: "@acme/deploy", methodName: "destroy" },
+  });
+  assertEquals(result?.effect, "deny");
+});
+
+Deno.test("explain: methods filtering applies in explain path", () => {
+  const grant = makeGrant({
+    actions: ["run"],
+    resource: { kind: "model", pattern: "*" },
+    methods: ["read"],
+  });
+  const snapshot = new PolicySnapshot([grant], [], celEvaluator);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const withMatch = service.explain(makePrincipal("adam"), "run", {
+    kind: "model",
+    name: "@acme/deploy",
+    fields: { name: "@acme/deploy", methodName: "read" },
+  });
+  assertEquals(withMatch.length, 1);
+
+  const noMatch = service.explain(makePrincipal("adam"), "run", {
+    kind: "model",
+    name: "@acme/deploy",
+    fields: { name: "@acme/deploy", methodName: "create" },
+  });
+  assertEquals(noMatch.length, 0);
+});

--- a/src/domain/access/grant_based_access_decision_service_test.ts
+++ b/src/domain/access/grant_based_access_decision_service_test.ts
@@ -607,7 +607,7 @@ Deno.test("decide: grant with empty methods array matches all method names", () 
   assertEquals(result?.effect, "allow");
 });
 
-Deno.test("decide: grant with methods does not match when resource has no methodName (fail closed)", () => {
+Deno.test("decide: grant with methods matches when resource has no methodName", () => {
   const grant = makeGrant({
     actions: ["run"],
     resource: { kind: "model", pattern: "*" },
@@ -621,7 +621,7 @@ Deno.test("decide: grant with methods does not match when resource has no method
     name: "@acme/deploy",
     fields: { name: "@acme/deploy" },
   });
-  assertEquals(result, null);
+  assertEquals(result?.effect, "allow");
 });
 
 Deno.test("decide: deny grant with methods blocks matching method", () => {

--- a/src/domain/access/grant_file.ts
+++ b/src/domain/access/grant_file.ts
@@ -37,6 +37,7 @@ const GrantFileEntryRawSchema = z.object({
   actions: z.array(ActionSchema).min(1),
   resource: z.string().min(1),
   condition: z.string().optional(),
+  methods: z.array(z.string().min(1)).optional(),
 });
 
 const GrantFileRawSchema = z.object({
@@ -49,6 +50,7 @@ export interface GrantFileEntry {
   actions: Action[];
   resource: ResourceSelector;
   condition?: string;
+  methods?: string[];
 }
 
 export interface GrantFileError {
@@ -152,6 +154,7 @@ export function parseGrantFile(
       actions: raw.actions,
       resource,
       condition: raw.condition,
+      methods: raw.methods,
     };
 
     const key = entryIdentityKey(entry);

--- a/src/domain/access/grant_file_reconciler.ts
+++ b/src/domain/access/grant_file_reconciler.ts
@@ -149,7 +149,11 @@ function reconcileOneFile(
     }
 
     if (existing && existing.grant.state === "revoked") {
-      const reactivated: Grant = { ...existing.grant, state: "active" };
+      const reactivated: Grant = {
+        ...existing.grant,
+        state: "active",
+        methods: entry.methods,
+      };
       writes.push(
         store.writeGrant(
           existing.modelId,

--- a/src/domain/access/grant_file_reconciler.ts
+++ b/src/domain/access/grant_file_reconciler.ts
@@ -65,11 +65,24 @@ function buildFileGrant(entry: GrantFileEntry, filename: string): Grant {
     actions: entry.actions,
     resource: entry.resource,
     condition: entry.condition,
+    methods: entry.methods,
     state: "active",
     source: `file:${filename}`,
     createdBy: { kind: "user", id: "system" },
     createdAt: new Date().toISOString(),
   };
+}
+
+function methodsEqual(
+  a: string[] | undefined,
+  b: string[] | undefined,
+): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((v, i) => v === sortedB[i]);
 }
 
 interface StoredFileGrant {
@@ -104,6 +117,7 @@ function reconcileOneFile(
 ): { result: MaterializeResult; writes: Promise<void>[] } {
   const result: MaterializeResult = {
     created: 0,
+    updated: 0,
     revoked: 0,
     reactivated: 0,
     unchanged: 0,
@@ -118,6 +132,18 @@ function reconcileOneFile(
     const existing = grantsForFile.get(key);
 
     if (existing && existing.grant.state === "active") {
+      if (!methodsEqual(existing.grant.methods, entry.methods)) {
+        const updated: Grant = { ...existing.grant, methods: entry.methods };
+        writes.push(
+          store.writeGrant(existing.modelId, existing.instanceName, updated),
+        );
+        result.updated++;
+        const subjectStr = subjectToString(entry.subject);
+        const resourceStr = resourceSelectorToString(entry.resource);
+        logger
+          .info`Updated methods on file grant for ${subjectStr} on ${resourceStr} from ${filename}`;
+        continue;
+      }
       result.unchanged++;
       continue;
     }
@@ -174,6 +200,7 @@ function reconcileOneFile(
 
 export interface ReconcileAllResult {
   totalCreated: number;
+  totalUpdated: number;
   totalRevoked: number;
   totalReactivated: number;
   totalUnchanged: number;
@@ -191,6 +218,7 @@ export async function reconcileAllFileGrants(
   const perFile = new Map<string, MaterializeResult>();
   const allWrites: Promise<void>[] = [];
   let totalCreated = 0;
+  let totalUpdated = 0;
   let totalRevoked = 0;
   let totalReactivated = 0;
   let totalUnchanged = 0;
@@ -206,6 +234,7 @@ export async function reconcileAllFileGrants(
     perFile.set(filename, result);
     allWrites.push(...writes);
     totalCreated += result.created;
+    totalUpdated += result.updated;
     totalRevoked += result.revoked;
     totalReactivated += result.reactivated;
     totalUnchanged += result.unchanged;
@@ -222,6 +251,7 @@ export async function reconcileAllFileGrants(
     perFile.set(filename, result);
     allWrites.push(...writes);
     totalCreated += result.created;
+    totalUpdated += result.updated;
     totalRevoked += result.revoked;
     totalReactivated += result.reactivated;
     totalUnchanged += result.unchanged;
@@ -231,6 +261,7 @@ export async function reconcileAllFileGrants(
 
   return {
     totalCreated,
+    totalUpdated,
     totalRevoked,
     totalReactivated,
     totalUnchanged,

--- a/src/domain/access/grant_file_reconciler_test.ts
+++ b/src/domain/access/grant_file_reconciler_test.ts
@@ -506,3 +506,40 @@ Deno.test("reconcileAllFileGrants: no update when methods unchanged", async () =
   assertEquals(result.totalUpdated, 0);
   assertEquals(result.totalUnchanged, 1);
 });
+
+Deno.test("reconcileAllFileGrants: reactivation applies updated methods from file entry", async () => {
+  const revokedGrant = makeFileGrant({
+    source: "file:ops.yaml",
+    subject: { kind: "user", name: "monitor" },
+    actions: ["run"],
+    resource: { kind: "model", pattern: "@acme/my-model" },
+    methods: ["read"],
+    state: "revoked",
+  });
+  const existingGrants = new Map([
+    ["model-1", {
+      grant: revokedGrant,
+      modelId: "model-1",
+      instanceName: "inst-1",
+    }],
+  ]);
+  const store = createMockStore(existingGrants);
+
+  const entry: GrantFileEntry = {
+    subject: { kind: "user", name: "monitor" },
+    effect: "allow",
+    actions: ["run"],
+    resource: { kind: "model", pattern: "@acme/my-model" },
+    methods: ["read", "list"],
+  };
+
+  const fileEntries = new Map([["ops.yaml", [entry]]]);
+  const result = await reconcileAllFileGrants(fileEntries, store);
+
+  assertEquals(result.totalReactivated, 1);
+  assertEquals(result.totalUpdated, 0);
+
+  const reactivatedGrant = store.written.get("inst-1")!;
+  assertEquals(reactivatedGrant.state, "active");
+  assertEquals(reactivatedGrant.methods, ["read", "list"]);
+});

--- a/src/domain/access/grant_file_reconciler_test.ts
+++ b/src/domain/access/grant_file_reconciler_test.ts
@@ -436,3 +436,73 @@ Deno.test("reconcileAllFileGrants: does not touch other files' grants when one i
   assertEquals(revokedGrant.state, "revoked");
   assertEquals(store.written.has("inst-1"), false);
 });
+
+Deno.test("reconcileAllFileGrants: updates methods in place when identity matches", async () => {
+  const existingGrant = makeFileGrant({
+    source: "file:ops.yaml",
+    subject: { kind: "user", name: "monitor" },
+    actions: ["run"],
+    resource: { kind: "model", pattern: "@acme/my-model" },
+    methods: ["read"],
+  });
+  const existingGrants = new Map([
+    ["model-1", {
+      grant: existingGrant,
+      modelId: "model-1",
+      instanceName: "inst-1",
+    }],
+  ]);
+  const store = createMockStore(existingGrants);
+
+  const updatedEntry: GrantFileEntry = {
+    subject: { kind: "user", name: "monitor" },
+    effect: "allow",
+    actions: ["run"],
+    resource: { kind: "model", pattern: "@acme/my-model" },
+    methods: ["read", "list"],
+  };
+
+  const fileEntries = new Map([["ops.yaml", [updatedEntry]]]);
+  const result = await reconcileAllFileGrants(fileEntries, store);
+
+  assertEquals(result.totalUpdated, 1);
+  assertEquals(result.totalCreated, 0);
+  assertEquals(result.totalRevoked, 0);
+  assertEquals(result.totalUnchanged, 0);
+
+  const writtenGrant = store.written.get("inst-1")!;
+  assertEquals(writtenGrant.methods, ["read", "list"]);
+  assertEquals(writtenGrant.id, existingGrant.id);
+});
+
+Deno.test("reconcileAllFileGrants: no update when methods unchanged", async () => {
+  const existingGrant = makeFileGrant({
+    source: "file:ops.yaml",
+    subject: { kind: "user", name: "monitor" },
+    actions: ["run"],
+    resource: { kind: "model", pattern: "@acme/my-model" },
+    methods: ["list", "read"],
+  });
+  const existingGrants = new Map([
+    ["model-1", {
+      grant: existingGrant,
+      modelId: "model-1",
+      instanceName: "inst-1",
+    }],
+  ]);
+  const store = createMockStore(existingGrants);
+
+  const entry: GrantFileEntry = {
+    subject: { kind: "user", name: "monitor" },
+    effect: "allow",
+    actions: ["run"],
+    resource: { kind: "model", pattern: "@acme/my-model" },
+    methods: ["read", "list"],
+  };
+
+  const fileEntries = new Map([["ops.yaml", [entry]]]);
+  const result = await reconcileAllFileGrants(fileEntries, store);
+
+  assertEquals(result.totalUpdated, 0);
+  assertEquals(result.totalUnchanged, 1);
+});

--- a/src/domain/access/grant_file_test.ts
+++ b/src/domain/access/grant_file_test.ts
@@ -480,3 +480,31 @@ Deno.test("collectErrors: aggregates errors from all files", () => {
   const errors = collectErrors(results);
   assertEquals(errors.length, 3);
 });
+
+Deno.test("parseGrantFile: parses grant with methods field", () => {
+  const content = `
+grants:
+  - subject: "user:monitor"
+    effect: allow
+    actions: [run]
+    resource: "model:@acme/my-model"
+    methods: [read, list]
+`;
+  const result = parseGrantFile("monitor.yaml", content);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.entries[0].methods, ["read", "list"]);
+});
+
+Deno.test("parseGrantFile: methods field is optional", () => {
+  const content = `
+grants:
+  - subject: "user:adam"
+    effect: allow
+    actions: [run]
+    resource: "workflow:@acme/*"
+`;
+  const result = parseGrantFile("basic.yaml", content);
+  assertEquals(result.errors.length, 0);
+  assertEquals(result.entries[0].methods, undefined);
+});

--- a/src/domain/models/access/grant_model.ts
+++ b/src/domain/models/access/grant_model.ts
@@ -49,6 +49,7 @@ export const GrantSchema = z.object({
   actions: z.array(ActionSchema).min(1),
   resource: ResourceSelectorSchema,
   condition: z.string().optional(),
+  methods: z.array(z.string().min(1)).optional(),
   state: GrantStateSchema,
   source: GrantSourceSchema,
   createdBy: PrincipalSchema,
@@ -79,6 +80,9 @@ const CreateArgsSchema = z.object({
   ),
   condition: z.string().optional().describe(
     "Optional CEL condition over resource fields and principal context",
+  ),
+  methods: z.array(z.string().min(1)).optional().describe(
+    "Optional list of method names this grant applies to (omit for all methods)",
   ),
   source: GrantSourceSchema,
   createdBy: z.string().min(1).describe(
@@ -119,6 +123,7 @@ async function create(
     actions: args.actions,
     resource,
     condition: args.condition,
+    methods: args.methods,
     state: "active",
     source: args.source,
     createdBy,

--- a/src/domain/models/access/grant_model_test.ts
+++ b/src/domain/models/access/grant_model_test.ts
@@ -209,3 +209,32 @@ Deno.test("create: source field is set at creation and persisted", async () => {
   const revoked = store.get("grant-main") as unknown as Grant;
   assertEquals(revoked.source, "file:test.yaml");
 });
+
+Deno.test("create: stores methods field when provided", async () => {
+  const { context, store } = createTestContext();
+  await grantModel.methods.create.execute(
+    { ...VALID_CREATE_ARGS, methods: ["read", "list"] },
+    context,
+  );
+  const grant = store.get("grant-main") as unknown as Grant;
+  assertEquals(grant.methods, ["read", "list"]);
+});
+
+Deno.test("create: methods field is undefined when omitted", async () => {
+  const { context, store } = createTestContext();
+  await grantModel.methods.create.execute(VALID_CREATE_ARGS, context);
+  const grant = store.get("grant-main") as unknown as Grant;
+  assertEquals(grant.methods, undefined);
+});
+
+Deno.test("revoke: preserves methods field", async () => {
+  const { context, store } = createTestContext();
+  await grantModel.methods.create.execute(
+    { ...VALID_CREATE_ARGS, methods: ["read"] },
+    context,
+  );
+  await grantModel.methods.revoke.execute({}, context);
+  const revoked = store.get("grant-main") as unknown as Grant;
+  assertEquals(revoked.methods, ["read"]);
+  assertEquals(revoked.state, "revoked");
+});

--- a/src/infrastructure/cel/grant_condition_environment.ts
+++ b/src/infrastructure/cel/grant_condition_environment.ts
@@ -38,7 +38,7 @@ export interface GrantConditionValidationResult {
 
 const RESOURCE_FIELDS: Record<ResourceKind, string[]> = {
   workflow: ["name", "tags", "collective"],
-  model: ["name", "modelType", "tags", "collective"],
+  model: ["name", "modelType", "tags", "collective", "methodName"],
   data: ["name", "ns", "tags", "owner"],
   access: ["name"],
 };
@@ -250,7 +250,7 @@ function createGrantConditionEnvironment(kind: ResourceKind): Environment {
       field === "tags" || field === "owner"
         ? "map"
         : field === "name" || field === "ns" || field === "modelType" ||
-            field === "collective"
+            field === "collective" || field === "methodName"
         ? "string"
         : "dyn",
     );
@@ -334,6 +334,16 @@ export function validateGrantCondition(
   return { valid: true };
 }
 
+const FIELD_ZERO_VALUES: Record<string, unknown> = {
+  tags: {},
+  owner: {},
+  name: "",
+  ns: "",
+  modelType: "",
+  collective: "",
+  methodName: "",
+};
+
 export function evaluateGrantCondition(
   condition: string,
   resourceKind: ResourceKind,
@@ -342,7 +352,10 @@ export function evaluateGrantCondition(
 ): boolean {
   const env = createGrantConditionEnvironment(resourceKind);
 
-  const context: Record<string, unknown> = { ...resourceFields };
+  const context: Record<string, unknown> = {};
+  for (const field of RESOURCE_FIELDS[resourceKind]) {
+    context[field] = resourceFields[field] ?? FIELD_ZERO_VALUES[field] ?? "";
+  }
   context.principal = principalContext;
 
   const result = env.evaluate(condition, context);

--- a/src/infrastructure/cel/grant_condition_environment_test.ts
+++ b/src/infrastructure/cel/grant_condition_environment_test.ts
@@ -425,6 +425,9 @@ Deno.test("validateGrantCondition: all existing condition patterns pass cost bou
     ['name == "deploy"', "workflow"],
     ['collective == "acme"', "workflow"],
     ['modelType == "aws/ec2"', "model"],
+    ['methodName == "read"', "model"],
+    ['methodName in ["read", "list"]', "model"],
+    ['methodName == "read" && modelType == "aws/ec2"', "model"],
     ['ns == "infra" && tags.env == "prod"', "data"],
     ["owner.createdBy == principal.sub", "data"],
     ['name == "admin-grant"', "access"],
@@ -441,4 +444,56 @@ Deno.test("validateGrantCondition: all existing condition patterns pass cost bou
     );
     assertEquals(result, { valid: true }, `Failed for: ${condition}`);
   }
+});
+
+Deno.test("evaluateGrantCondition: methodName matches when present", () => {
+  const result = evaluateGrantCondition(
+    'methodName == "read"',
+    "model",
+    {
+      name: "my-model",
+      modelType: "aws/ec2",
+      tags: {},
+      collective: "",
+      methodName: "read",
+    },
+    PRINCIPAL,
+  );
+  assertEquals(result, true);
+});
+
+Deno.test("evaluateGrantCondition: methodName does not match wrong value", () => {
+  const result = evaluateGrantCondition(
+    'methodName == "read"',
+    "model",
+    {
+      name: "my-model",
+      modelType: "aws/ec2",
+      tags: {},
+      collective: "",
+      methodName: "create",
+    },
+    PRINCIPAL,
+  );
+  assertEquals(result, false);
+});
+
+Deno.test("evaluateGrantCondition: absent methodName defaults to empty string", () => {
+  const result = evaluateGrantCondition(
+    'methodName == "read"',
+    "model",
+    { name: "my-model", modelType: "aws/ec2", tags: {}, collective: "" },
+    PRINCIPAL,
+  );
+  assertEquals(result, false);
+});
+
+Deno.test("evaluateGrantCondition: absent field does not throw", () => {
+  const result = evaluateGrantCondition(
+    'methodName == ""',
+    "model",
+    { name: "my-model" },
+    PRINCIPAL,
+  );
+  assertEquals(result, true);
 });

--- a/src/presentation/renderers/access_grant.ts
+++ b/src/presentation/renderers/access_grant.ts
@@ -50,8 +50,8 @@ class LogAccessGrantListRenderer implements AccessGrantListRenderer {
     const header = `${"ID".padEnd(idDisplay)}  ${"SUBJECT".padEnd(28)}  ${
       "EFFECT".padEnd(6)
     }  ${"ACTIONS".padEnd(20)}  ${"RESOURCE".padEnd(28)}  ${
-      "CONDITION".padEnd(20)
-    }  SOURCE`;
+      "METHODS".padEnd(16)
+    }  ${"CONDITION".padEnd(20)}  SOURCE`;
     writeOutput(header);
 
     for (const grant of grants) {
@@ -60,10 +60,11 @@ class LogAccessGrantListRenderer implements AccessGrantListRenderer {
       const effect = grant.effect.padEnd(6);
       const actions = grant.actions.join(",").padEnd(20);
       const resource = formatResource(grant.resource).padEnd(28);
+      const methods = (grant.methods?.join(",") ?? "*").padEnd(16);
       const condition = (grant.condition ?? "").padEnd(20);
       const source = grant.source;
       writeOutput(
-        `${id}  ${subject}  ${effect}  ${actions}  ${resource}  ${condition}  ${source}`,
+        `${id}  ${subject}  ${effect}  ${actions}  ${resource}  ${methods}  ${condition}  ${source}`,
       );
     }
   }

--- a/src/presentation/renderers/access_grant_test.ts
+++ b/src/presentation/renderers/access_grant_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertStringIncludes } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { createAccessGrantListRenderer } from "./access_grant.ts";
 import type { Grant } from "../../domain/models/access/grant_model.ts";
 
@@ -177,4 +177,46 @@ Deno.test("accessGrantListRenderer log: works without display names argument", (
     console.log = origLog;
   }
   assertStringIncludes(output[1], "user:adam");
+});
+
+Deno.test("accessGrantListRenderer log: shows methods when present", () => {
+  const renderer = createAccessGrantListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render([makeGrant({ methods: ["read", "list"] })]);
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[0], "METHODS");
+  assertStringIncludes(output[1], "read,list");
+});
+
+Deno.test("accessGrantListRenderer log: shows * when methods omitted", () => {
+  const renderer = createAccessGrantListRenderer("log");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render([makeGrant()]);
+  } finally {
+    console.log = origLog;
+  }
+  assertStringIncludes(output[0], "METHODS");
+  assertStringIncludes(output[1], "*");
+});
+
+Deno.test("accessGrantListRenderer json: includes methods in JSON output", () => {
+  const renderer = createAccessGrantListRenderer("json");
+  const output: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  try {
+    renderer.render([makeGrant({ methods: ["read", "list"] })]);
+  } finally {
+    console.log = origLog;
+  }
+  const parsed = JSON.parse(output.join(""));
+  assertEquals(parsed[0].methods, ["read", "list"]);
 });

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -259,6 +259,7 @@ const AccessCanIRequestSchema = z.object({
   payload: z.object({
     action: z.string().optional(),
     resource: z.string().optional(),
+    method: z.string().optional(),
     collectives: z.array(z.string()).optional(),
   }).refine(
     (p) => !!p.action === !!p.resource,

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -471,11 +471,15 @@ export function handleAccessCanI(
       }
 
       const resource = parseResourceSelector(payload.resource);
+      const fields: Record<string, unknown> = {};
+      if (payload.method) {
+        fields.methodName = payload.method;
+      }
       const service = ctx.policySnapshotLoader.decisionService;
       const decisions = service.explain(
         accessPrincipal,
         actionResult.data,
-        { kind: resource.kind, name: resource.pattern, fields: {} },
+        { kind: resource.kind, name: resource.pattern, fields },
       );
 
       send(socket, {
@@ -517,6 +521,9 @@ export function handleAccessCanI(
               grantId: g.id,
               via: `${g.subject.kind}:${g.subject.name}`,
               ...(g.condition ? { condition: g.condition } : {}),
+              ...(g.methods && g.methods.length > 0
+                ? { methods: g.methods }
+                : {}),
             }))
           ),
         },

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -139,6 +139,7 @@ export async function handleModelMethodRun(
         const tags = preResult.definition.tags;
         if (tags && Object.keys(tags).length > 0) modelFields.tags = tags;
       }
+      modelFields.methodName = payload.methodName;
 
       if (
         isAdminOnlyModelType(

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -326,6 +326,7 @@ export async function handleModelMethodRun(
     const tags = preResult.definition.tags;
     if (tags && Object.keys(tags).length > 0) modelFields.tags = tags;
   }
+  modelFields.methodName = payload.methodName;
 
   if (
     isAdminOnlyModelType(

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -86,6 +86,7 @@ export interface AccessCheckPayload {
 export interface AccessCanIPayload {
   action?: string;
   resource?: string;
+  method?: string;
   collectives?: string[];
   groups?: string[];
 }


### PR DESCRIPTION
## Summary

- Adds an optional `methods` field to the Grant schema so grants can restrict which model methods a principal may invoke (e.g., allow `read` but not `create`)
- Adds `methodName` as a CEL condition variable for model resources, enabling compound expressions like `methodName in ["read", "list"]`
- Adds `--methods` flag to `swamp access grant create` and `--method` flag to `swamp access can-i`
- Adds update-in-place path to the grant file reconciler for methods changes (avoids unnecessary revoke+create churn)
- Adds defensive zero-value defaulting for absent CEL fields to prevent `Unknown variable` errors

Closes #1994

## Test Plan

- 26 new tests across unit, integration, and CLI levels
- Decision service: methods match/no-match/undefined-means-all/empty-means-all/deny/explain (7 tests)
- CEL environment: methodName evaluation, absent field defaulting (4 tests)
- Grant model: create with/without methods, revoke preserves methods (3 tests)
- Grant file: parse with methods, optional field (2 tests)
- Reconciler: update-in-place when methods change, no-op when unchanged (2 tests)
- Renderer: log output with/without methods, JSON serialization (3 tests)
- CLI: --methods and --method option registration (2 tests)
- Integration: full pipeline from grant file → decision service → CEL (9 tests)
- Full test suite passes (11,071 tests, 2 pre-existing worktree flakes unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)