### PR TITLE
fix(extensions): surface auto-install bundle conflicts at warn level (swamp-club#2037)

### DIFF
--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -247,7 +247,7 @@ export function createAutoResolveInstallerAdapter(
       } catch (error) {
         if (error instanceof ConflictError) {
           logger
-            .debug`Auto-install of ${extensionName} hit conflicts: ${error.conflicts}`;
+            .warn`Auto-install of ${extensionName} failed: bundle files already exist on disk and the type was not registered. To resolve: swamp extension pull ${extensionName} --force`;
           return null;
         }
         throw error;


### PR DESCRIPTION
## Summary

- Upgraded the ConflictError log in the auto-resolver from `debug` to `warn` with an actionable message — operators now see why `Unknown model type` errors occur and how to recover (`swamp extension pull <name> --force`)
- Root cause is a deployment misconfiguration: running `swamp extension install` in an init container before the managed-config sentinel exists writes bundles to the default path, then the serve switches to managed paths and the auto-resolver re-downloads the same bundle, hitting a silent conflict

## Test plan

- [x] All 11,189 existing tests pass
- [x] Build verification: 9/9 steps passed (lint, fmt, type-check, tests, compile, deps-audit, binary-check)
- [x] Code review: passed
- [x] Adversarial/UX/security reviews: skipped (guards — only `src/cli/auto_resolver_adapters.ts` changed)

Fixes swamp-club#2037

🤖 Generated with [Claude Code](https://claude.com/claude-code)