### PR TITLE
feat(access): add approve action for workflow gate authorization

### DIFF
--- a/design/enablers/access-control.md
+++ b/design/enablers/access-control.md
@@ -160,12 +160,18 @@ Implementation: `src/domain/access/resource_selector.ts`.
 
 ### Actions
 
-| Action  | Typical operations                                  |
-| ------- | --------------------------------------------------- |
-| `run`   | Execute a workflow or model method                  |
-| `read`  | Query data, view definitions, list resources        |
-| `write` | Create or update models, definitions, data          |
-| `admin` | Manage grants, groups, tokens, restricted models    |
+| Action    | Typical operations                                          |
+| --------- | ----------------------------------------------------------- |
+| `run`     | Execute a workflow or model method (implies `approve`)      |
+| `read`    | Query data, view definitions, list resources                |
+| `write`   | Create or update models, definitions, data                  |
+| `approve` | Approve or reject a workflow manual-approval gate           |
+| `admin`   | Manage grants, groups, tokens, restricted models            |
+
+**`run` implies `approve`**: a grant with `actions: [run]` also satisfies
+`approve` checks. This preserves backwards compatibility — existing `run` grants
+continue to permit approval. To grant approval without execution authority, use
+`actions: [approve]` alone.
 
 Implementation: `src/domain/access/action.ts`.
 
@@ -178,7 +184,8 @@ given (principal, action, resource) triple:
    groups)
 2. **Collect candidates** — find all grants whose subject is in the list
 3. **Filter** — keep only grants that match the resource selector, the requested
-   action, and the method name (when the grant specifies a `methods` list)
+   action (including implied actions: `run` implies `approve`), and the method
+   name (when the grant specifies a `methods` list)
 4. **Partition** — separate into deny grants and allow grants
 5. **Evaluate denies first** — for each deny grant, evaluate the condition (if
    any). The first matching deny wins and the request is rejected

--- a/design/primitives/workflows.md
+++ b/design/primitives/workflows.md
@@ -161,7 +161,10 @@ steps:
    local command performs no authorization of its own: `decidedBy` is recorded
    from `$USER`/`$USERNAME`, falling back to `"unknown"`
    (`src/libswamp/workflows/approve.ts`); authorization applies only on the
-   `--server` path via the `workflow.approve` handler. The `--run` flag
+   `--server` path via the `workflow.approve` handler, which checks the
+   `approve` action (not `run`). A `run` grant implies `approve`, so existing
+   grants continue to work; an `approve`-only grant permits gate decisions
+   without workflow execution authority. The `--run` flag
    disambiguates when multiple runs are suspended; it is optional when only
    one run is suspended.
 3. `swamp workflow resume <workflow> --run <id>` re-enters the executor, skips

