### PR TITLE
fix(lock): clean up unreadable lock files instead of timing out (swamp-club#2039)

### DIFF
--- a/src/infrastructure/persistence/file_lock.ts
+++ b/src/infrastructure/persistence/file_lock.ts
@@ -165,6 +165,19 @@ export class FileLock implements DistributedLock {
             .warn`Waiting for lock ${this.lockPath} held by ${existing.holder} (pid ${existing.pid}, acquired ${ageMs}ms ago)`;
           contentionLogged = true;
         }
+      } else {
+        // Lock file exists on disk but is unreadable (0 bytes, corrupt
+        // JSON, or partial write from a crashed process). No holder info
+        // to respect — treat as stale and clean up.
+        const logger = getSwampLogger(["datastore", "lock"]);
+        logger
+          .warn`Removing unreadable lock file ${this.lockPath}`;
+        try {
+          await Deno.remove(this.lockPath);
+        } catch {
+          // Another process may have already cleaned it up
+        }
+        continue;
       }
 
       // Jittered exponential backoff, clamped to remaining budget

--- a/src/infrastructure/persistence/file_lock_test.ts
+++ b/src/infrastructure/persistence/file_lock_test.ts
@@ -451,6 +451,43 @@ Deno.test("FileLock - maxWaitMs override is respected", async () => {
   });
 });
 
+Deno.test("FileLock - zero-byte lock file is cleaned up and acquire succeeds", async () => {
+  await withTempDir(async (dir) => {
+    const lockPath = `${dir}/.datastore.lock`;
+    // Simulate a crash between Deno.open({ createNew }) and file.write()
+    const file = await Deno.open(lockPath, { createNew: true, write: true });
+    file.close();
+    const stat = await Deno.stat(lockPath);
+    assertEquals(stat.size, 0);
+
+    const lock = new FileLock(dir, { ttlMs: 5000, maxWaitMs: 2000 });
+    await lock.acquire();
+
+    const info = await lock.inspect();
+    assertEquals(info !== null, true);
+    assertEquals(info!.pid, Deno.pid);
+
+    await lock.release();
+  });
+});
+
+Deno.test("FileLock - corrupt JSON lock file is cleaned up and acquire succeeds", async () => {
+  await withTempDir(async (dir) => {
+    const lockPath = `${dir}/.datastore.lock`;
+    // Simulate a partial write (truncated JSON)
+    await Deno.writeTextFile(lockPath, '{"holder":"crash@host","hos');
+
+    const lock = new FileLock(dir, { ttlMs: 5000, maxWaitMs: 2000 });
+    await lock.acquire();
+
+    const info = await lock.inspect();
+    assertEquals(info !== null, true);
+    assertEquals(info!.pid, Deno.pid);
+
+    await lock.release();
+  });
+});
+
 Deno.test("FileLock - contention message includes lock file path", async () => {
   await withTempDir(async (dir) => {
     // Set up a LogTape capture sink for the datastore.lock category


### PR DESCRIPTION
## Summary

- Fix `FileLock.acquire()` to treat unreadable lock files (0 bytes or corrupt JSON) as stale, removing them and retrying instead of spinning until the 60-second timeout
- Add unit tests for zero-byte and corrupt-JSON lock file recovery

## Problem

When a process crashes between `Deno.open({ createNew: true })` and `file.write()`, the lock file is left as 0 bytes on disk. `readLockFile()` returns `null` because `JSON.parse("")` throws, and the `if (existing)` guard skips the staleness check entirely — causing the acquire loop to back off and retry until timeout, never cleaning up the orphaned file.

Reported by @svendowideit after a reboot left a stale lock from July 31st blocking workflow runs.

## Fix

Added an `else` branch after the existing staleness check: when the lock file exists on disk but `readLockFile()` returns `null`, treat it as stale (no holder info to respect), log a warning, remove it, and retry.

## Test plan

- [x] New test: zero-byte lock file is cleaned up and acquire succeeds
- [x] New test: corrupt JSON lock file is cleaned up and acquire succeeds
- [x] All 22 existing `file_lock_test.ts` tests pass
- [x] Full verification: lint, fmt, type-check, tests, compile, code review, adversarial review

Closes swamp-club/lab#2039

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: svendowideit <svendowideit@users.noreply.github.com>