### PR TITLE
fix(data): add modelName tag to report artifacts for catalog query visibility

### DIFF
--- a/src/domain/reports/report_execution_service.ts
+++ b/src/domain/reports/report_execution_service.ts
@@ -215,6 +215,7 @@ async function persistReportData(
   markdown: string,
   json: Record<string, unknown>,
   varySuffix?: string,
+  modelName?: string,
 ): Promise<DataHandle[]> {
   const handles: DataHandle[] = [];
   const tags: Record<string, string> = {
@@ -222,6 +223,7 @@ async function persistReportData(
     reportName,
     reportScope: scope,
     ...(varySuffix ? { varySuffix } : {}),
+    ...(modelName ? { modelName } : {}),
   };
 
   const sanitized = sanitizeReportNameForData(reportName);
@@ -329,6 +331,10 @@ export async function executeReports(
   varySuffix?: string,
   emitUnresolvableRequireFailures = true,
 ): Promise<ReportExecutionSummary> {
+  const modelName = context.scope === "workflow"
+    ? context.workflowName
+    : context.definition.name;
+
   // Promote lazy-registered reports for every candidate name before calling
   // getAll(). getAll() only returns fully-loaded entries from the registry's
   // `reports` Map; lazy entries in `lazyTypes` are excluded. Without this
@@ -415,6 +421,7 @@ export async function executeReports(
           fallback.markdown,
           fallback.json,
           varySuffix,
+          modelName,
         );
       } catch {
         // Best-effort — the failure event carries the message regardless.
@@ -486,6 +493,7 @@ export async function executeReports(
         result.markdown,
         result.json,
         varySuffix,
+        modelName,
       );
 
       events?.onReportCompleted(
@@ -528,6 +536,7 @@ export async function executeReports(
           fallback.markdown,
           fallback.json,
           varySuffix,
+          modelName,
         );
       } catch {
         // Best-effort — don't mask the original report error.

--- a/src/domain/reports/report_execution_service_test.ts
+++ b/src/domain/reports/report_execution_service_test.ts
@@ -1979,3 +1979,100 @@ Deno.test("executeReports: mixed empty and non-empty reports persist only non-em
   assertEquals(contentResult?.dataHandles?.length, 2);
   assertEquals(saved.length, 2);
 });
+
+// --- modelName tag tests ---
+
+Deno.test("executeReports - method scope includes modelName tag from definition", async () => {
+  const registry = new ReportRegistry();
+  registry.register("tag-test", makeReport("method"));
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("test/model");
+
+  const context: MethodReportContext = {
+    scope: "method",
+    repoDir: "/tmp/test",
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fatal: () => {},
+    } as unknown as MethodReportContext["logger"],
+    // deno-lint-ignore no-explicit-any
+    dataRepository: repo as any,
+    // deno-lint-ignore no-explicit-any
+    definitionRepository: {} as any,
+    modelType,
+    modelId: "test-id",
+    definition: { id: "test-id", name: "my-model", version: 1, tags: {} },
+    globalArgs: {},
+    methodArgs: {},
+    methodName: "run",
+    executionStatus: "succeeded",
+    dataHandles: [],
+    extensionFile: () => {
+      throw new Error("extensionFile not stubbed in this test");
+    },
+  };
+
+  await executeReports(
+    registry,
+    context,
+    modelType,
+    "test-id",
+    { require: ["tag-test"] },
+    {},
+    undefined,
+    "run",
+  );
+
+  assertEquals(saved.length, 2);
+  assertEquals(saved[0].tags.modelName, "my-model");
+  assertEquals(saved[1].tags.modelName, "my-model");
+});
+
+Deno.test("executeReports - workflow scope includes modelName tag from workflowName", async () => {
+  const registry = new ReportRegistry();
+  registry.register("wf-report", makeReport("workflow"));
+
+  const { repo, saved } = createInMemoryDataRepo();
+  const modelType = ModelType.create("workflow");
+
+  const context: WorkflowReportContext = {
+    scope: "workflow",
+    repoDir: "/tmp/test",
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      fatal: () => {},
+    } as unknown as WorkflowReportContext["logger"],
+    // deno-lint-ignore no-explicit-any
+    dataRepository: repo as any,
+    // deno-lint-ignore no-explicit-any
+    definitionRepository: {} as any,
+    workflowId: "wf-123",
+    workflowRunId: "run-456",
+    workflowName: "my-workflow",
+    workflowStatus: "succeeded",
+    stepExecutions: [],
+  };
+
+  await executeReports(
+    registry,
+    context,
+    modelType,
+    "wf-123",
+    { require: ["wf-report"] },
+    {},
+    undefined,
+    undefined,
+    undefined,
+  );
+
+  assertEquals(saved.length, 2);
+  assertEquals(saved[0].tags.modelName, "my-workflow");
+  assertEquals(saved[1].tags.modelName, "my-workflow");
+});


### PR DESCRIPTION
## Summary

- Report artifacts written by `persistReportData()` bypassed the `modelName` tag auto-injection in the normal `createResourceWriter()` path, causing them to be indexed in the SQLite catalog with an empty `model_name` column
- This made report data invisible to model-scoped `data query` predicates like `modelName == "X"`, even though `data list` and `data versions` (filesystem-based) returned them correctly
- Adds the `modelName` tag to report persistence, sourced from `definition.name` (method/model scope) or `workflowName` (workflow scope)
- Forward fix only — existing data self-heals as new report versions are written

Closes swamp-club#2035

## Test plan

- [x] Unit test: method scope report artifacts include `modelName` tag from `definition.name`
- [x] Unit test: workflow scope report artifacts include `modelName` tag from `workflowName`
- [x] All 55 report execution service tests pass
- [x] Full verification: lint, fmt, type-check, tests (11190 passed), compile, code review, adversarial review

Co-authored-by: Dieter <Dieter@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)