### PR TITLE
fix(models): widen isUuid() to accept all RFC UUID versions (swamp-club#1999)

### DIFF
--- a/src/domain/models/model_lookup.ts
+++ b/src/domain/models/model_lookup.ts
@@ -24,10 +24,10 @@ import { createDefinitionId } from "../definitions/definition.ts";
 import type { DefinitionRepository } from "../definitions/repositories.ts";
 
 /**
- * UUID v4 regex pattern for detecting if an argument is a UUID.
+ * UUID regex pattern for detecting if an argument is a UUID (versions 1-8).
  */
 const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /**
  * Partial ID pattern - at least 3 hex characters (with optional dashes).
@@ -36,7 +36,7 @@ const UUID_PATTERN =
 const PARTIAL_ID_PATTERN = /^[0-9a-f-]{3,}$/i;
 
 /**
- * Checks if a string looks like a UUID v4.
+ * Checks if a string looks like a UUID.
  */
 export function isUuid(value: string): boolean {
   return UUID_PATTERN.test(value);

--- a/src/domain/models/model_lookup_test.ts
+++ b/src/domain/models/model_lookup_test.ts
@@ -51,6 +51,17 @@ Deno.test("isUuid returns true for valid UUID v4", () => {
   assertEquals(isUuid("f47ac10b-58cc-4372-a567-0e02b2c3d479"), true);
 });
 
+Deno.test("isUuid returns true for non-v4 UUID versions", () => {
+  // UUIDv1
+  assertEquals(isUuid("550e8400-e29b-11d4-a716-446655440000"), true);
+  // UUIDv3
+  assertEquals(isUuid("550e8400-e29b-31d4-a716-446655440000"), true);
+  // UUIDv5 (from issue #1999)
+  assertEquals(isUuid("de8ad612-90b7-56bc-82dc-ba90e425e6f6"), true);
+  // UUIDv7
+  assertEquals(isUuid("01929b6e-f83d-7f32-8eb2-3a1f0b5e4c9d"), true);
+});
+
 Deno.test("isUuid is case insensitive", () => {
   assertEquals(isUuid("550E8400-E29B-41D4-A716-446655440000"), true);
   assertEquals(isUuid("550e8400-E29B-41d4-a716-446655440000"), true);
@@ -68,9 +79,9 @@ Deno.test("isUuid returns false for invalid UUIDs", () => {
   // Wrong format (missing dashes)
   assertEquals(isUuid("550e8400e29b41d4a716446655440000"), false);
 
-  // Not a v4 UUID (version digit is not 4)
-  assertEquals(isUuid("550e8400-e29b-11d4-a716-446655440000"), false);
-  assertEquals(isUuid("550e8400-e29b-51d4-a716-446655440000"), false);
+  // Invalid version digit (0 and 9+ are not valid UUID versions)
+  assertEquals(isUuid("550e8400-e29b-01d4-a716-446655440000"), false);
+  assertEquals(isUuid("550e8400-e29b-91d4-a716-446655440000"), false);
 
   // Invalid variant (4th group must start with 8, 9, a, or b)
   assertEquals(isUuid("550e8400-e29b-41d4-0716-446655440000"), false);

--- a/src/libswamp/workflows/delete.ts
+++ b/src/libswamp/workflows/delete.ts
@@ -33,7 +33,7 @@ import { notFound, validationFailed } from "../errors.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function isUuid(value: string): boolean {
   return UUID_PATTERN.test(value);

--- a/src/libswamp/workflows/edit.ts
+++ b/src/libswamp/workflows/edit.ts
@@ -40,10 +40,10 @@ import {
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 /**
- * UUID v4 regex pattern for detecting if an argument is a UUID.
+ * UUID regex pattern for detecting if an argument is a UUID (versions 1-8).
  */
 const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function isUuid(value: string): boolean {
   return UUID_PATTERN.test(value);

--- a/src/libswamp/workflows/get.ts
+++ b/src/libswamp/workflows/get.ts
@@ -83,10 +83,10 @@ export interface WorkflowGetDeps {
 }
 
 /**
- * UUID v4 regex pattern for detecting if an argument is a UUID.
+ * UUID regex pattern for detecting if an argument is a UUID (versions 1-8).
  */
 const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /** Wires real infrastructure into WorkflowGetDeps. */
 export function createWorkflowGetDeps(

--- a/src/libswamp/workflows/validate.ts
+++ b/src/libswamp/workflows/validate.ts
@@ -37,9 +37,9 @@ import { zodToJsonSchema } from "../types/schema_helpers.ts";
 
 import { withGeneratorSpan } from "../../infrastructure/tracing/mod.ts";
 import { type BrokenWorkflow, listBrokenWorkflows } from "./broken_workflow.ts";
-/** UUID v4 regex pattern for detecting if an argument is a UUID. */
+/** UUID regex pattern for detecting if an argument is a UUID (versions 1-8). */
 const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /** Checks if a string looks like a UUID. */
 export function isUuid(value: string): boolean {


### PR DESCRIPTION
## Summary

- Widen `UUID_PATTERN` regex from v4-only (`4[0-9a-f]{3}`) to versions 1-8 (`[1-8][0-9a-f]{3}`) in all 5 files where it is defined
- Fixes debug log flooding in `getContent`/`findAllForModel` for deterministic UUIDv5 model IDs
- Fixes incorrect name-based routing in `resolveModelId` and workflow operations for non-v4 UUIDs

## Details

`isUuid()` hardcoded the version nibble to `4`, rejecting valid v1/v3/v5/v7/v8 UUIDs. This caused `@hivemq/asdlc`'s deterministic UUIDv5 model IDs (`uuidv5(sha1("<type>/<name>"))`) to trip the "called with model name instead of UUID" debug warning on every read, and to route through `findByName` instead of `findById`.

The fix widens the version nibble to `[1-8]` (covering RFC 4122 v1-5 and RFC 9562 v6-8) while preserving the RFC variant bits check (`[89ab]`). Nil UUID (v0) and reserved versions (9+) remain excluded.

### Files changed

| File | Change |
|------|--------|
| `src/domain/models/model_lookup.ts` | Widen pattern, update JSDoc |
| `src/libswamp/workflows/get.ts` | Widen pattern, update JSDoc |
| `src/libswamp/workflows/validate.ts` | Widen pattern, update JSDoc |
| `src/libswamp/workflows/delete.ts` | Widen pattern |
| `src/libswamp/workflows/edit.ts` | Widen pattern, update JSDoc |
| `src/domain/models/model_lookup_test.ts` | Add v1/v3/v5/v7 positive tests, fix negative tests |

## Test plan

- [x] Existing `isUuid` tests updated — v1/v5 assertions flipped from false to true
- [x] New test cases for UUIDv1, v3, v5, v7 added
- [x] Negative tests updated to use v0 and v9 as invalid versions
- [x] All unit tests pass (`deno run test`)
- [x] Verification workflow: lint, fmt, type-check, tests, compile, all agent reviews pass

Closes swamp-club#1999

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Blake Irvin <blakeirvin@me.com>