### PR TITLE
feat(search): include method and argument detail in model search JSON output

### DIFF
--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -119,9 +119,7 @@ export async function modelSearchAction(
   };
 
   const repoDir = resolveRepoDir(options.repoDir);
-  const fetchPreview = effectiveMode === "log"
-    ? await createModelFetchPreview(repoDir)
-    : undefined;
+  const fetchPreview = await createModelFetchPreview(repoDir);
   const renderer = createModelSearchRenderer(effectiveMode, fetchPreview);
   await consumeStream(
     modelSearch(libCtx, deps, { query, includeInternal }),

--- a/src/cli/commands/model_search.ts
+++ b/src/cli/commands/model_search.ts
@@ -97,7 +97,7 @@ export async function modelSearchAction(
       },
     );
     const renderer = createModelSearchRenderer(interactiveOutputMode(ctx));
-    renderer.handlers().completed({
+    await renderer.handlers().completed({
       kind: "completed",
       data: response.data as unknown as ModelSearchData,
     });

--- a/src/presentation/renderers/model_search.tsx
+++ b/src/presentation/renderers/model_search.tsx
@@ -23,7 +23,6 @@ import { Box, Text } from "ink";
 import type {
   EventHandlers,
   ModelGetData,
-  ModelSearchData,
   ModelSearchEvent,
   ModelSearchItem,
 } from "../../libswamp/mod.ts";
@@ -74,6 +73,11 @@ export type ModelSearchRenderer = SearchRenderer<
 
 class JsonModelSearchRenderer implements ModelSearchRenderer {
   private _selected: ModelSearchItem | undefined;
+  private readonly fetchPreview: ModelPreviewFetcher | undefined;
+
+  constructor(fetchPreview?: ModelPreviewFetcher) {
+    this.fetchPreview = fetchPreview;
+  }
 
   selectedItem(): ModelSearchItem | undefined {
     return this._selected;
@@ -82,13 +86,42 @@ class JsonModelSearchRenderer implements ModelSearchRenderer {
   handlers(): EventHandlers<ModelSearchEvent> {
     return {
       resolving: () => {},
-      completed: (e) => {
+      completed: async (e) => {
         const filtered = filterModels(e.data.results, e.data.query);
-        const output: ModelSearchData = {
-          query: e.data.query,
-          results: filtered,
-        };
-        console.log(JSON.stringify(output, null, 2));
+
+        if (!this.fetchPreview) {
+          console.log(
+            JSON.stringify({ query: e.data.query, results: filtered }, null, 2),
+          );
+          return;
+        }
+
+        const typeCache = new Map<
+          string,
+          Pick<ModelGetData, "methods" | "globalArgumentsSchema">
+        >();
+        for (const item of filtered) {
+          if (!typeCache.has(item.type)) {
+            try {
+              const detail = await this.fetchPreview(item);
+              typeCache.set(item.type, {
+                methods: detail.methods,
+                globalArgumentsSchema: detail.globalArgumentsSchema,
+              });
+            } catch {
+              typeCache.set(item.type, {});
+            }
+          }
+        }
+
+        const results = filtered.map((item) => ({
+          ...item,
+          ...typeCache.get(item.type),
+        }));
+
+        console.log(
+          JSON.stringify({ query: e.data.query, results }, null, 2),
+        );
       },
       error: (e) => {
         throw new UserError(e.error.message);
@@ -154,7 +187,7 @@ export function createModelSearchRenderer(
 ): ModelSearchRenderer {
   switch (mode) {
     case "json":
-      return new JsonModelSearchRenderer();
+      return new JsonModelSearchRenderer(fetchPreview);
     case "log":
       return new InkModelSearchRenderer(fetchPreview);
   }

--- a/src/presentation/renderers/model_search_test.ts
+++ b/src/presentation/renderers/model_search_test.ts
@@ -28,7 +28,7 @@ import {
   type ModelPreviewFetcher,
 } from "./model_search.tsx";
 
-Deno.test("JsonModelSearchRenderer: single match returns envelope shape", () => {
+Deno.test("JsonModelSearchRenderer: single match returns envelope shape", async () => {
   const renderer = createModelSearchRenderer("json");
   const handlers = renderer.handlers();
 
@@ -41,7 +41,7 @@ Deno.test("JsonModelSearchRenderer: single match returns envelope shape", () => 
   console.log = (...args: unknown[]) => logs.push(String(args[0]));
   try {
     const data: ModelSearchData = { query: "unique", results: items };
-    handlers.completed({ kind: "completed", data });
+    await handlers.completed({ kind: "completed", data });
   } finally {
     console.log = originalLog;
   }
@@ -54,7 +54,7 @@ Deno.test("JsonModelSearchRenderer: single match returns envelope shape", () => 
   assertEquals(renderer.selectedItem(), undefined);
 });
 
-Deno.test("JsonModelSearchRenderer: multiple matches returns envelope shape", () => {
+Deno.test("JsonModelSearchRenderer: multiple matches returns envelope shape", async () => {
   const renderer = createModelSearchRenderer("json");
   const handlers = renderer.handlers();
 
@@ -68,7 +68,7 @@ Deno.test("JsonModelSearchRenderer: multiple matches returns envelope shape", ()
   console.log = (...args: unknown[]) => logs.push(String(args[0]));
   try {
     const data: ModelSearchData = { query: "model", results: items };
-    handlers.completed({ kind: "completed", data });
+    await handlers.completed({ kind: "completed", data });
   } finally {
     console.log = originalLog;
   }
@@ -80,7 +80,7 @@ Deno.test("JsonModelSearchRenderer: multiple matches returns envelope shape", ()
   assertEquals(renderer.selectedItem(), undefined);
 });
 
-Deno.test("JsonModelSearchRenderer: zero matches returns envelope shape", () => {
+Deno.test("JsonModelSearchRenderer: zero matches returns envelope shape", async () => {
   const renderer = createModelSearchRenderer("json");
   const handlers = renderer.handlers();
 
@@ -89,7 +89,7 @@ Deno.test("JsonModelSearchRenderer: zero matches returns envelope shape", () => 
   console.log = (...args: unknown[]) => logs.push(String(args[0]));
   try {
     const data: ModelSearchData = { query: "nonexistent", results: [] };
-    handlers.completed({ kind: "completed", data });
+    await handlers.completed({ kind: "completed", data });
   } finally {
     console.log = originalLog;
   }

--- a/src/presentation/renderers/model_search_test.ts
+++ b/src/presentation/renderers/model_search_test.ts
@@ -18,8 +18,15 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals } from "@std/assert";
-import type { ModelSearchData, ModelSearchItem } from "../../libswamp/mod.ts";
-import { createModelSearchRenderer } from "./model_search.tsx";
+import type {
+  ModelGetData,
+  ModelSearchData,
+  ModelSearchItem,
+} from "../../libswamp/mod.ts";
+import {
+  createModelSearchRenderer,
+  type ModelPreviewFetcher,
+} from "./model_search.tsx";
 
 Deno.test("JsonModelSearchRenderer: single match returns envelope shape", () => {
   const renderer = createModelSearchRenderer("json");
@@ -92,4 +99,140 @@ Deno.test("JsonModelSearchRenderer: zero matches returns envelope shape", () => 
   assertEquals(parsed.query, "nonexistent");
   assertEquals(parsed.results.length, 0);
   assertEquals(renderer.selectedItem(), undefined);
+});
+
+function stubFetchPreview(
+  detailMap: Record<string, Partial<ModelGetData>>,
+): ModelPreviewFetcher {
+  return (item: ModelSearchItem) => {
+    const detail = detailMap[item.name];
+    if (!detail) return Promise.reject(new Error("not found"));
+    return Promise.resolve({
+      id: item.id,
+      name: item.name,
+      type: item.type,
+      version: 1,
+      tags: {},
+      globalArguments: {},
+      ...detail,
+    } as ModelGetData);
+  };
+}
+
+Deno.test("JsonModelSearchRenderer: includes methods and globalArgumentsSchema when fetchPreview is provided", async () => {
+  const methods = [
+    {
+      name: "run",
+      description: "Execute the model",
+      arguments: {
+        type: "object",
+        properties: { message: { type: "string" } },
+        required: ["message"],
+      },
+    },
+  ];
+  const globalArgumentsSchema = {
+    type: "object",
+    properties: { timeout: { type: "number" } },
+  };
+  const fetchPreview = stubFetchPreview({
+    "my-model": { methods, globalArgumentsSchema },
+  });
+  const renderer = createModelSearchRenderer("json", fetchPreview);
+  const handlers = renderer.handlers();
+
+  const items: ModelSearchItem[] = [
+    { id: "id-1", name: "my-model", type: "swamp/echo" },
+  ];
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => logs.push(String(args[0]));
+  try {
+    await handlers.completed({
+      kind: "completed",
+      data: { query: "", results: items },
+    });
+  } finally {
+    console.log = originalLog;
+  }
+
+  const parsed = JSON.parse(logs[0]);
+  assertEquals(parsed.results.length, 1);
+  assertEquals(parsed.results[0].methods, methods);
+  assertEquals(parsed.results[0].globalArgumentsSchema, globalArgumentsSchema);
+});
+
+Deno.test("JsonModelSearchRenderer: deduplicates type resolution across models of the same type", async () => {
+  let fetchCount = 0;
+  const methods = [
+    { name: "run", description: "Run it", arguments: {} },
+  ];
+  const fetchPreview: ModelPreviewFetcher = (item) => {
+    fetchCount++;
+    return Promise.resolve({
+      id: item.id,
+      name: item.name,
+      type: item.type,
+      version: 1,
+      tags: {},
+      globalArguments: {},
+      methods,
+    } as ModelGetData);
+  };
+  const renderer = createModelSearchRenderer("json", fetchPreview);
+  const handlers = renderer.handlers();
+
+  const items: ModelSearchItem[] = [
+    { id: "id-1", name: "model-a", type: "swamp/echo" },
+    { id: "id-2", name: "model-b", type: "swamp/echo" },
+    { id: "id-3", name: "model-c", type: "swamp/echo" },
+  ];
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => logs.push(String(args[0]));
+  try {
+    await handlers.completed({
+      kind: "completed",
+      data: { query: "", results: items },
+    });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assertEquals(fetchCount, 1);
+  const parsed = JSON.parse(logs[0]);
+  for (const result of parsed.results) {
+    assertEquals(result.methods, methods);
+  }
+});
+
+Deno.test("JsonModelSearchRenderer: gracefully handles fetchPreview failure", async () => {
+  const fetchPreview: ModelPreviewFetcher = () =>
+    Promise.reject(new Error("type not found"));
+  const renderer = createModelSearchRenderer("json", fetchPreview);
+  const handlers = renderer.handlers();
+
+  const items: ModelSearchItem[] = [
+    { id: "id-1", name: "broken-model", type: "missing/type" },
+  ];
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => logs.push(String(args[0]));
+  try {
+    await handlers.completed({
+      kind: "completed",
+      data: { query: "", results: items },
+    });
+  } finally {
+    console.log = originalLog;
+  }
+
+  const parsed = JSON.parse(logs[0]);
+  assertEquals(parsed.results.length, 1);
+  assertEquals(parsed.results[0].name, "broken-model");
+  assertEquals(parsed.results[0].methods, undefined);
+  assertEquals(parsed.results[0].globalArgumentsSchema, undefined);
 });


### PR DESCRIPTION
## Summary

- Enriches `swamp model search --json` output with `methods` and `globalArgumentsSchema` per result, closing the data gap between interactive and JSON output modes
- Deduplicates type resolution — each unique model type is resolved once regardless of how many models share it
- Gracefully degrades when type resolution fails — the result appears without detail rather than failing the whole search
- Remote server path (`--server`) is unaffected — outputs lean results as before (server protocol would need changes for enrichment, out of scope)

Closes swamp-club#1904

Co-authored-by: dieter <dieter@users.noreply.github.com>

## Test plan

- [x] Existing tests updated to properly await async handler
- [x] New test: enriched output includes methods and globalArgumentsSchema
- [x] New test: type deduplication (3 models same type, fetchPreview called once)
- [x] New test: graceful fallback when fetchPreview fails
- [x] Verification: lint, fmt, type-check, tests, compile, code review, UX review all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)