### PR TITLE
fix(expressions): remove data.latest() cache so reads are always live

### DIFF
--- a/src/domain/expressions/model_resolver.ts
+++ b/src/domain/expressions/model_resolver.ts
@@ -260,9 +260,8 @@ export interface DataNamespace {
   ): Promise<DataRecord[] | unknown[]>;
 
   /**
-   * Invalidate the cached `latest()` result for a specific model+data
-   * coordinate so subsequent reads re-fetch from disk. Called by the
-   * workflow engine after a step writes data.
+   * No-op — retained for interface compatibility. `latest()` always reads
+   * from disk so there is no cache to invalidate.
    */
   invalidateLatest?(modelName: string, dataName: string): void;
 }
@@ -788,7 +787,6 @@ export class ModelResolver {
     ownNamespace: Namespace,
     coordsMap: ModelCoordinatesMap,
   ): DataNamespace {
-    const latestCache = new Map<string, DataRecord | null>();
     return {
       version: async (
         rawModelName: string,
@@ -817,12 +815,6 @@ export class ModelResolver {
         const ns = routeNamespace(rawModelName, ownNamespace);
 
         if (!ns.isWildcard) {
-          const nsForKey = ns.namespacePredicate
-            ? (ns.namespacePredicate.match(/ns == "([^"]*)"/)?.[1] ?? "")
-            : ownNamespace;
-          const cacheKey = `${nsForKey}\0${ns.modelName}\0${dataName}`;
-          if (latestCache.has(cacheKey)) return latestCache.get(cacheKey)!;
-
           const coords = coordsMap.get(ns.modelName);
           if (coords && coords.length > 0) {
             for (const { modelType, modelId } of coords) {
@@ -864,7 +856,6 @@ export class ModelResolver {
                     // Vault unavailable — leave refs unresolved
                   }
                 }
-                latestCache.set(cacheKey, record);
                 return record;
               }
             }
@@ -876,16 +867,13 @@ export class ModelResolver {
                 /ns == "([^"]*)"/,
               )?.[1]
               : (ownNamespace || undefined);
-            const record = await this.dataQueryService.getLatestRecord(
+            return await this.dataQueryService.getLatestRecord(
               ns.modelName,
               dataName,
               targetNs,
             );
-            latestCache.set(cacheKey, record);
-            return record;
           }
 
-          latestCache.set(cacheKey, null);
           return null;
         }
 
@@ -965,13 +953,8 @@ export class ModelResolver {
         if (!this.dataQueryService) return [];
         return await this.dataQueryService.query(predicate, { select });
       },
-      invalidateLatest: (modelName: string, dataName: string): void => {
-        const suffix = `\0${modelName}\0${dataName}`;
-        for (const key of latestCache.keys()) {
-          if (key.endsWith(suffix)) {
-            latestCache.delete(key);
-          }
-        }
+      invalidateLatest: (_modelName: string, _dataName: string): void => {
+        // No-op — latest() always reads from disk; no cache to invalidate.
       },
     };
   }

--- a/src/domain/expressions/model_resolver_test.ts
+++ b/src/domain/expressions/model_resolver_test.ts
@@ -1334,10 +1334,10 @@ Deno.test("workers.connected() returns empty array when all workers disconnected
 });
 
 // ============================================================================
-// invalidateLatest() causes re-read of written coordinate
+// latest() always returns fresh data from disk (no caching)
 // ============================================================================
 
-Deno.test("invalidateLatest: re-reads coordinate after invalidation", async () => {
+Deno.test("latest: returns fresh data after intervening write", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);
     const defRepo = new YamlDefinitionRepository(repoDir);
@@ -1350,7 +1350,7 @@ Deno.test("invalidateLatest: re-reads coordinate after invalidation", async () =
     const type = ModelType.create("test/model");
 
     const model = Definition.create({
-      name: "cached-model",
+      name: "live-model",
       globalArguments: {},
     });
     await defRepo.save(type, model);
@@ -1360,7 +1360,7 @@ Deno.test("invalidateLatest: re-reads coordinate after invalidation", async () =
       contentType: "application/json",
       lifetime: "infinite",
       garbageCollection: 10,
-      tags: { type: "resource", modelName: "cached-model" },
+      tags: { type: "resource", modelName: "live-model" },
       ownerDefinition: owner,
     });
     await dataRepo.save(
@@ -1381,7 +1381,7 @@ Deno.test("invalidateLatest: re-reads coordinate after invalidation", async () =
     const ctx = await resolver.buildContext();
     assertExists(ctx.data);
 
-    const first = await ctx.data.latest("cached-model", "result");
+    const first = await ctx.data.latest("live-model", "result");
     assertExists(first);
     assertEquals(first.attributes.value, "old");
 
@@ -1392,123 +1392,14 @@ Deno.test("invalidateLatest: re-reads coordinate after invalidation", async () =
       new TextEncoder().encode(JSON.stringify({ value: "new" })),
     );
 
-    const stale = await ctx.data.latest("cached-model", "result");
-    assertExists(stale);
-    assertEquals(stale.attributes.value, "old");
-
-    ctx.data.invalidateLatest!("cached-model", "result");
-
-    const fresh = await ctx.data.latest("cached-model", "result");
+    const fresh = await ctx.data.latest("live-model", "result");
     assertExists(fresh);
     assertEquals(fresh.attributes.value, "new");
     catalog.close();
   });
 });
 
