### PR TITLE
fix(serve): skip write locks for non-mutating model method invocations

### DIFF
--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -37,7 +37,11 @@ import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
 import { getAutoResolver } from "../auto_resolver_context.ts";
 import { DefaultMethodExecutionService } from "../../domain/models/method_execution_service.ts";
-import { modelRegistry } from "../../domain/models/model.ts";
+import {
+  inferMethodKind,
+  isMutatingKind,
+  modelRegistry,
+} from "../../domain/models/model.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
 import { reportRegistry } from "../../domain/reports/report_registry.ts";
 import { VaultService } from "../../domain/vaults/vault_service.ts";
@@ -420,21 +424,38 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
           modelIdOrName,
         );
         let flushModelLocks: (() => Promise<void>) | null = null;
+        let mutating = true;
         if (preResult) {
-          const lockResult = await acquireModelLocks(
-            datastoreConfig,
-            [
-              {
-                modelType: preResult.type.normalized,
-                modelId: preResult.definition.id,
-              },
-            ],
-            repoDir,
-            syncService,
-            repoContext.catalogStore,
-          );
-          if (lockResult.synced) repoContext.catalogStore.invalidate();
-          flushModelLocks = lockResult.flush;
+          try {
+            const modelDef = await resolveModelType(
+              preResult.type.normalized,
+              getAutoResolver(),
+            );
+            if (modelDef) {
+              const method = modelDef.methods[methodName];
+              mutating = isMutatingKind(
+                inferMethodKind(methodName, method),
+              );
+            }
+          } catch {
+            // Resolution failure — fall back to acquiring locks
+          }
+          if (mutating) {
+            const lockResult = await acquireModelLocks(
+              datastoreConfig,
+              [
+                {
+                  modelType: preResult.type.normalized,
+                  modelId: preResult.definition.id,
+                },
+              ],
+              repoDir,
+              syncService,
+              repoContext.catalogStore,
+            );
+            if (lockResult.synced) repoContext.catalogStore.invalidate();
+            flushModelLocks = lockResult.flush;
+          }
         }
 
         const initiatedBy = await resolveCliInitiatedBy();

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -93,7 +93,13 @@ import {
   type Principal,
   principalToString,
 } from "../../domain/access/principal.ts";
-import { modelRegistry } from "../../domain/models/model.ts";
+import {
+  inferMethodKind,
+  isMutatingKind,
+  modelRegistry,
+} from "../../domain/models/model.ts";
+import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
+import { getAutoResolver } from "../../domain/extensions/auto_resolver_context.ts";
 import { RegistryCapacityError } from "../active_run_registry.ts";
 import { RunEventBuffer } from "../run_event_buffer.ts";
 import { deleteActiveRun, writeActiveRun } from "../active_run_tracker.ts";
@@ -115,6 +121,20 @@ const logger = getSwampLogger(["serve", "connection"]);
 
 const DEFAULT_BUFFER_CAPACITY = 10_000;
 