--- a/src/cli/commands/access_can_i.ts
+++ b/src/cli/commands/access_can_i.ts
@@ -57,7 +57,7 @@ export const accessCanICommand = new Command()
   )
   .option(
     "--action <action:string>",
-    "Action to check (run, read, write, admin)",
+    "Action to check (run, read, write, approve, admin)",
   )
   .option(
     "--on <resource:string>",

--- a/src/cli/commands/access_check.ts
+++ b/src/cli/commands/access_check.ts
@@ -76,7 +76,7 @@ export const accessCheckCommand = new Command()
   )
   .option(
     "--action <action:string>",
-    "Action to check (run, read, write, admin)",
+    "Action to check (run, read, write, approve, admin)",
     { required: true },
   )
   .option(
@@ -177,7 +177,7 @@ export const accessCheckCommand = new Command()
     const actionResult = ActionSchema.safeParse(options.action);
     if (!actionResult.success) {
       throw new UserError(
-        `Invalid action "${options.action}": must be one of run, read, write, admin`,
+        `Invalid action "${options.action}": must be one of run, read, write, approve, admin`,
       );
     }
     const action: Action = actionResult.data;

--- a/src/cli/commands/access_helpers.ts
+++ b/src/cli/commands/access_helpers.ts
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
+import { ActionSchema } from "../../domain/access/action.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { resolveModelType } from "../../domain/extensions/extension_auto_resolver.ts";
 import { getAutoResolver } from "../auto_resolver_context.ts";
@@ -118,9 +119,9 @@ export function parseActionsFlag(value: string): string[] {
   const actions = value.split(",").map((a) => a.trim()).filter((a) =>
     a.length > 0
   );
-  const validActions = ["run", "read", "write", "admin"];
+  const validActions = ActionSchema.options;
   for (const action of actions) {
-    if (!validActions.includes(action)) {
+    if (!validActions.includes(action as typeof validActions[number])) {
       throw new UserError(
         `Invalid action "${action}": must be one of ${validActions.join(", ")}`,
       );

--- a/src/domain/access/action.ts
+++ b/src/domain/access/action.ts
@@ -19,6 +19,12 @@
 
 import { z } from "zod";
 
-export const ActionSchema = z.enum(["run", "read", "write", "admin"]);
+export const ActionSchema = z.enum([
+  "run",
+  "read",
+  "write",
+  "approve",
+  "admin",
+]);
 
 export type Action = z.infer<typeof ActionSchema>;

--- a/src/domain/access/grant_based_access_decision_service.ts
+++ b/src/domain/access/grant_based_access_decision_service.ts
@@ -69,7 +69,10 @@ function grantMatchesResource(grant: Grant, resource: AccessResource): boolean {
 }
 
 function grantMatchesAction(grant: Grant, action: Action): boolean {
-  return grant.actions.includes(action);
+  if (grant.actions.includes(action)) return true;
+  // run implies approve: a grant with "run" also matches "approve" requests
+  if (action === "approve" && grant.actions.includes("run")) return true;
+  return false;
 }
 
 function grantMatchesMethods(

--- a/src/domain/access/grant_based_access_decision_service_test.ts
+++ b/src/domain/access/grant_based_access_decision_service_test.ts
@@ -673,3 +673,90 @@ Deno.test("explain: methods filtering applies in explain path", () => {
   });
   assertEquals(noMatch.length, 0);
 });
+
+Deno.test("decide: run grant implies approve — allows approve action", () => {
+  const snapshot = new PolicySnapshot(
+    [makeGrant({ actions: ["run"] })],
+    [],
+    celEvaluator,
+  );
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  const result = service.decide(
+    makePrincipal("adam"),
+    "approve",
+    makeResource(),
+  );
+  assertEquals(result?.effect, "allow");
+});
+
+Deno.test("decide: approve-only grant allows approve but not run", () => {
+  const snapshot = new PolicySnapshot(
+    [makeGrant({ actions: ["approve"] })],
+    [],
+    celEvaluator,
+  );
+  const service = new GrantBasedAccessDecisionService(snapshot);
+
+  const approveResult = service.decide(
+    makePrincipal("adam"),
+    "approve",
+    makeResource(),
+  );
+  assertEquals(approveResult?.effect, "allow");
+
+  const runResult = service.decide(
+    makePrincipal("adam"),
+    "run",
+    makeResource(),
+  );
+  assertEquals(runResult, null);
+});
+
+Deno.test("decide: deny on approve blocks approval even with run grant", () => {
+  const snapshot = new PolicySnapshot(
+    [
+      makeGrant({ actions: ["run"], effect: "allow" }),
+      makeGrant({ actions: ["approve"], effect: "deny" }),
+    ],
+    [],
+    celEvaluator,
+  );
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  const result = service.decide(
+    makePrincipal("adam"),
+    "approve",
+    makeResource(),
+  );
+  assertEquals(result?.effect, "deny");
+});
+
+Deno.test("decide: run grant without approve still permits run action", () => {
+  const snapshot = new PolicySnapshot(
+    [makeGrant({ actions: ["run"] })],
+    [],
+    celEvaluator,
+  );
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  const result = service.decide(
+    makePrincipal("adam"),
+    "run",
+    makeResource(),
+  );
+  assertEquals(result?.effect, "allow");
+});
+
+Deno.test("explain: run-implies-approve flows through explain", () => {
+  const snapshot = new PolicySnapshot(
+    [makeGrant({ actions: ["run"] })],
+    [],
+    celEvaluator,
+  );
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  const results = service.explain(
+    makePrincipal("adam"),
+    "approve",
+    makeResource(),
+  );
+  assertEquals(results.length, 1);
+  assertEquals(results[0].effect, "allow");
+});

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -386,7 +386,7 @@ export function handleAccessCheck(
         socket,
         requestId,
         "invalid_action",
-        `Invalid action "${payload.action}": must be one of run, read, write, admin`,
+        `Invalid action "${payload.action}": must be one of run, read, write, approve, admin`,
       );
       return Promise.resolve();
     }
@@ -465,7 +465,7 @@ export function handleAccessCanI(
           socket,
           requestId,
           "invalid_action",
-          `Invalid action "${payload.action}": must be one of run, read, write, admin`,
+          `Invalid action "${payload.action}": must be one of run, read, write, approve, admin`,
         );
         return Promise.resolve();
       }

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -920,7 +920,7 @@ export async function handleWorkflowApprove(
     payload.workflowIdOrName,
   );
   if (
-    !authorizeOrReject(socket, requestId, principal, "run", {
+    !authorizeOrReject(socket, requestId, principal, "approve", {
       kind: "workflow",
       name: payload.workflowIdOrName,
       fields: workflowFields,
@@ -993,7 +993,7 @@ export async function handleWorkflowReject(
     payload.workflowIdOrName,
   );
   if (
-    !authorizeOrReject(socket, requestId, principal, "run", {
+    !authorizeOrReject(socket, requestId, principal, "approve", {
       kind: "workflow",
       name: payload.workflowIdOrName,
       fields: workflowFields,


### PR DESCRIPTION
## Summary

- Adds `approve` to `ActionSchema` so `workflow.approve` and `workflow.reject` can be authorized independently from `workflow.run`
- `run` implies `approve` for backwards compatibility — existing grants keep working unchanged
- Organizations that want separation of duties can now grant `approve` without `run`, enabling approve-only roles

## Details

The grant model previously had four actions: `run`, `read`, `write`, `admin`. Both `workflow.approve` and `workflow.reject` handlers authorized against `run`, making it impossible to express "may approve a gate but may not start runs." This adds `approve` as a fifth action and changes the approve/reject handlers to check it, while keeping `run` as a superset that implies `approve` — no existing grants break.

**What changed:**
- `ActionSchema` extended with `approve`
- `grantMatchesAction` treats `run` as implying `approve`
- `handleWorkflowApprove` and `handleWorkflowReject` authorize against `approve` instead of `run`
- `handleWorkflowResume` stays on `run` (resume is execution, not a gate decision)
- CLI help strings and error messages updated
- `access_helpers.ts` now derives valid actions from `ActionSchema.options` instead of hardcoding
- Design docs updated (`access-control.md`, `workflows.md`)

**What's NOT in scope:**
- No four-eyes / self-approval prevention logic
- No `run.initiatedBy` in CEL conditions
- Self-approval prevention is an organizational concern solved through IdP group separation

## Test plan

- [x] Unit tests for run-implies-approve matching
- [x] Unit tests for approve-only grants (approve allowed, run denied)
- [x] Unit tests for deny-approve overriding run-implies-approve
- [x] Unit tests for existing run grants unchanged
- [x] Unit tests for explain path flowing through implication
- [x] Full verification workflow (lint, fmt, type-check, tests, compile, code review, adversarial review, UX review)

Closes swamp-club#1957

🤖 Generated with [Claude Code](https://claude.com/claude-code)