### PR TITLE
fix(datastores): raise sync error message truncation limit from 200 to 2000 chars (#2041)

### DIFF
--- a/src/infrastructure/persistence/sync_error_diagnostic.ts
+++ b/src/infrastructure/persistence/sync_error_diagnostic.ts
@@ -27,7 +27,7 @@
 
 export type SyncOperation = "pull" | "push";
 
-const MESSAGE_PREVIEW_LIMIT = 200;
+const MESSAGE_PREVIEW_LIMIT = 2000;
 
 export interface SyncErrorSummary {
   /**

--- a/src/infrastructure/persistence/sync_error_diagnostic_test.ts
+++ b/src/infrastructure/persistence/sync_error_diagnostic_test.ts
@@ -129,17 +129,17 @@ Deno.test("summarizeSyncError: empty message treated as missing", () => {
   assertEquals(fields.errorMessage, undefined);
 });
 
-Deno.test("summarizeSyncError: long message truncated at 200 chars with ellipsis", () => {
-  const long = "a".repeat(500);
+Deno.test("summarizeSyncError: long message truncated at 2000 chars with ellipsis", () => {
+  const long = "a".repeat(5000);
   const err = new Error(long);
   const { summary, fields } = summarizeSyncError("pull", "@t/x", err);
   // `fields.errorMessage` retains the full message for consumers that want it
   // (e.g. .cause-walking renderers); only the summary is truncated.
   assertEquals(fields.errorMessage, long);
-  // Summary contains exactly 200 'a's followed by ellipsis.
-  assertStringIncludes(summary, "a".repeat(200) + "…");
-  // Summary does NOT contain the 201st 'a' because it was truncated.
-  const after = summary.split("a".repeat(200))[1] ?? "";
+  // Summary contains exactly 2000 'a's followed by ellipsis.
+  assertStringIncludes(summary, "a".repeat(2000) + "…");
+  // Summary does NOT contain the 2001st 'a' because it was truncated.
+  const after = summary.split("a".repeat(2000))[1] ?? "";
   assertEquals(after.startsWith("a"), false);
 });
 


### PR DESCRIPTION
## Summary

- Raise `MESSAGE_PREVIEW_LIMIT` in `sync_error_diagnostic.ts` from 200 to 2000 chars
- Update truncation test to match the new limit

## Problem

When extension datastores (e.g. `@swamp/s3-datastore`) throw errors that list
failing file paths, the 200-char truncation budget is consumed by file paths
before the actual S3/MinIO error (e.g. `AccessDenied`, `SignatureDoesNotMatch`)
is shown. Users see a truncated message with no actionable root cause.

Discovered while diagnosing a user's `datastore setup extension` push failure
where 24901 files failed — the warning showed only file paths, hiding the
actual error from the extension.

## Fix

Bump the limit to 2000 chars so the actual error detail is visible in the
warning output. The full untruncated message remains available on
`fields.errorMessage` for consumers that need fidelity.

## Test plan

- [x] Updated existing truncation test to assert on 2000-char limit
- [x] All 17 `sync_error_diagnostic_test.ts` tests pass
- [x] Full verification: lint, fmt, type-check, tests, compile, code review,
  adversarial review

Closes swamp-club/lab#2041

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>