+export async function isMethodMutating(
+  modelType: string,
+  methodName: string,
+): Promise<boolean> {
+  try {
+    const modelDef = await resolveModelType(modelType, getAutoResolver());
+    if (!modelDef) return true;
+    const method = modelDef.methods[methodName];
+    return isMutatingKind(inferMethodKind(methodName, method));
+  } catch {
+    return true;
+  }
+}
+
 export async function handleModelMethodRun(
   socket: WebSocket,
   ctx: ConnectionContext,
@@ -126,6 +146,7 @@ export async function handleModelMethodRun(
   const registry = ctx.activeRunRegistry;
   if (!registry) {
     let flushLocks: (() => Promise<void>) | null = null;
+    let mutating = true;
     const initiatedBy = principal ? principalToString(principal) : "ghost";
     const telemetry = createCommandTelemetry(initiatedBy);
     try {
@@ -181,18 +202,24 @@ export async function handleModelMethodRun(
       }
 
       if (preResult) {
-        const lockResult = await acquireModelLocks(
-          ctx.datastoreConfig,
-          [{
-            modelType: preResult.type.normalized,
-            modelId: preResult.definition.id,
-          }],
-          ctx.repoDir,
-          ctx.syncService,
-          ctx.repoContext.catalogStore,
+        mutating = await isMethodMutating(
+          preResult.type.normalized,
+          payload.methodName,
         );
-        if (lockResult.synced) ctx.repoContext.catalogStore.invalidate();
-        flushLocks = lockResult.flush;
+        if (mutating) {
+          const lockResult = await acquireModelLocks(
+            ctx.datastoreConfig,
+            [{
+              modelType: preResult.type.normalized,
+              modelId: preResult.definition.id,
+            }],
+            ctx.repoDir,
+            ctx.syncService,
+            ctx.repoContext.catalogStore,
+          );
+          if (lockResult.synced) ctx.repoContext.catalogStore.invalidate();
+          flushLocks = lockResult.flush;
+        }
       }
 
       const isDirectExecution = payload.typeArg !== undefined;
@@ -253,7 +280,7 @@ export async function handleModelMethodRun(
       } else {
         await runMethod();
       }
-      if (ctx.syncService && !flushLocks) {
+      if (ctx.syncService && !flushLocks && mutating) {
         const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
           ? ctx.datastoreConfig.namespace
           : undefined;
@@ -410,10 +437,14 @@ export async function handleModelMethodRun(
 
   const detachedTelemetry = createCommandTelemetry(initiatedBy);
 
+  const detachedMutating = preResult
+    ? await isMethodMutating(preResult.type.normalized, payload.methodName)
+    : true;
+
   (async () => {
     let flushLocks: (() => Promise<void>) | null = null;
     try {
-      if (preResult) {
+      if (preResult && detachedMutating) {
         const lockResult = await acquireModelLocks(
           ctx.datastoreConfig,
           [{
@@ -483,7 +514,7 @@ export async function handleModelMethodRun(
         await doRun();
       }
 
-      if (ctx.syncService && !flushLocks) {
+      if (ctx.syncService && !flushLocks && detachedMutating) {
         const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
           ? ctx.datastoreConfig.namespace
           : undefined;

--- a/src/serve/handlers/model_handlers_test.ts
+++ b/src/serve/handlers/model_handlers_test.ts
@@ -1,0 +1,171 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { z } from "zod";
+import { isMethodMutating } from "./model_handlers.ts";
+import { modelRegistry } from "../../domain/models/model.ts";
+import { ModelType } from "../../domain/models/model_type.ts";
+
+const TEST_TYPE = ModelType.create("test/lock-check");
+
+function registerTestModel(methods: Record<string, { kind?: string }>) {
+  const methodDefs: Record<
+    string,
+    {
+      description: string;
+      kind?: "read" | "list" | "create" | "update" | "delete" | "action";
+      arguments: z.ZodTypeAny;
+      execute: () => Promise<Record<string, unknown>>;
+    }
+  > = {};
+  for (const [name, config] of Object.entries(methods)) {
+    methodDefs[name] = {
+      description: `test method ${name}`,
+      ...(config.kind
+        ? {
+          kind: config.kind as
+            | "read"
+            | "list"
+            | "create"
+            | "update"
+            | "delete"
+            | "action",
+        }
+        : {}),
+      arguments: z.object({}),
+      execute: () => Promise.resolve({}),
+    };
+  }
+  modelRegistry.register({
+    type: TEST_TYPE,
+    version: "2026.01.01.1",
+    methods: methodDefs,
+  });
+}
+
+function cleanup() {
+  modelRegistry.invalidateType(TEST_TYPE);
+}
+
+Deno.test("isMethodMutating: returns false for method with kind 'read'", async () => {
+  registerTestModel({ status: { kind: "read" } });
+  try {
+    assertEquals(await isMethodMutating(TEST_TYPE.normalized, "status"), false);
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("isMethodMutating: returns false for method with kind 'list'", async () => {
+  registerTestModel({ search: { kind: "list" } });
+  try {
+    assertEquals(await isMethodMutating(TEST_TYPE.normalized, "search"), false);
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("isMethodMutating: returns true for method with kind 'create'", async () => {
+  registerTestModel({ provision: { kind: "create" } });
+  try {
+    assertEquals(
+      await isMethodMutating(TEST_TYPE.normalized, "provision"),
+      true,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("isMethodMutating: returns true for method with kind 'update'", async () => {
+  registerTestModel({ patch: { kind: "update" } });
+  try {
+    assertEquals(await isMethodMutating(TEST_TYPE.normalized, "patch"), true);
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("isMethodMutating: returns true for method with kind 'action'", async () => {
+  registerTestModel({ deploy: { kind: "action" } });
+  try {
+    assertEquals(await isMethodMutating(TEST_TYPE.normalized, "deploy"), true);
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("isMethodMutating: returns true for method with no kind and unrecognized name", async () => {
+  registerTestModel({ custom_process: {} });
+  try {
+    assertEquals(
+      await isMethodMutating(TEST_TYPE.normalized, "custom_process"),
+      true,
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("isMethodMutating: infers 'read' from name 'get' without explicit kind", async () => {
+  registerTestModel({ get: {} });
+  try {
+    assertEquals(await isMethodMutating(TEST_TYPE.normalized, "get"), false);
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("isMethodMutating: infers 'list' from name 'list' without explicit kind", async () => {
+  registerTestModel({ list: {} });
+  try {
+    assertEquals(await isMethodMutating(TEST_TYPE.normalized, "list"), false);
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("isMethodMutating: returns true for method with kind 'delete'", async () => {
+  registerTestModel({ purge: { kind: "delete" } });
+  try {
+    assertEquals(await isMethodMutating(TEST_TYPE.normalized, "purge"), true);
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("isMethodMutating: returns true for unknown model type", async () => {
+  assertEquals(
+    await isMethodMutating("nonexistent/model-type", "get"),
+    true,
+  );
+});
+
+Deno.test("isMethodMutating: returns true for unknown method on known model", async () => {
+  registerTestModel({ run: { kind: "action" } });
+  try {
+    assertEquals(
+      await isMethodMutating(TEST_TYPE.normalized, "nonexistent"),
+      true,
+    );
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- Skip `acquireModelLocks` for non-mutating model methods (read/list kind) in both serve handlers and the CLI path
- Guard the fallback sync push (`markDirty` + `pushChanged`) to also skip for read methods
- Add `isMethodMutating` helper that resolves the model type definition and checks method kind via `inferMethodKind`/`isMutatingKind`, with safe fallback to mutating on resolution failure

Fixes swamp-club#1992

## Details

`model_handlers.ts` called `acquireModelLocks` on every method invocation, including pure-read methods like `status`. This caused concurrent read-only calls to block behind in-progress writes on the same model instance. The domain already distinguishes read from write methods via `MethodKind` and `isMutatingKind()` — this change wires that into the lock acquisition decision.

Methods with `kind: "read"` or `kind: "list"` (either explicit or name-inferred) now skip lock acquisition entirely. Unknown method kinds default to mutating (safe).

## Test plan

- [x] 11 unit tests for `isMethodMutating` covering all `MethodKind` values, name inference, unknown types, and unknown methods
- [x] `deno check` passes
- [x] `deno lint` and `deno fmt` pass
- [x] Full test suite passes
- [x] Compile + binary check passes
- [x] Code review, adversarial review, and UX review all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)