### PR TITLE
fix(persistence): guard against null parseYaml returns in YAML repositories

### DIFF
--- a/src/infrastructure/persistence/extension_workflow_repository.ts
+++ b/src/infrastructure/persistence/extension_workflow_repository.ts
@@ -80,7 +80,8 @@ export class ExtensionWorkflowRepository implements WorkflowRepository {
           if (MANIFEST_FILENAMES.has(entry.name)) continue;
           try {
             const content = await Deno.readTextFile(entry.path);
-            const data = parseYaml(content) as WorkflowData;
+            const data = parseYaml(content) as WorkflowData | null;
+            if (!data) continue;
             const workflow = Workflow.fromData(data);
             // Deduplicate: first directory wins (user dir before pulled dir)
             if (!seenNames.has(workflow.name)) {
@@ -155,7 +156,8 @@ export class ExtensionWorkflowRepository implements WorkflowRepository {
           if (MANIFEST_FILENAMES.has(entry.name)) continue;
           try {
             const content = await Deno.readTextFile(entry.path);
-            const data = parseYaml(content) as WorkflowData;
+            const data = parseYaml(content) as WorkflowData | null;
+            if (!data) continue;
             if (data.id === id) {
               return entry.path;
             }

--- a/src/infrastructure/persistence/repo_marker_repository.ts
+++ b/src/infrastructure/persistence/repo_marker_repository.ts
@@ -134,7 +134,8 @@ export class RepoMarkerRepository {
     const path = this.getMarkerPath(repoPath);
     try {
       const content = await Deno.readTextFile(path);
-      const data = parseYaml(content) as RepoMarkerData;
+      const data = parseYaml(content) as RepoMarkerData | null;
+      if (!data) return null;
       rejectRemovedDriverFields(data, path);
       return normalizeMarker(data);
     } catch (error) {

--- a/src/infrastructure/persistence/unified_data_repository.ts
+++ b/src/infrastructure/persistence/unified_data_repository.ts
@@ -474,7 +474,8 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     );
     try {
       const content = await Deno.readTextFile(metadataPath);
-      const metadata = parseYaml(content) as DataMetadata;
+      const metadata = parseYaml(content) as DataMetadata | null;
+      if (!metadata) return null;
       const data = Data.fromData(metadata);
 
       // Follow forward references for latest lookups (not explicit version requests)
@@ -1471,7 +1472,8 @@ export class FileSystemUnifiedDataRepository implements UnifiedDataRepository {
     );
     try {
       const content = Deno.readTextFileSync(metadataPath);
-      const metadata = parseYaml(content) as DataMetadata;
+      const metadata = parseYaml(content) as DataMetadata | null;
+      if (!metadata) return null;
       const data = Data.fromData(metadata);
 
       // Follow forward references for latest lookups (not explicit version requests)

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -98,10 +98,12 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     const legacyPath = this.getLegacyPath(type, id);
     try {
       const content = await Deno.readTextFile(legacyPath);
-      const data = parseYaml(content) as DefinitionData;
-      const definition = Definition.fromData(data);
-      this.idToActualPath.set(id, legacyPath);
-      return definition;
+      const data = parseYaml(content) as DefinitionData | null;
+      if (data) {
+        const definition = Definition.fromData(data);
+        this.idToActualPath.set(id, legacyPath);
+        return definition;
+      }
     } catch (error) {
       if (!(error instanceof Deno.errors.NotFound)) {
         throw error;
@@ -113,8 +115,8 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     if (cachedPath && cachedPath !== legacyPath) {
       try {
         const content = await Deno.readTextFile(cachedPath);
-        const data = parseYaml(content) as DefinitionData;
-        return Definition.fromData(data);
+        const data = parseYaml(content) as DefinitionData | null;
+        if (data) return Definition.fromData(data);
       } catch (error) {
         if (!(error instanceof Deno.errors.NotFound)) {
           throw error;
@@ -143,8 +145,8 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     const path = join(dir, type.toDirectoryPath(), `${id}.yaml`);
     try {
       const content = await Deno.readTextFile(path);
-      const data = parseYaml(content) as DefinitionData;
-      return Definition.fromData(data);
+      const data = parseYaml(content) as DefinitionData | null;
+      if (data) return Definition.fromData(data);
     } catch (error) {
       if (!(error instanceof Deno.errors.NotFound)) {
         throw error;
@@ -158,7 +160,8 @@ export class YamlDefinitionRepository implements DefinitionRepository {
         if (entry.isFile && entry.name.endsWith(".yaml")) {
           try {
             const content = await Deno.readTextFile(join(typeDir, entry.name));
-            const data = parseYaml(content) as DefinitionData;
+            const data = parseYaml(content) as DefinitionData | null;
+            if (!data) continue;
             const definition = Definition.fromData(data);
             if (definition.id === id) {
               return definition;
@@ -193,7 +196,8 @@ export class YamlDefinitionRepository implements DefinitionRepository {
               await assertSafePath(path, this.repoDir);
             }
             const content = await Deno.readTextFile(path);
-            const data = parseYaml(content) as DefinitionData;
+            const data = parseYaml(content) as DefinitionData | null;
+            if (!data) continue;
             const definition = Definition.fromData(data);
             this.idToActualPath.set(
               definition.id as DefinitionId,
@@ -229,13 +233,15 @@ export class YamlDefinitionRepository implements DefinitionRepository {
       const namePath = this.getNamePath(type, name);
       try {
         const content = await Deno.readTextFile(namePath);
-        const data = parseYaml(content) as DefinitionData;
-        const definition = Definition.fromData(data);
-        if (definition.name !== name) {
-          // File content doesn't match filename — fall through to slow path
-        } else {
-          this.idToActualPath.set(definition.id as DefinitionId, namePath);
-          return definition;
+        const data = parseYaml(content) as DefinitionData | null;
+        if (data) {
+          const definition = Definition.fromData(data);
+          if (definition.name !== name) {
+            // File content doesn't match filename — fall through to slow path
+          } else {
+            this.idToActualPath.set(definition.id as DefinitionId, namePath);
+            return definition;
+          }
         }
       } catch (error) {
         if (!(error instanceof Deno.errors.NotFound)) {
@@ -269,7 +275,8 @@ export class YamlDefinitionRepository implements DefinitionRepository {
               await assertSafePath(path, this.repoDir);
             }
             const content = await Deno.readTextFile(path);
-            const data = parseYaml(content) as DefinitionData;
+            const data = parseYaml(content) as DefinitionData | null;
+            if (!data) continue;
             definitions.push(Definition.fromData(data));
           } catch (error) {
             if (isIoError(error)) {
@@ -329,7 +336,8 @@ export class YamlDefinitionRepository implements DefinitionRepository {
               await assertSafePath(fullPath, this.repoDir);
             }
             const content = await Deno.readTextFile(fullPath);
-            const data = parseYaml(content) as DefinitionData;
+            const data = parseYaml(content) as DefinitionData | null;
+            if (!data) continue;
             const definition = Definition.fromData(data);
 
             if (definition.name === name) {
@@ -406,7 +414,8 @@ export class YamlDefinitionRepository implements DefinitionRepository {
               await assertSafePath(fullPath, this.repoDir);
             }
             const content = await Deno.readTextFile(fullPath);
-            const data = parseYaml(content) as DefinitionData;
+            const data = parseYaml(content) as DefinitionData | null;
+            if (!data) continue;
             const definition = Definition.fromData(data);
 
             this.idToActualPath.set(
@@ -511,15 +520,20 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     if (!isNew && await this.exists(targetPath)) {
       try {
         const existingRaw = await Deno.readTextFile(targetPath);
-        const existingParsed = parseYaml(existingRaw) as Record<
-          string,
-          unknown
-        >;
-        const normalizedExisting = JSON.parse(
-          JSON.stringify(existingParsed),
-        ) as Record<string, unknown>;
+        const existingParsed = parseYaml(existingRaw) as
+          | Record<
+            string,
+            unknown
+          >
+          | null;
+        const normalizedExisting = existingParsed
+          ? JSON.parse(
+            JSON.stringify(existingParsed),
+          ) as Record<string, unknown>
+          : null;
 
         if (
+          normalizedExisting &&
           canonicalJson(cleanData) === canonicalJson(normalizedExisting)
         ) {
           this.idToActualPath.set(definition.id, targetPath);
@@ -528,9 +542,11 @@ export class YamlDefinitionRepository implements DefinitionRepository {
         }
 
         // Data changed — merge onto existing document to preserve comments
-        const doc = parseDocument(existingRaw);
-        mergeIntoDocument(doc, cleanData);
-        await atomicWriteTextFile(targetPath, doc.toString());
+        if (normalizedExisting) {
+          const doc = parseDocument(existingRaw);
+          mergeIntoDocument(doc, cleanData);
+          await atomicWriteTextFile(targetPath, doc.toString());
+        }
       } catch (error) {
         if (error instanceof Deno.errors.NotFound) {
           // File disappeared between exists() and read — fall through to

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -526,6 +526,15 @@ export class YamlDefinitionRepository implements DefinitionRepository {
             unknown
           >
           | null;
+        if (!existingParsed) {
+          // Corrupt/empty file — remove it so the fresh-write path below
+          // overwrites with valid content.
+          try {
+            await Deno.remove(targetPath);
+          } catch (error) {
+            if (!(error instanceof Deno.errors.NotFound)) throw error;
+          }
+        }
         const normalizedExisting = existingParsed
           ? JSON.parse(
             JSON.stringify(existingParsed),

--- a/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_definition_repository.ts
@@ -77,10 +77,12 @@ export class YamlEvaluatedDefinitionRepository {
     const legacyPath = this.getLegacyPath(type, id);
     try {
       const content = await Deno.readTextFile(legacyPath);
-      const data = parseYaml(content) as DefinitionData;
-      const definition = Definition.fromData(data);
-      this.idToActualPath.set(id, legacyPath);
-      return definition;
+      const data = parseYaml(content) as DefinitionData | null;
+      if (data) {
+        const definition = Definition.fromData(data);
+        this.idToActualPath.set(id, legacyPath);
+        return definition;
+      }
     } catch (error) {
       if (!(error instanceof Deno.errors.NotFound)) {
         throw error;
@@ -92,8 +94,8 @@ export class YamlEvaluatedDefinitionRepository {
     if (cachedPath && cachedPath !== legacyPath) {
       try {
         const content = await Deno.readTextFile(cachedPath);
-        const data = parseYaml(content) as DefinitionData;
-        return Definition.fromData(data);
+        const data = parseYaml(content) as DefinitionData | null;
+        if (data) return Definition.fromData(data);
       } catch (error) {
         if (!(error instanceof Deno.errors.NotFound)) {
           throw error;
@@ -121,7 +123,8 @@ export class YamlEvaluatedDefinitionRepository {
         if (entry.isFile && entry.name.endsWith(".yaml")) {
           const path = join(dir, entry.name);
           const content = await Deno.readTextFile(path);
-          const data = parseYaml(content) as DefinitionData;
+          const data = parseYaml(content) as DefinitionData | null;
+          if (!data) continue;
           const definition = Definition.fromData(data);
           this.idToActualPath.set(definition.id as DefinitionId, path);
           definitions.push(definition);
@@ -149,13 +152,15 @@ export class YamlEvaluatedDefinitionRepository {
       const namePath = this.getNamePath(type, name);
       try {
         const content = await Deno.readTextFile(namePath);
-        const data = parseYaml(content) as DefinitionData;
-        const definition = Definition.fromData(data);
-        if (definition.name !== name) {
-          // File content doesn't match filename — fall through to slow path
-        } else {
-          this.idToActualPath.set(definition.id as DefinitionId, namePath);
-          return definition;
+        const data = parseYaml(content) as DefinitionData | null;
+        if (data) {
+          const definition = Definition.fromData(data);
+          if (definition.name !== name) {
+            // File content doesn't match filename — fall through to slow path
+          } else {
+            this.idToActualPath.set(definition.id as DefinitionId, namePath);
+            return definition;
+          }
         }
       } catch (error) {
         if (!(error instanceof Deno.errors.NotFound)) {
@@ -196,7 +201,8 @@ export class YamlEvaluatedDefinitionRepository {
         if (entry.isFile && entry.name.endsWith(".yaml")) {
           // Found a YAML file, check if it matches the name
           const content = await Deno.readTextFile(fullPath);
-          const data = parseYaml(content) as DefinitionData;
+          const data = parseYaml(content) as DefinitionData | null;
+          if (!data) continue;
           const definition = Definition.fromData(data);
 
           if (definition.name === name) {
@@ -256,7 +262,8 @@ export class YamlEvaluatedDefinitionRepository {
         if (entry.isFile && entry.name.endsWith(".yaml")) {
           // Found a YAML file, add it to results
           const content = await Deno.readTextFile(fullPath);
-          const data = parseYaml(content) as DefinitionData;
+          const data = parseYaml(content) as DefinitionData | null;
+          if (!data) continue;
           const definition = Definition.fromData(data);
 
           this.idToActualPath.set(definition.id as DefinitionId, fullPath);

--- a/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
@@ -51,7 +51,8 @@ export class YamlEvaluatedWorkflowRepository {
     const legacyPath = this.getLegacyPath(id);
     try {
       const content = await Deno.readTextFile(legacyPath);
-      const data = parseYaml(content) as WorkflowData;
+      const data = parseYaml(content) as WorkflowData | null;
+      if (!data) return null;
       const workflow = Workflow.fromData(data);
       this.idToActualPath.set(id, legacyPath);
       return workflow;
@@ -66,7 +67,8 @@ export class YamlEvaluatedWorkflowRepository {
     if (cachedPath && cachedPath !== legacyPath) {
       try {
         const content = await Deno.readTextFile(cachedPath);
-        const data = parseYaml(content) as WorkflowData;
+        const data = parseYaml(content) as WorkflowData | null;
+        if (!data) return null;
         return Workflow.fromData(data);
       } catch (error) {
         if (!(error instanceof Deno.errors.NotFound)) {
@@ -92,7 +94,8 @@ export class YamlEvaluatedWorkflowRepository {
         ) {
           const path = join(dir, entry.name);
           const content = await Deno.readTextFile(path);
-          const data = parseYaml(content) as WorkflowData;
+          const data = parseYaml(content) as WorkflowData | null;
+          if (!data) continue;
           const workflow = Workflow.fromData(data);
           this.idToActualPath.set(workflow.id as WorkflowId, path);
           workflows.push(workflow);
@@ -119,7 +122,8 @@ export class YamlEvaluatedWorkflowRepository {
       const namePath = this.getNamePath(name);
       try {
         const content = await Deno.readTextFile(namePath);
-        const data = parseYaml(content) as WorkflowData;
+        const data = parseYaml(content) as WorkflowData | null;
+        if (!data) return null;
         const workflow = Workflow.fromData(data);
         if (workflow.name !== name) {
           // File content doesn't match filename — fall through to slow path

--- a/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
@@ -52,10 +52,11 @@ export class YamlEvaluatedWorkflowRepository {
     try {
       const content = await Deno.readTextFile(legacyPath);
       const data = parseYaml(content) as WorkflowData | null;
-      if (!data) return null;
-      const workflow = Workflow.fromData(data);
-      this.idToActualPath.set(id, legacyPath);
-      return workflow;
+      if (data) {
+        const workflow = Workflow.fromData(data);
+        this.idToActualPath.set(id, legacyPath);
+        return workflow;
+      }
     } catch (error) {
       if (!(error instanceof Deno.errors.NotFound)) {
         throw error;
@@ -68,8 +69,9 @@ export class YamlEvaluatedWorkflowRepository {
       try {
         const content = await Deno.readTextFile(cachedPath);
         const data = parseYaml(content) as WorkflowData | null;
-        if (!data) return null;
-        return Workflow.fromData(data);
+        if (data) {
+          return Workflow.fromData(data);
+        }
       } catch (error) {
         if (!(error instanceof Deno.errors.NotFound)) {
           throw error;
@@ -123,13 +125,14 @@ export class YamlEvaluatedWorkflowRepository {
       try {
         const content = await Deno.readTextFile(namePath);
         const data = parseYaml(content) as WorkflowData | null;
-        if (!data) return null;
-        const workflow = Workflow.fromData(data);
-        if (workflow.name !== name) {
-          // File content doesn't match filename — fall through to slow path
-        } else {
-          this.idToActualPath.set(workflow.id as WorkflowId, namePath);
-          return workflow;
+        if (data) {
+          const workflow = Workflow.fromData(data);
+          if (workflow.name !== name) {
+            // File content doesn't match filename — fall through to slow path
+          } else {
+            this.idToActualPath.set(workflow.id as WorkflowId, namePath);
+            return workflow;
+          }
         }
       } catch (error) {
         if (!(error instanceof Deno.errors.NotFound)) {

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -391,6 +391,14 @@ export class YamlOutputRepository implements OutputRepository {
         const content = await Deno.readTextFile(yamlPath);
         const data = parseYaml(content) as ModelOutputData | null;
         if (!data) {
+          const logPath = yamlPath.replace(/\.yaml$/, ".log");
+          let fileBytes = stat.size ?? 0;
+          try {
+            const logStat = await Deno.stat(logPath);
+            fileBytes += logStat.size ?? 0;
+          } catch {
+            // log file may not exist
+          }
           if (!options?.dryRun) {
             await this.notifyDirty(yamlPath);
             try {
@@ -398,10 +406,15 @@ export class YamlOutputRepository implements OutputRepository {
             } catch (error) {
               if (!(error instanceof Deno.errors.NotFound)) throw error;
             }
+            try {
+              await Deno.remove(logPath);
+            } catch (error) {
+              if (!(error instanceof Deno.errors.NotFound)) throw error;
+            }
             await cleanupEmptyParentDirs(yamlPath, this.baseDir);
           }
           deleted++;
-          bytesReclaimed += stat.size ?? 0;
+          bytesReclaimed += fileBytes;
           continue;
         }
         if (!TERMINAL_STATUSES.has(data.status)) continue;

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -390,7 +390,20 @@ export class YamlOutputRepository implements OutputRepository {
 
         const content = await Deno.readTextFile(yamlPath);
         const data = parseYaml(content) as ModelOutputData | null;
-        if (!data) continue;
+        if (!data) {
+          if (!options?.dryRun) {
+            await this.notifyDirty(yamlPath);
+            try {
+              await Deno.remove(yamlPath);
+            } catch (error) {
+              if (!(error instanceof Deno.errors.NotFound)) throw error;
+            }
+            await cleanupEmptyParentDirs(yamlPath, this.baseDir);
+          }
+          deleted++;
+          bytesReclaimed += stat.size ?? 0;
+          continue;
+        }
         if (!TERMINAL_STATUSES.has(data.status)) continue;
         const startedAt = data.startedAt
           ? new Date(data.startedAt).getTime()

--- a/src/infrastructure/persistence/yaml_output_repository.ts
+++ b/src/infrastructure/persistence/yaml_output_repository.ts
@@ -81,7 +81,8 @@ export class YamlOutputRepository implements OutputRepository {
         // exists later in the directory."
         try {
           const content = await Deno.readTextFile(path);
-          const data = parseYaml(content) as ModelOutputData;
+          const data = parseYaml(content) as ModelOutputData | null;
+          if (!data) continue;
           if (data.id === id) {
             // Convert logFile back to absolute path
             if (data.logFile) {
@@ -154,7 +155,8 @@ export class YamlOutputRepository implements OutputRepository {
             // current method directory."
             try {
               const content = await Deno.readTextFile(path);
-              const data = parseYaml(content) as ModelOutputData;
+              const data = parseYaml(content) as ModelOutputData | null;
+              if (!data) continue;
               if (data.logFile) {
                 data.logFile = toAbsolutePath(this.repoDir, data.logFile);
               }
@@ -250,7 +252,8 @@ export class YamlOutputRepository implements OutputRepository {
 
                 // Stage B: parse and verify
                 const content = await Deno.readTextFile(path);
-                const data = parseYaml(content) as ModelOutputData;
+                const data = parseYaml(content) as ModelOutputData | null;
+                if (!data) continue;
                 if (data.logFile) {
                   data.logFile = toAbsolutePath(this.repoDir, data.logFile);
                 }
@@ -332,7 +335,8 @@ export class YamlOutputRepository implements OutputRepository {
 
         try {
           const content = await Deno.readTextFile(path);
-          const data = parseYaml(content) as ModelOutputData;
+          const data = parseYaml(content) as ModelOutputData | null;
+          if (!data) continue;
           if (data.id === id) {
             matchPath = path;
             break;
@@ -385,7 +389,8 @@ export class YamlOutputRepository implements OutputRepository {
         if (mtimeMs !== undefined && mtimeMs >= cutoffMs) continue;
 
         const content = await Deno.readTextFile(yamlPath);
-        const data = parseYaml(content) as ModelOutputData;
+        const data = parseYaml(content) as ModelOutputData | null;
+        if (!data) continue;
         if (!TERMINAL_STATUSES.has(data.status)) continue;
         const startedAt = data.startedAt
           ? new Date(data.startedAt).getTime()

--- a/src/infrastructure/persistence/yaml_output_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_output_repository_test.ts
@@ -773,7 +773,7 @@ Deno.test(
 );
 
 Deno.test(
-  "deleteOlderThan: empty YAML file is skipped, not fatal",
+  "deleteOlderThan: empty YAML file is cleaned up",
   async () => {
     await withTempDir(async (dir) => {
       const repo = new YamlOutputRepository(dir);
@@ -797,7 +797,7 @@ Deno.test(
       const result = await repo.deleteOlderThan(
         new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
       );
-      assertEquals(result.deleted, 1);
+      assertEquals(result.deleted, 2);
     });
   },
 );

--- a/src/infrastructure/persistence/yaml_output_repository_test.ts
+++ b/src/infrastructure/persistence/yaml_output_repository_test.ts
@@ -19,6 +19,7 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { assertPathStringIncludes } from "./path_test_helpers.ts";
+import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import {
   createModelOutputId,
@@ -691,6 +692,112 @@ Deno.test(
       // notifyDirty must have fired with the target's path.
       assertEquals(dirtyPaths.length, 1);
       assertEquals(dirtyPaths[0], targetPath);
+    });
+  },
+);
+
+async function seedEmptyYaml(
+  dir: string,
+  type: ModelType,
+  method: string,
+): Promise<void> {
+  const methodDir = join(dir, ".swamp", "outputs", type.normalized, method);
+  await ensureDir(methodDir);
+  await Deno.writeTextFile(join(methodDir, "empty-corrupt.yaml"), "");
+}
+
+Deno.test(
+  "findById: empty YAML file is skipped, not fatal",
+  async () => {
+    await withTempDir(async (dir) => {
+      const repo = new YamlOutputRepository(dir);
+      const target = await makeOutput(repo, new Date());
+
+      await seedEmptyYaml(dir, registeredType, "run");
+
+      const found = await repo.findById(registeredType, "run", target.id);
+      assertEquals(found?.id, target.id);
+    });
+  },
+);
+
+Deno.test(
+  "findAll: empty YAML file is skipped, not fatal",
+  async () => {
+    await withTempDir(async (dir) => {
+      const repo = new YamlOutputRepository(dir);
+      const valid = await makeOutput(repo, new Date());
+
+      await seedEmptyYaml(dir, registeredType, "run");
+
+      const found = await repo.findAll(registeredType);
+      assertEquals(found.length, 1);
+      assertEquals(found[0].id, valid.id);
+    });
+  },
+);
+
+Deno.test(
+  "findAllGlobalSince: empty YAML file is skipped, not fatal",
+  async () => {
+    await withTempDir(async (dir) => {
+      const repo = new YamlOutputRepository(dir);
+      const valid = await makeOutput(repo, new Date());
+
+      await seedEmptyYaml(dir, registeredType, "run");
+
+      const cutoff = new Date(Date.now() - 60 * 60 * 1000);
+      const found = await repo.findAllGlobalSince(cutoff);
+      assertEquals(found.length, 1);
+      assertEquals(found[0].output.id, valid.id);
+    });
+  },
+);
+
+Deno.test(
+  "delete: empty YAML file does not crash scan",
+  async () => {
+    await withTempDir(async (dir) => {
+      const repo = new YamlOutputRepository(dir);
+      const target = await makeOutput(repo, new Date());
+
+      await seedEmptyYaml(dir, registeredType, "run");
+
+      await repo.delete(registeredType, "run", target.id);
+      assertEquals(
+        await repo.findById(registeredType, "run", target.id),
+        null,
+      );
+    });
+  },
+);
+
+Deno.test(
+  "deleteOlderThan: empty YAML file is skipped, not fatal",
+  async () => {
+    await withTempDir(async (dir) => {
+      const repo = new YamlOutputRepository(dir);
+
+      const oldDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      const old = await makeOutput(repo, oldDate);
+      const oldPath = repo.getPath(registeredType, "run", old);
+      await Deno.utime(oldPath, oldDate, oldDate);
+
+      await seedEmptyYaml(dir, registeredType, "run");
+      const emptyPath = join(
+        dir,
+        ".swamp",
+        "outputs",
+        registeredType.normalized,
+        "run",
+        "empty-corrupt.yaml",
+      );
+      await Deno.utime(emptyPath, oldDate, oldDate);
+
+      const result = await repo.deleteOlderThan(
+        new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+      );
+      assertEquals(result.deleted, 1);
     });
   },
 );

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -71,7 +71,8 @@ export class YamlWorkflowRepository implements WorkflowRepository {
     const legacyPath = this.getLegacyPath(id);
     try {
       const content = await Deno.readTextFile(legacyPath);
-      const data = parseYaml(content) as WorkflowData;
+      const data = parseYaml(content) as WorkflowData | null;
+      if (!data) return null;
       const workflow = Workflow.fromData(data);
       this.idToActualPath.set(id, legacyPath);
       return workflow;
@@ -86,7 +87,8 @@ export class YamlWorkflowRepository implements WorkflowRepository {
     if (cachedPath && cachedPath !== legacyPath) {
       try {
         const content = await Deno.readTextFile(cachedPath);
-        const data = parseYaml(content) as WorkflowData;
+        const data = parseYaml(content) as WorkflowData | null;
+        if (!data) return null;
         return Workflow.fromData(data);
       } catch (error) {
         if (!(error instanceof Deno.errors.NotFound)) {
@@ -106,7 +108,8 @@ export class YamlWorkflowRepository implements WorkflowRepository {
       const namePath = this.getNamePath(name);
       try {
         const content = await Deno.readTextFile(namePath);
-        const data = parseYaml(content) as WorkflowData;
+        const data = parseYaml(content) as WorkflowData | null;
+        if (!data) return null;
         const workflow = Workflow.fromData(data);
         if (workflow.name !== name) {
           // File content doesn't match filename — fall through to slow path
@@ -139,7 +142,8 @@ export class YamlWorkflowRepository implements WorkflowRepository {
           const path = join(dir, entry.name);
           try {
             const content = await Deno.readTextFile(path);
-            const data = parseYaml(content) as WorkflowData;
+            const data = parseYaml(content) as WorkflowData | null;
+            if (!data) continue;
             const workflow = Workflow.fromData(data);
             this.idToActualPath.set(workflow.id as WorkflowId, path);
             workflows.push(workflow);

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -72,10 +72,11 @@ export class YamlWorkflowRepository implements WorkflowRepository {
     try {
       const content = await Deno.readTextFile(legacyPath);
       const data = parseYaml(content) as WorkflowData | null;
-      if (!data) return null;
-      const workflow = Workflow.fromData(data);
-      this.idToActualPath.set(id, legacyPath);
-      return workflow;
+      if (data) {
+        const workflow = Workflow.fromData(data);
+        this.idToActualPath.set(id, legacyPath);
+        return workflow;
+      }
     } catch (error) {
       if (!(error instanceof Deno.errors.NotFound)) {
         throw error;
@@ -88,8 +89,9 @@ export class YamlWorkflowRepository implements WorkflowRepository {
       try {
         const content = await Deno.readTextFile(cachedPath);
         const data = parseYaml(content) as WorkflowData | null;
-        if (!data) return null;
-        return Workflow.fromData(data);
+        if (data) {
+          return Workflow.fromData(data);
+        }
       } catch (error) {
         if (!(error instanceof Deno.errors.NotFound)) {
           throw error;
@@ -109,13 +111,14 @@ export class YamlWorkflowRepository implements WorkflowRepository {
       try {
         const content = await Deno.readTextFile(namePath);
         const data = parseYaml(content) as WorkflowData | null;
-        if (!data) return null;
-        const workflow = Workflow.fromData(data);
-        if (workflow.name !== name) {
-          // File content doesn't match filename — fall through to slow path
-        } else {
-          this.idToActualPath.set(workflow.id as WorkflowId, namePath);
-          return workflow;
+        if (data) {
+          const workflow = Workflow.fromData(data);
+          if (workflow.name !== name) {
+            // File content doesn't match filename — fall through to slow path
+          } else {
+            this.idToActualPath.set(workflow.id as WorkflowId, namePath);
+            return workflow;
+          }
         }
       } catch (error) {
         if (!(error instanceof Deno.errors.NotFound)) {

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -659,6 +659,14 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
               const content = await Deno.readTextFile(yamlPath);
               const data = parseYaml(content) as WorkflowRunData | null;
               if (!data) {
+                const logPath = yamlPath.replace(/\.yaml$/, ".log");
+                let fileBytes = stat.size ?? 0;
+                try {
+                  const logStat = await Deno.stat(logPath);
+                  fileBytes += logStat.size ?? 0;
+                } catch {
+                  // log file may not exist
+                }
                 if (!options?.dryRun) {
                   await this.notifyDirty(yamlPath);
                   try {
@@ -666,11 +674,16 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
                   } catch (error) {
                     if (!(error instanceof Deno.errors.NotFound)) throw error;
                   }
+                  try {
+                    await Deno.remove(logPath);
+                  } catch (error) {
+                    if (!(error instanceof Deno.errors.NotFound)) throw error;
+                  }
                   await cleanupEmptyParentDirs(yamlPath, this.baseDir);
                   affectedDirs.add(dir);
                 }
                 deleted++;
-                bytesReclaimed += stat.size ?? 0;
+                bytesReclaimed += fileBytes;
                 continue;
               }
               if (!TERMINAL_STATUSES.has(data.status)) continue;

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -658,7 +658,21 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
 
               const content = await Deno.readTextFile(yamlPath);
               const data = parseYaml(content) as WorkflowRunData | null;
-              if (!data) continue;
+              if (!data) {
+                if (!options?.dryRun) {
+                  await this.notifyDirty(yamlPath);
+                  try {
+                    await Deno.remove(yamlPath);
+                  } catch (error) {
+                    if (!(error instanceof Deno.errors.NotFound)) throw error;
+                  }
+                  await cleanupEmptyParentDirs(yamlPath, this.baseDir);
+                  affectedDirs.add(dir);
+                }
+                deleted++;
+                bytesReclaimed += stat.size ?? 0;
+                continue;
+              }
               if (!TERMINAL_STATUSES.has(data.status)) continue;
 
               const completedAt = data.completedAt

--- a/src/infrastructure/persistence/yaml_workflow_run_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_run_repository.ts
@@ -111,7 +111,8 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
         ) {
           const path = join(dir, entry.name);
           const content = await Deno.readTextFile(path);
-          const data = parseYaml(content) as WorkflowRunData;
+          const data = parseYaml(content) as WorkflowRunData | null;
+          if (!data) continue;
           if (data.id === runId) {
             // Convert logFile back to absolute path
             if (data.logFile) {
@@ -151,7 +152,8 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
         // means "skip it" — never "abandon the rest of the workflow."
         try {
           const content = await Deno.readTextFile(path);
-          const data = parseYaml(content) as WorkflowRunData;
+          const data = parseYaml(content) as WorkflowRunData | null;
+          if (!data) continue;
           if (data.logFile) {
             data.logFile = toAbsolutePath(this.repoDir, data.logFile);
           }
@@ -219,7 +221,9 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
           const content = await Deno.readTextFile(path);
           // parseWorkflowRunSummary keeps only the displayed fields; the heavy
           // jobs/output subtree in `parseYaml`'s result is dropped and GC'd.
-          summaries.push(parseWorkflowRunSummary(parseYaml(content)));
+          const parsed = parseYaml(content);
+          if (!parsed) continue;
+          summaries.push(parseWorkflowRunSummary(parsed));
         } catch (error) {
           if (error instanceof Deno.errors.NotFound) continue;
           throw error;
@@ -398,7 +402,8 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
 
           // Stage B: parse and verify
           const content = await Deno.readTextFile(path);
-          const data = parseYaml(content) as WorkflowRunData;
+          const data = parseYaml(content) as WorkflowRunData | null;
+          if (!data) continue;
           if (data.logFile) {
             data.logFile = toAbsolutePath(this.repoDir, data.logFile);
           }
@@ -652,7 +657,8 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
               if (mtimeMs !== undefined && mtimeMs >= cutoffMs) continue;
 
               const content = await Deno.readTextFile(yamlPath);
-              const data = parseYaml(content) as WorkflowRunData;
+              const data = parseYaml(content) as WorkflowRunData | null;
+              if (!data) continue;
               if (!TERMINAL_STATUSES.has(data.status)) continue;
 
               const completedAt = data.completedAt
@@ -779,7 +785,9 @@ export class YamlWorkflowRunRepository implements WorkflowRunRepository {
         const path = join(runsDir, entry.name);
         try {
           const content = await Deno.readTextFile(path);
-          const summary = parseWorkflowRunSummary(parseYaml(content));
+          const parsed = parseYaml(content);
+          if (!parsed) continue;
+          const summary = parseWorkflowRunSummary(parsed);
           index[summary.id] = summaryToIndexEntry(summary);
         } catch (error) {
           if (error instanceof Deno.errors.NotFound) continue;


### PR DESCRIPTION
## Summary

- Guard all `parseYaml` call sites across YAML persistence repositories against
  `null` returns from empty/corrupt YAML files, preventing `TypeError: Cannot
  read properties of null` crashes
- Use fall-through pattern (`if (data) { ... }`) in multi-strategy lookups
  (`findById`, `findByName`) so a corrupt file at one strategy doesn't
  short-circuit the remaining strategies
- Clean up empty/corrupt YAML files (and companion `.log` files) during
  `deleteOlderThan` GC instead of skipping them
- Remove corrupt existing definition files in `save()` so the fresh-write path
  overwrites with valid content instead of silently returning

**Repositories fixed:** YamlOutputRepository, YamlWorkflowRunRepository,
YamlDefinitionRepository, YamlEvaluatedDefinitionRepository,
YamlWorkflowRepository, YamlEvaluatedWorkflowRepository,
ExtensionWorkflowRepository, FileSystemUnifiedDataRepository,
RepoMarkerRepository (~36 call sites across 11 files)

**Root cause:** `@std/yaml`'s `parse()` returns `null` for empty content (`""`,
`"null"`, `"---"`). All call sites cast the result with `as SomeType` and
immediately dereference a property, which throws when the result is `null`.

Closes swamp-club#1997

## Test plan

- [x] 5 new unit tests in `yaml_output_repository_test.ts` covering empty YAML
  file handling for `findById`, `findAll`, `findAllGlobalSince`, `delete`, and
  `deleteOlderThan`
- [x] All 113 existing tests pass across affected repos
- [x] Reproduced the exact crash (`parseYaml("").id` → TypeError) and verified
  the guard prevents it
- [x] 3 rounds of verification (build + adversarial review caught and fixed
  strategy short-circuit and GC accumulation issues)
- [x] Existing UAT coverage in `swamp-uat/tests/cli/adversarial/state_corruption_test.ts`
  exercises empty/corrupt definition and workflow files end-to-end

Co-authored-by: Blake Irvin <blakeirvin@me.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)