-// ============================================================================
-// invalidateLatest() only affects the targeted coordinate
-// ============================================================================
-
-Deno.test("invalidateLatest: other coordinates remain cached", async () => {
-  await withTempDir(async (repoDir) => {
-    await setupRepoDir(repoDir);
-    const defRepo = new YamlDefinitionRepository(repoDir);
-    const catalog = new CatalogStore(join(repoDir, "_catalog.db"));
-    const dataRepo = new FileSystemUnifiedDataRepository(
-      repoDir,
-      undefined,
-      catalog,
-    );
-    const type = ModelType.create("test/model");
-
-    const modelA = Definition.create({
-      name: "model-a",
-      globalArguments: {},
-    });
-    await defRepo.save(type, modelA);
-
-    const modelB = Definition.create({
-      name: "model-b",
-      globalArguments: {},
-    });
-    await defRepo.save(type, modelB);
-
-    const dataA = Data.create({
-      name: "result",
-      contentType: "application/json",
-      lifetime: "infinite",
-      garbageCollection: 10,
-      tags: { type: "resource", modelName: "model-a" },
-      ownerDefinition: owner,
-    });
-    await dataRepo.save(
-      type,
-      modelA.id,
-      dataA,
-      new TextEncoder().encode(JSON.stringify({ from: "a-v1" })),
-    );
-
-    const dataB = Data.create({
-      name: "result",
-      contentType: "application/json",
-      lifetime: "infinite",
-      garbageCollection: 10,
-      tags: { type: "resource", modelName: "model-b" },
-      ownerDefinition: owner,
-    });
-    await dataRepo.save(
-      type,
-      modelB.id,
-      dataB,
-      new TextEncoder().encode(JSON.stringify({ from: "b-v1" })),
-    );
-
-    const dqs = new DataQueryService(catalog, dataRepo);
-    await dqs.query('name == ""');
-
-    const resolver = new ModelResolver(defRepo, {
-      repoDir,
-      dataRepo,
-      dataQueryService: dqs,
-    });
-    const ctx = await resolver.buildContext();
-    assertExists(ctx.data);
-
-    await ctx.data.latest("model-a", "result");
-    await ctx.data.latest("model-b", "result");
-
-    await dataRepo.save(
-      type,
-      modelA.id,
-      dataA,
-      new TextEncoder().encode(JSON.stringify({ from: "a-v2" })),
-    );
-    await dataRepo.save(
-      type,
-      modelB.id,
-      dataB,
-      new TextEncoder().encode(JSON.stringify({ from: "b-v2" })),
-    );
-
-    ctx.data.invalidateLatest!("model-a", "result");
-
-    const freshA = await ctx.data.latest("model-a", "result");
-    assertExists(freshA);
-    assertEquals(freshA.attributes.from, "a-v2");
-
-    const staleB = await ctx.data.latest("model-b", "result");
-    assertExists(staleB);
-    assertEquals(staleB.attributes.from, "b-v1");
-
-    catalog.close();
-  });
-});
-
-// ============================================================================
-// invalidateLatest() clears cached null (miss)
-// ============================================================================
-
-Deno.test("invalidateLatest: clears cached null so new data is visible", async () => {
+Deno.test("latest: returns data written after initial miss", async () => {
   await withTempDir(async (repoDir) => {
     await setupRepoDir(repoDir);
     const defRepo = new YamlDefinitionRepository(repoDir);
@@ -1554,11 +1445,6 @@ Deno.test("invalidateLatest: clears cached null so new data is visible", async (
       data,
       new TextEncoder().encode(JSON.stringify({ appeared: true })),
     );
-
-    const stillNull = await ctx.data.latest("late-writer", "result");
-    assertEquals(stillNull, null);
-
-    ctx.data.invalidateLatest!("late-writer", "result");
 
     const found = await ctx.data.latest("late-writer", "result");
     assertExists(found);

--- a/src/domain/workflows/execution_service.ts
+++ b/src/domain/workflows/execution_service.ts
@@ -3176,17 +3176,6 @@ export class WorkflowExecutionService {
           }
         }
 
-        // Invalidate data.latest() cache entries for data written by this
-        // step so subsequent steps (and their guards) see fresh values.
-        if (stepExprContext?.data?.invalidateLatest && stepDataHandles) {
-          for (const handle of stepDataHandles) {
-            const modelName = handle.tags["modelName"];
-            if (modelName) {
-              stepExprContext.data.invalidateLatest(modelName, handle.name);
-            }
-          }
-        }
-
         // Update expression context for subsequent steps (only when not using --last-evaluated)
         if (stepExprContext && taskOutput.model) {
           // Create model entry if it doesn't exist


### PR DESCRIPTION
## Summary

- Remove the `latestCache` from `ModelResolver.buildDataNamespace()` so `data.latest()` always reads from disk, restoring the documented contract (`design/enablers/expressions.md`: "read directly from disk on every call with no cache staleness")
- Fix stale reads across nested workflow boundaries — a child workflow's writes were invisible to the parent's `data.latest()` because each nesting level had an independent cache
- Retain `invalidateLatest` on `DataNamespace` as a no-op for interface compatibility; remove the call site from `WorkflowExecutionService`

Fixes swamp-club#1995

## Test plan

- [x] Unit tests verify `latest()` returns fresh data after intervening writes (no caching)
- [x] Unit tests verify `latest()` returns data written after initial null miss
- [x] Type check passes
- [x] Full test suite passes (49.6s)
- [x] Code review: VERDICT pass
- [x] Adversarial review: VERDICT pass
- [x] Compile + binary check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>