### PR TITLE
feat(serve): audit log Phase 2 — WAL, chain hashing, query API, complete coverage

### DIFF
--- a/design/enablers/serve-audit.md
+++ b/design/enablers/serve-audit.md
@@ -1,14 +1,14 @@
 ---
 audience: everyone
-last-verified: 2026-09-04 @ HEAD
+last-verified: 2026-09-05 @ HEAD
 ---
 
 # Serve Audit
 
-Audit event pipeline for `swamp serve`. Automatically captures authorization
-denials across all handlers and success/failure events for high-value operations
-(execution, secrets, admin, access). Events persist to remote stores as
-date-partitioned JSONL.
+Audit event pipeline for `swamp serve`. Captures authorization decisions across
+all handlers and success/failure events for every operation. Events are
+chain-hashed for tamper evidence, persisted durably via a write-ahead log, and
+queryable through the `audit.query` API and `swamp audit log` CLI command.
 
 This is distinct from the CLI audit subsystem (`src/domain/audit/`), which
 tracks local command history. The serve audit bounded context
@@ -18,21 +18,30 @@ authenticated WebSocket connections.
 ## How it works
 
 ```
-Handler → authorizeOrReject / audited() → AuditEmitter → RingBuffer → StoreSink → AuditStore(s)
+Handler → authorizeOrReject / audited() → AuditEmitter → RingBuffer → [chain hash] → WalSink/StoreSink → AuditStore(s)
 ```
 
-1. **authorizeOrReject** emits a denial event as a side effect when access is
-   denied (optional `AuditEmitter` parameter — existing callers are unaffected).
+1. **authorizeOrReject** returns `{ allowed, decision }` — the `AccessDecision`
+   is captured in the audit event so every allow/deny is traceable to a specific
+   grant rule. Denials emit an audit event as a side effect.
 2. **audited()** wraps a handler's `Promise<void>`, emitting success on
    resolution and failure on rejection. It re-throws the original error so
-   handler semantics are unchanged.
+   handler semantics are unchanged. All 106+ handlers are wrapped.
 3. **AuditEmitter** appends events synchronously to a **RingBuffer** (10,000
-   capacity), then drains asynchronously to registered sinks. Sink errors are
-   logged and absorbed — audit never disrupts request handling.
-4. **StoreSink** batches events in memory, writes date-partitioned JSONL
+   capacity). During drain, events receive chain-hashed integrity fields
+   (sequence, SHA-256 digest, version) via **AuditChainState** before reaching
+   sinks. Sink errors are logged and absorbed — audit never disrupts request
+   handling unless fail-secure mode is enabled.
+4. **AuditPolicy** evaluates each event against ordered rules to determine the
+   detail level (none, metadata, request, requestResponse). Management-tier
+   events (audit.query, audit.verify) default to metadata level.
+5. **WalSink** spills events to local disk when the remote backend is
+   unreachable, replays on reconnection. Configurable max size (default 100MB).
+6. **StoreSink** batches events in memory, writes date-partitioned JSONL
    (`events/YYYY-MM-DD/<uuid>.jsonl`) to all configured **AuditStore** targets
-   on a timer or when the batch is full. Flushes on shutdown via `AbortSignal`.
-5. **RemoteAuditStore** adapts `ControlPlaneStore` with a key prefix.
+   on a timer or when the batch is full. Supports per-target retention with
+   automatic date-partition GC.
+7. **RemoteAuditStore** adapts `ControlPlaneStore` with a key prefix.
 
 ## Configuration
 
@@ -45,7 +54,6 @@ application data, so it cannot be tampered with by someone who has access to
 the main datastore.
 
 ```yaml
-# Recommended: dedicated audit store (separate S3 bucket)
 audit:
   stores:
     - target: security-audit
@@ -53,70 +61,82 @@ audit:
       config:
         bucket: my-audit-bucket
         region: us-east-1
+      retention:
+        days: 90
   batch-size: 100
   flush-interval: 5s
+  fail-open: true
+  policy:
+    default-level: metadata
+    rules:
+      - category: secrets
+        level: requestResponse
+      - tier: management
+        level: metadata
+  wal:
+    directory: .swamp/audit-wal
+    max-size: 100MB
 ```
 
 Config values support `${{ }}` expression interpolation — the same syntax as
 datastore config in `.swamp.yaml` (see
 [datastores.md § Config Value Interpolation](datastores.md#config-value-interpolation)).
-Two expression namespaces are available: `${{ env.VAR }}` for environment
-variables and `${{ vault.get(vaultName, secretKey) }}` for vault secrets.
-
-```yaml
-audit:
-  stores:
-    - target: security-audit
-      type: "@swamp/s3-datastore"
-      config:
-        bucket: audit-bucket
-        region: us-east-1
-        accessKeyId: "${{ env.AUDIT_AWS_ACCESS_KEY_ID }}"
-        secretAccessKey: "${{ vault.get(infra, audit-s3-secret) }}"
-```
 
 A store entry without `type` + `config` falls back to the repo's existing
 control-plane store (shared datastore). This works for development but logs
 a warning at startup — production deployments should use a dedicated store.
 
-```yaml
-# Development fallback: shared datastore (warns at startup)
-audit:
-  stores:
-    - target: default
-```
-
 ## What is audited
 
-- **All 106 handlers**: automatic denial auditing via `authorizeOrReject`
-- **~20 high-value handlers**: success/failure via `audited()` wrapper
-  - Execution: `workflow.run`, `model.method.run`
-  - Secrets: `vault.get`, `vault.put`, `vault.delete`
-  - Access: `access.check`, `access.can-i`, `access.grant.list`,
-    `access.group.list`, `access.group.list-idp`, `access.reload`
-  - Admin: `serve.reload`, `model.create`, `model.delete`, `model.edit`,
-    `workflow.create`, `workflow.delete`, `workflow.edit`, `data.delete`
+- **All handlers**: authorization decision capture via `authorizeOrReject` and
+  success/failure auditing via `audited()` wrapper
+- **Chain hashing**: every event carries a sequence number and SHA-256 digest
+  chaining it to the previous event for tamper evidence
+- **Access decisions**: every allow/deny is recorded with the matched grant
+  rule, effect, and principal groups at decision time
+
+## Query API
+
+- `audit.query` — paginated query with filters (time range, principal,
+  category, action, resource, outcome). Requires `read` permission on the
+  `audit` resource kind.
+- `audit.verify` — verify chain integrity for a time range, reports broken
+  chains or missing events
+
+## CLI commands
+
+- `swamp audit log` — query the audit log with filters (`--since`, `--until`,
+  `--principal`, `--category`, `--action`, `--outcome`, `--limit`)
+- `swamp audit verify` — check chain integrity for a time range
 
 ## Domain model
 
 | Type              | DDD Building Block | Location                          |
 | ----------------- | ------------------ | --------------------------------- |
 | AuditEvent        | Entity             | `src/domain/serve_audit/`         |
+| ChainedAuditEvent | Type Alias         | `src/domain/serve_audit/`         |
+| AuditDecision     | Value Object       | `src/domain/serve_audit/`         |
 | AuditCategory     | Value Object       | `src/domain/serve_audit/`         |
 | AuditStage        | Value Object       | `src/domain/serve_audit/`         |
 | AuditOutcome      | Value Object       | `src/domain/serve_audit/`         |
+| AuditLevel        | Value Object       | `src/domain/serve_audit/`         |
+| AuditPolicyRule   | Value Object       | `src/domain/serve_audit/`         |
+| AuditChainState   | Domain Service     | `src/domain/serve_audit/`         |
 | RingBuffer        | Data Structure     | `src/domain/serve_audit/`         |
 | AuditEmitter      | Domain Service     | `src/domain/serve_audit/`         |
+| AuditPolicy       | Value Object       | `src/domain/serve_audit/`         |
+| AuditWal          | Domain Service     | `src/domain/serve_audit/`         |
+| AuditQueryService | Domain Service     | `src/domain/serve_audit/`         |
 | AuditSink         | Port Interface     | `src/domain/serve_audit/`         |
 | AuditStore        | Port Interface     | `src/domain/serve_audit/`         |
 | AuditEventBuilder | Factory            | `src/domain/serve_audit/`         |
 | RemoteAuditStore  | Adapter            | `src/infrastructure/persistence/` |
 | StoreSink         | Adapter            | `src/serve/audit_sinks/`          |
+| WalSink           | Adapter            | `src/serve/audit_sinks/`          |
 
 ## Future phases
 
-- **Phase 2**: Write-ahead log, chain hashing, query API, complete handler
-  coverage
-- **Phase 3**: Real-time WebSocket streaming
-- **Phase 4**: Webhook and syslog sinks, bulk export
-- **Phase 5**: Extension sinks, alerting
+- **Phase 3**: Real-time WebSocket streaming (`audit.subscribe`), `--follow`
+  for `swamp audit log`
+- **Phase 4**: Webhook and syslog sinks, bulk export, HMAC
+- **Phase 5**: Extension sinks, alerting, compliance templates

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -53,6 +53,8 @@ import {
   createLibSwampContext,
 } from "../../libswamp/mod.ts";
 import { createAuditTimelineRenderer } from "../../presentation/renderers/audit_timeline.ts";
+import { auditLogCommand } from "./audit_log.ts";
+import { auditVerifyCommand } from "./audit_verify.ts";
 
 /**
  * Reads all of stdin as a string.
@@ -245,4 +247,6 @@ export const auditCommand = withRemoteOptions(
   );
 
   ctx.logger.debug("Audit command completed");
-}).command("record", auditRecordCommand);
+}).command("record", auditRecordCommand)
+  .command("log", auditLogCommand)
+  .command("verify", auditVerifyCommand);

--- a/src/cli/commands/audit_log.ts
+++ b/src/cli/commands/audit_log.ts
@@ -1,0 +1,106 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { AuditQueryResponse } from "../../serve/protocol.ts";
+import { renderAuditLog } from "../../presentation/output/audit_log_output.ts";
+import { UserError } from "../../domain/errors.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const auditLogCommand = withRemoteOptions(
+  new Command()
+    .name("log")
+    .description("Query the serve audit log")
+    .example("Last 24 hours", "swamp audit log --server http://localhost:7443")
+    .example(
+      "Filter by category",
+      "swamp audit log --server http://localhost:7443 --category secrets",
+    )
+    .example(
+      "Filter by outcome",
+      "swamp audit log --server http://localhost:7443 --outcome denied",
+    )
+    .option(
+      "--since <date:string>",
+      "Start time, e.g. 2026-09-01T00:00:00Z [default: 24 hours ago]",
+    )
+    .option(
+      "--until <date:string>",
+      "End time, e.g. 2026-09-02T00:00:00Z [default: now]",
+    )
+    .option("--principal <id:string>", "Filter by principal ID")
+    .option(
+      "--category <cat:string>",
+      "Filter by audit category (auth, access, execution, secrets, admin, data)",
+    )
+    .option("--action <action:string>", "Filter by action")
+    .option(
+      "--outcome <outcome:string>",
+      "Filter by outcome (success, failure, denied)",
+    )
+    .option(
+      "--cursor <token:string>",
+      "Pagination cursor from a previous query",
+    )
+    .option("--limit <count:integer>", "Max events to return [default: 100]", {
+      default: 100,
+    }),
+).action(async function (options: AnyOptions) {
+  const ctx = createContext(options as GlobalOptions, ["audit", "log"]);
+
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (!server) {
+    throw new UserError(
+      "The audit log command requires a running serve instance. Use --server to specify the URL.",
+    );
+  }
+
+  const token = await resolveServerToken(
+    server,
+    options.token as string | undefined,
+  );
+
+  const response = await requestServerResponse<AuditQueryResponse>(
+    { server, token },
+    {
+      type: "audit.query",
+      payload: {
+        since: options.since,
+        until: options.until,
+        principal: options.principal,
+        category: options.category,
+        action: options.action,
+        outcome: options.outcome,
+        limit: options.limit,
+        cursor: options.cursor,
+      },
+    },
+  );
+
+  renderAuditLog(response, ctx.outputMode);
+});

--- a/src/cli/commands/audit_log_test.ts
+++ b/src/cli/commands/audit_log_test.ts
@@ -1,0 +1,91 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+import "../../domain/models/models.ts";
+
+await initializeLogging({});
+
+Deno.test("auditLogCommand: module loads", async () => {
+  const { auditLogCommand } = await import("./audit_log.ts");
+  assertEquals(auditLogCommand.getName(), "log");
+});
+
+Deno.test("auditLogCommand: has correct description", async () => {
+  const { auditLogCommand } = await import("./audit_log.ts");
+  assertEquals(auditLogCommand.getDescription(), "Query the serve audit log");
+});
+
+Deno.test("auditLogCommand: has --since option", async () => {
+  const { auditLogCommand } = await import("./audit_log.ts");
+  const options = auditLogCommand.getOptions();
+  const opt = options.find((o) => o.name === "since");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("auditLogCommand: has --until option", async () => {
+  const { auditLogCommand } = await import("./audit_log.ts");
+  const options = auditLogCommand.getOptions();
+  const opt = options.find((o) => o.name === "until");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("auditLogCommand: has --principal option", async () => {
+  const { auditLogCommand } = await import("./audit_log.ts");
+  const options = auditLogCommand.getOptions();
+  const opt = options.find((o) => o.name === "principal");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("auditLogCommand: has --category option", async () => {
+  const { auditLogCommand } = await import("./audit_log.ts");
+  const options = auditLogCommand.getOptions();
+  const opt = options.find((o) => o.name === "category");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("auditLogCommand: has --action option", async () => {
+  const { auditLogCommand } = await import("./audit_log.ts");
+  const options = auditLogCommand.getOptions();
+  const opt = options.find((o) => o.name === "action");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("auditLogCommand: has --outcome option", async () => {
+  const { auditLogCommand } = await import("./audit_log.ts");
+  const options = auditLogCommand.getOptions();
+  const opt = options.find((o) => o.name === "outcome");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("auditLogCommand: has --limit option", async () => {
+  const { auditLogCommand } = await import("./audit_log.ts");
+  const options = auditLogCommand.getOptions();
+  const opt = options.find((o) => o.name === "limit");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("auditLogCommand: is registered as subcommand of audit", async () => {
+  const { auditCommand } = await import("./audit.ts");
+  const commands = auditCommand.getCommands();
+  const logCmd = commands.find((c) => c.getName() === "log");
+  assertEquals(logCmd !== undefined, true);
+});

--- a/src/cli/commands/audit_verify.ts
+++ b/src/cli/commands/audit_verify.ts
@@ -1,0 +1,86 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import type { AuditVerifyResponse } from "../../serve/protocol.ts";
+import { renderAuditVerify } from "../../presentation/output/audit_verify_output.ts";
+import { UserError } from "../../domain/errors.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+export const auditVerifyCommand = withRemoteOptions(
+  new Command()
+    .name("verify")
+    .description("Verify audit log chain integrity")
+    .example(
+      "Verify last 24 hours",
+      "swamp audit verify --server http://localhost:7443",
+    )
+    .example(
+      "Verify a time range",
+      "swamp audit verify --server http://localhost:7443 --since 2026-09-01T00:00:00Z --until 2026-09-02T00:00:00Z",
+    )
+    .option(
+      "--since <date:string>",
+      "Start time, e.g. 2026-09-01T00:00:00Z [default: 24 hours ago]",
+    )
+    .option(
+      "--until <date:string>",
+      "End time, e.g. 2026-09-02T00:00:00Z [default: now]",
+    ),
+).action(async function (options: AnyOptions) {
+  const ctx = createContext(options as GlobalOptions, ["audit", "verify"]);
+
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (!server) {
+    throw new UserError(
+      "The audit verify command requires a running serve instance. Use --server to specify the URL.",
+    );
+  }
+
+  const token = await resolveServerToken(
+    server,
+    options.token as string | undefined,
+  );
+
+  const response = await requestServerResponse<AuditVerifyResponse>(
+    { server, token },
+    {
+      type: "audit.verify",
+      payload: {
+        since: options.since,
+        until: options.until,
+      },
+    },
+  );
+
+  renderAuditVerify(response, ctx.outputMode);
+
+  if (!response.valid) {
+    Deno.exitCode = 1;
+  }
+});

--- a/src/cli/commands/audit_verify_test.ts
+++ b/src/cli/commands/audit_verify_test.ts
@@ -1,0 +1,59 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+
+import "../../domain/models/models.ts";
+
+await initializeLogging({});
+
+Deno.test("auditVerifyCommand: module loads", async () => {
+  const { auditVerifyCommand } = await import("./audit_verify.ts");
+  assertEquals(auditVerifyCommand.getName(), "verify");
+});
+
+Deno.test("auditVerifyCommand: has correct description", async () => {
+  const { auditVerifyCommand } = await import("./audit_verify.ts");
+  assertEquals(
+    auditVerifyCommand.getDescription(),
+    "Verify audit log chain integrity",
+  );
+});
+
+Deno.test("auditVerifyCommand: has --since option", async () => {
+  const { auditVerifyCommand } = await import("./audit_verify.ts");
+  const options = auditVerifyCommand.getOptions();
+  const opt = options.find((o) => o.name === "since");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("auditVerifyCommand: has --until option", async () => {
+  const { auditVerifyCommand } = await import("./audit_verify.ts");
+  const options = auditVerifyCommand.getOptions();
+  const opt = options.find((o) => o.name === "until");
+  assertEquals(opt !== undefined, true);
+});
+
+Deno.test("auditVerifyCommand: is registered as subcommand of audit", async () => {
+  const { auditCommand } = await import("./audit.ts");
+  const commands = auditCommand.getCommands();
+  const verifyCmd = commands.find((c) => c.getName() === "verify");
+  assertEquals(verifyCmd !== undefined, true);
+});

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -110,10 +110,19 @@ import {
   parseExplicitFlags,
   parseWebhookConfig,
 } from "../../serve/serve_config.ts";
-import { AuditEmitter } from "../../domain/serve_audit/audit_emitter.ts";
+import {
+  type AuditCategory,
+  AuditChainState,
+  AuditEmitter,
+  type AuditLevel,
+  AuditPolicy,
+  type AuditPolicyRule,
+  type AuditStore,
+  AuditWal,
+} from "../../domain/serve_audit/mod.ts";
 import { StoreSink } from "../../serve/audit_sinks/store_sink.ts";
+import { WalSink } from "../../serve/audit_sinks/wal_sink.ts";
 import { RemoteAuditStore } from "../../infrastructure/persistence/remote_audit_store.ts";
-import type { AuditStore } from "../../domain/serve_audit/audit_store.ts";
 import { resolveDatastoreExpressions } from "../datastore_expression_resolver.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
 import { modelRegistry } from "../../domain/models/model.ts";
@@ -259,6 +268,61 @@ export interface CancelDeps {
   cancelRegistry: RunCancelRegistry;
   activeRunRegistry?: ActiveRunRegistry;
   scheduledCancelByRunId?: (id: string) => boolean;
+}
+
+const CHAIN_RECONSTRUCT_LOOKBACK_DAYS = 14;
+
+async function reconstructChainStateFromStore(
+  store: AuditStore,
+): Promise<{ sequence: number; previousDigest: string } | null> {
+  try {
+    let latestSeq = -1;
+    let latestDigest = "";
+    let found = false;
+    for (let d = 0; d < CHAIN_RECONSTRUCT_LOOKBACK_DAYS; d++) {
+      const date = new Date(Date.now() - d * 86_400_000).toISOString().slice(
+        0,
+        10,
+      );
+      const keys = await store.list(`events/${date}/`);
+      for (const key of keys) {
+        const data = await store.get(key);
+        if (!data) continue;
+        const text = new TextDecoder().decode(data);
+        for (const line of text.split("\n")) {
+          if (!line.trim()) continue;
+          try {
+            const event = JSON.parse(line) as Record<string, unknown>;
+            const seq = event.sequence;
+            const digest = event.digest;
+            if (
+              event.version === 1 &&
+              typeof seq === "number" &&
+              typeof digest === "string"
+            ) {
+              if (seq > latestSeq) {
+                latestSeq = seq;
+                latestDigest = digest;
+                found = true;
+              }
+            }
+          } catch {
+            // skip malformed
+          }
+        }
+      }
+      if (found) break;
+    }
+    if (found) {
+      return {
+        sequence: latestSeq,
+        previousDigest: latestDigest,
+      };
+    }
+  } catch {
+    // best-effort reconstruction
+  }
+  return null;
 }
 
 export async function cancelExecution(
@@ -2730,7 +2794,10 @@ export const serveCommand = new Command()
     // ── Audit Pipeline ───────────────────────────────────────────────
     const auditConfig = parseAuditConfig(configFile);
     if (auditConfig) {
-      const auditStores: AuditStore[] = [];
+      const auditStoresWithConfig: {
+        store: AuditStore;
+        entry: (typeof auditConfig.stores)[number];
+      }[] = [];
       for (const entry of auditConfig.stores) {
         if (entry.type && entry.config) {
           await datastoreTypeRegistry.ensureLoaded();
@@ -2761,20 +2828,22 @@ export const serveCommand = new Command()
               `Audit store target "${entry.target}": datastore type "${entry.type}" does not support control-plane storage`,
             );
           }
-          auditStores.push(
-            new RemoteAuditStore(store, `audit/${entry.target}/`),
-          );
+          auditStoresWithConfig.push({
+            store: new RemoteAuditStore(store, `audit/${entry.target}/`),
+            entry,
+          });
           logger.info(
             "Audit target {target}: dedicated {type} datastore",
             { target: entry.target, type: entry.type },
           );
         } else if (controlPlaneStore) {
-          auditStores.push(
-            new RemoteAuditStore(
+          auditStoresWithConfig.push({
+            store: new RemoteAuditStore(
               controlPlaneStore,
               `_audit/${entry.target}/`,
             ),
-          );
+            entry,
+          });
           logger.warn(
             "Audit target {target}: using shared control-plane store (configure type + config for a dedicated audit store)",
             { target: entry.target },
@@ -2786,17 +2855,112 @@ export const serveCommand = new Command()
           );
         }
       }
+      const auditStores = auditStoresWithConfig.map((s) => s.store);
       if (auditStores.length > 0) {
+        const storesWithRetention = auditStoresWithConfig.map(
+          ({ store, entry }) => {
+            const retentionDays = (entry as { retention?: { days?: number } })
+              ?.retention?.days;
+            return retentionDays ? { store, retentionDays } : store;
+          },
+        );
         const storeSink = new StoreSink({
-          stores: auditStores,
+          stores: storesWithRetention,
           batchSize: auditConfig.batchSize,
           flushIntervalMs: auditConfig.flushIntervalMs,
           signal: ac.signal,
         });
-        connectionCtx.auditEmitter = new AuditEmitter([storeSink]);
+
+        const walDir = resolve(resolvedRepoDir, auditConfig.walDir);
+        const wal = new AuditWal({
+          dir: walDir,
+          maxWalBytes: auditConfig.walMaxBytes,
+        });
+        await wal.initialize();
+        const walSink = new WalSink({
+          wal,
+          downstream: storeSink,
+        });
+
+        const policyRules = auditConfig.policyRules.map((r) => ({
+          category: r.category as AuditCategory | undefined,
+          action: r.action,
+          tier: r.tier as AuditPolicyRule["tier"],
+          level: r.level as AuditLevel,
+        }));
+        const policy = new AuditPolicy(
+          policyRules,
+          auditConfig.policyDefaultLevel as AuditLevel,
+        );
+
+        let highestSeq = -1;
+        let highestDigest = "";
+        for (const segName of wal.listSegments()) {
+          const events = await wal.readSegment(segName);
+          for (const event of events) {
+            const e = event as unknown as Record<string, unknown>;
+            if (
+              typeof e.sequence === "number" && typeof e.digest === "string" &&
+              e.sequence > highestSeq
+            ) {
+              highestSeq = e.sequence;
+              highestDigest = e.digest as string;
+            }
+          }
+        }
+
+        const replayed = await walSink.replay();
+        if (replayed > 0) {
+          logger.info(
+            "Replayed {count} WAL event(s) from previous session",
+            { count: replayed },
+          );
+        }
+
+        let chainState: AuditChainState | undefined;
+        const savedChainState = await wal.loadChainState();
+        if (savedChainState) {
+          chainState = new AuditChainState(
+            savedChainState.sequence,
+            savedChainState.previousDigest,
+          );
+        }
+        if (highestSeq > (chainState?.sequence ?? -1)) {
+          chainState = new AuditChainState(highestSeq, highestDigest);
+          logger.info(
+            "Chain state advanced from WAL segments: sequence {seq}",
+            { seq: highestSeq },
+          );
+        }
+        if (!chainState) {
+          const reconstructed = await reconstructChainStateFromStore(
+            auditStores[0],
+          );
+          if (reconstructed) {
+            chainState = new AuditChainState(
+              reconstructed.sequence,
+              reconstructed.previousDigest,
+            );
+            logger.info(
+              "Reconstructed chain state from store: sequence {seq}",
+              { seq: reconstructed.sequence },
+            );
+          }
+        }
+
+        connectionCtx.auditEmitter = new AuditEmitter({
+          sinks: [walSink],
+          policy,
+          chainState,
+        });
+        connectionCtx.auditStores = auditStores;
+        connectionCtx.auditPolicy = policy;
+        connectionCtx.auditFailOpen = auditConfig.failOpen;
+        connectionCtx.auditWal = wal;
+
         logger.info(
-          "Audit pipeline enabled with {count} store target(s)",
-          { count: auditStores.length },
+          "Audit pipeline enabled with {count} store target(s), WAL at {walDir}",
+          { count: auditStores.length, walDir },
         );
       }
     }
@@ -4160,6 +4324,11 @@ export const serveCommand = new Command()
       }
       if (connectionCtx.auditEmitter) {
         await connectionCtx.auditEmitter.close();
+        if (connectionCtx.auditWal) {
+          await connectionCtx.auditWal.saveChainState(
+            connectionCtx.auditEmitter.chainState.snapshot(),
+          );
+        }
       }
       rejectionGuard.dispose();
       setRemoteStepDispatcher(null);

--- a/src/domain/datastore/datastore_config.ts
+++ b/src/domain/datastore/datastore_config.ts
@@ -39,6 +39,7 @@ export const ALWAYS_LOCAL_SUBDIRS = [
   "bundles",
   "vault-bundles",
   "report-bundles",
+  "audit-wal",
 ] as const;
 
 /**

--- a/src/domain/serve_audit/audit_chain.ts
+++ b/src/domain/serve_audit/audit_chain.ts
@@ -1,0 +1,109 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AuditEvent, ChainedAuditEvent } from "./audit_event.ts";
+
+export const CHAIN_SEED_DIGEST =
+  "0000000000000000000000000000000000000000000000000000000000000000";
+
+const encoder = new TextEncoder();
+
+function sortKeys(obj: unknown): unknown {
+  if (obj === null || obj === undefined || typeof obj !== "object") return obj;
+  if (Array.isArray(obj)) return obj.map(sortKeys);
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(obj as Record<string, unknown>).sort()) {
+    sorted[key] = sortKeys((obj as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}
+
+function canonicalize(event: AuditEvent): string {
+  const { version: _, sequence: __, digest: ___, ...rest } = event;
+  return JSON.stringify(sortKeys(rest));
+}
+
+async function computeDigest(
+  previousDigest: string,
+  eventJson: string,
+): Promise<string> {
+  const input = previousDigest + eventJson;
+  const data = encoder.encode(input);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = new Uint8Array(hashBuffer);
+  return Array.from(hashArray).map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export class AuditChainState {
+  #sequence: number;
+  #previousDigest: string;
+
+  constructor(sequence = 0, previousDigest = CHAIN_SEED_DIGEST) {
+    this.#sequence = sequence;
+    this.#previousDigest = previousDigest;
+  }
+
+  get sequence(): number {
+    return this.#sequence;
+  }
+
+  get previousDigest(): string {
+    return this.#previousDigest;
+  }
+
+  snapshot(): { sequence: number; previousDigest: string } {
+    return { sequence: this.#sequence, previousDigest: this.#previousDigest };
+  }
+
+  restore(snapshot: { sequence: number; previousDigest: string }): void {
+    this.#sequence = snapshot.sequence;
+    this.#previousDigest = snapshot.previousDigest;
+  }
+
+  async chain(event: AuditEvent): Promise<ChainedAuditEvent> {
+    this.#sequence++;
+    const canonical = canonicalize(event);
+    const digest = await computeDigest(this.#previousDigest, canonical);
+    this.#previousDigest = digest;
+    return {
+      ...event,
+      version: 1,
+      sequence: this.#sequence,
+      digest,
+    };
+  }
+}
+
+export async function verifyChain(
+  events: readonly ChainedAuditEvent[],
+  startDigest = CHAIN_SEED_DIGEST,
+): Promise<{ valid: boolean; brokenAt?: number }> {
+  let previousDigest = startDigest;
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    const canonical = canonicalize(event);
+    const expected = await computeDigest(previousDigest, canonical);
+    if (event.digest !== expected) {
+      return { valid: false, brokenAt: event.sequence };
+    }
+    previousDigest = event.digest;
+  }
+  return { valid: true };
+}

--- a/src/domain/serve_audit/audit_chain_test.ts
+++ b/src/domain/serve_audit/audit_chain_test.ts
@@ -1,0 +1,178 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import {
+  AuditChainState,
+  CHAIN_SEED_DIGEST,
+  verifyChain,
+} from "./audit_chain.ts";
+import { createAuditEvent } from "./audit_event.ts";
+import type { ChainedAuditEvent } from "./audit_event.ts";
+
+function makeEvent(action: string): ReturnType<typeof createAuditEvent> {
+  return createAuditEvent({
+    instanceId: "inst-1",
+    category: "auth",
+    stage: "response",
+    outcome: "success",
+    action,
+    resourceKind: "access",
+    resourceName: "*",
+    principalKind: "user",
+    principalId: "test-user",
+    initiatedBy: "user:test-user",
+    sourceIp: "127.0.0.1",
+    requestId: crypto.randomUUID(),
+  });
+}
+
+Deno.test("AuditChainState: assigns incrementing sequence numbers", async () => {
+  const chain = new AuditChainState();
+  const a = await chain.chain(makeEvent("a"));
+  const b = await chain.chain(makeEvent("b"));
+
+  assertEquals(a.sequence, 1);
+  assertEquals(b.sequence, 2);
+});
+
+Deno.test("AuditChainState: sets version to 1", async () => {
+  const chain = new AuditChainState();
+  const event = await chain.chain(makeEvent("test"));
+
+  assertEquals(event.version, 1);
+});
+
+Deno.test("AuditChainState: computes non-empty digest", async () => {
+  const chain = new AuditChainState();
+  const event = await chain.chain(makeEvent("test"));
+
+  assertEquals(event.digest.length, 64);
+  assertNotEquals(event.digest, CHAIN_SEED_DIGEST);
+});
+
+Deno.test("AuditChainState: each event has a different digest", async () => {
+  const chain = new AuditChainState();
+  const a = await chain.chain(makeEvent("a"));
+  const b = await chain.chain(makeEvent("b"));
+
+  assertNotEquals(a.digest, b.digest);
+});
+
+Deno.test("AuditChainState: chain is deterministic for same input", async () => {
+  const event = makeEvent("deterministic");
+  const chain1 = new AuditChainState();
+  const chain2 = new AuditChainState();
+  const result1 = await chain1.chain(event);
+  const result2 = await chain2.chain(event);
+
+  assertEquals(result1.digest, result2.digest);
+  assertEquals(result1.sequence, result2.sequence);
+});
+
+Deno.test("AuditChainState: preserves all original event fields", async () => {
+  const chain = new AuditChainState();
+  const original = makeEvent("preserve");
+  const chained = await chain.chain(original);
+
+  assertEquals(chained.id, original.id);
+  assertEquals(chained.timestamp, original.timestamp);
+  assertEquals(chained.action, original.action);
+  assertEquals(chained.category, original.category);
+  assertEquals(chained.instanceId, original.instanceId);
+});
+
+Deno.test("AuditChainState: can resume from saved state", async () => {
+  const chain1 = new AuditChainState();
+  await chain1.chain(makeEvent("first"));
+
+  const chain2 = new AuditChainState(
+    chain1.sequence,
+    chain1.previousDigest,
+  );
+  const secondEvent = makeEvent("second");
+  const event2a = await chain1.chain(secondEvent);
+  const event2b = await chain2.chain(secondEvent);
+
+  assertEquals(event2a.digest, event2b.digest);
+  assertEquals(event2a.sequence, event2b.sequence);
+});
+
+Deno.test("verifyChain: valid chain passes verification", async () => {
+  const chain = new AuditChainState();
+  const events: ChainedAuditEvent[] = [];
+  for (let i = 0; i < 5; i++) {
+    events.push(await chain.chain(makeEvent(`action-${i}`)));
+  }
+
+  const result = await verifyChain(events);
+  assertEquals(result.valid, true);
+  assertEquals(result.brokenAt, undefined);
+});
+
+Deno.test("verifyChain: detects tampered event", async () => {
+  const chain = new AuditChainState();
+  const events: ChainedAuditEvent[] = [];
+  for (let i = 0; i < 3; i++) {
+    events.push(await chain.chain(makeEvent(`action-${i}`)));
+  }
+
+  const tampered = [
+    events[0],
+    { ...events[1], action: "tampered" } as ChainedAuditEvent,
+    events[2],
+  ];
+
+  const result = await verifyChain(tampered);
+  assertEquals(result.valid, false);
+  assertEquals(result.brokenAt, events[1].sequence);
+});
+
+Deno.test("verifyChain: detects missing event", async () => {
+  const chain = new AuditChainState();
+  const events: ChainedAuditEvent[] = [];
+  for (let i = 0; i < 4; i++) {
+    events.push(await chain.chain(makeEvent(`action-${i}`)));
+  }
+
+  const gapped = [events[0], events[2], events[3]];
+
+  const result = await verifyChain(gapped);
+  assertEquals(result.valid, false);
+  assertEquals(result.brokenAt, events[2].sequence);
+});
+
+Deno.test("verifyChain: empty chain is valid", async () => {
+  const result = await verifyChain([]);
+  assertEquals(result.valid, true);
+});
+
+Deno.test("verifyChain: can verify from a custom start digest", async () => {
+  const chain = new AuditChainState();
+  const events: ChainedAuditEvent[] = [];
+  for (let i = 0; i < 5; i++) {
+    events.push(await chain.chain(makeEvent(`action-${i}`)));
+  }
+
+  const midDigest = events[1].digest;
+  const tail = events.slice(2);
+
+  const result = await verifyChain(tail, midDigest);
+  assertEquals(result.valid, true);
+});

--- a/src/domain/serve_audit/audit_emitter.ts
+++ b/src/domain/serve_audit/audit_emitter.ts
@@ -18,34 +18,75 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
-import type { AuditEvent } from "./audit_event.ts";
+import type {
+  AuditCategory,
+  AuditEvent,
+  ChainedAuditEvent,
+} from "./audit_event.ts";
 import type { AuditSink } from "./audit_sink.ts";
+import { AuditChainState } from "./audit_chain.ts";
+import type { AuditPolicy } from "./audit_policy.ts";
 import { RingBuffer } from "./ring_buffer.ts";
 
 const logger = getSwampLogger(["serve", "audit", "emitter"]);
 
 const DEFAULT_BUFFER_CAPACITY = 10_000;
 
+export interface AuditEmitterOptions {
+  readonly sinks: AuditSink[];
+  readonly capacity?: number;
+  readonly chainState?: AuditChainState;
+  readonly policy?: AuditPolicy;
+}
+
 export class AuditEmitter {
   readonly #buffer: RingBuffer<AuditEvent>;
   readonly #sinks: AuditSink[];
   readonly #cursors: Map<string, number> = new Map();
   readonly #deniedRequests = new Set<string>();
+  readonly #chainState: AuditChainState;
+  readonly #policy: AuditPolicy | undefined;
   #drainPending = false;
   #drainPromise: Promise<void> | null = null;
 
   constructor(
-    sinks: AuditSink[],
-    capacity: number = DEFAULT_BUFFER_CAPACITY,
+    sinksOrOptions: AuditSink[] | AuditEmitterOptions,
+    capacity?: number,
   ) {
-    this.#buffer = new RingBuffer(capacity);
-    this.#sinks = sinks;
-    for (const sink of sinks) {
+    if (Array.isArray(sinksOrOptions)) {
+      this.#buffer = new RingBuffer(capacity ?? DEFAULT_BUFFER_CAPACITY);
+      this.#sinks = sinksOrOptions;
+      this.#chainState = new AuditChainState();
+    } else {
+      this.#buffer = new RingBuffer(
+        sinksOrOptions.capacity ?? DEFAULT_BUFFER_CAPACITY,
+      );
+      this.#sinks = sinksOrOptions.sinks;
+      this.#chainState = sinksOrOptions.chainState ?? new AuditChainState();
+      this.#policy = sinksOrOptions.policy;
+    }
+    if (this.#sinks.length > 1) {
+      throw new Error(
+        "AuditEmitter currently supports a single sink — multi-sink chain integrity requires per-sink chain state (planned for a future phase)",
+      );
+    }
+    for (const sink of this.#sinks) {
       this.#cursors.set(sink.name, 0);
     }
   }
 
+  get chainState(): AuditChainState {
+    return this.#chainState;
+  }
+
   emit(event: AuditEvent): void {
+    if (this.#policy) {
+      const level = this.#policy.evaluate(
+        event.category as AuditCategory,
+        event.action,
+      );
+      if (level === "none") return;
+    }
     if (event.outcome === "denied") {
       this.#deniedRequests.add(event.requestId);
       if (this.#deniedRequests.size > 10_000) {
@@ -89,13 +130,26 @@ export class AuditEmitter {
   }
 
   async #drain(): Promise<void> {
+    const minCursor = this.#minCursor();
+    const { items, throughSeq } = this.#buffer.readFrom(minCursor);
+    if (items.length === 0) return;
+
+    const chainSnapshot = this.#chainState.snapshot();
+    const chained: ChainedAuditEvent[] = [];
+    for (const event of items) {
+      chained.push(await this.#chainState.chain(event));
+    }
+
+    let anyWriteSucceeded = false;
     for (const sink of this.#sinks) {
-      const cursor = this.#cursors.get(sink.name) ?? 0;
-      const { items, throughSeq } = this.#buffer.readFrom(cursor);
-      if (items.length === 0) continue;
+      const sinkCursor = this.#cursors.get(sink.name) ?? 0;
+      const offset = sinkCursor - minCursor;
+      const sinkEvents = offset > 0 ? chained.slice(offset) : chained;
+      if (sinkEvents.length === 0) continue;
       try {
-        await sink.write(items);
+        await sink.write(sinkEvents);
         this.#cursors.set(sink.name, throughSeq);
+        anyWriteSucceeded = true;
       } catch (error: unknown) {
         logger.warn(
           "Audit sink {sink} failed, events dropped: {error}",
@@ -105,6 +159,10 @@ export class AuditEmitter {
           },
         );
       }
+    }
+
+    if (!anyWriteSucceeded) {
+      this.#chainState.restore(chainSnapshot);
     }
   }
 

--- a/src/domain/serve_audit/audit_emitter_test.ts
+++ b/src/domain/serve_audit/audit_emitter_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import { AuditEmitter } from "./audit_emitter.ts";
 import type { AuditEvent } from "./audit_event.ts";
@@ -97,16 +97,14 @@ Deno.test("AuditEmitter: batches multiple events in single drain", async () => {
   assertEquals(sink.written[0].length, 3);
 });
 
-Deno.test("AuditEmitter: fans out to multiple sinks", async () => {
+Deno.test("AuditEmitter: rejects multiple sinks", () => {
   const sinkA = createMockSink("a");
   const sinkB = createMockSink("b");
-  const emitter = new AuditEmitter([sinkA, sinkB]);
-
-  emitter.emit(makeEvent("test"));
-  await emitter.flush();
-
-  assertEquals(sinkA.written.length, 1);
-  assertEquals(sinkB.written.length, 1);
+  assertThrows(
+    () => new AuditEmitter([sinkA, sinkB]),
+    Error,
+    "single sink",
+  );
 });
 
 Deno.test("AuditEmitter: sink error does not propagate to caller", async () => {
@@ -122,13 +120,10 @@ Deno.test("AuditEmitter: sink error does not propagate to caller", async () => {
       return Promise.resolve();
     },
   };
-  const goodSink = createMockSink("good");
-  const emitter = new AuditEmitter([failingSink, goodSink]);
+  const emitter = new AuditEmitter([failingSink]);
 
   emitter.emit(makeEvent("test"));
   await emitter.flush();
-
-  assertEquals(goodSink.written.length, 1);
 });
 
 Deno.test("AuditEmitter: close flushes then closes all sinks", async () => {

--- a/src/domain/serve_audit/audit_event.ts
+++ b/src/domain/serve_audit/audit_event.ts
@@ -29,6 +29,15 @@ export type AuditStage = "request" | "response";
 
 export type AuditOutcome = "success" | "failure" | "denied";
 
+export interface AuditDecision {
+  readonly action: string;
+  readonly resourceKind: string;
+  readonly resourceName: string;
+  readonly effect: "allow" | "deny";
+  readonly grantId: string | null;
+  readonly principalGroups: readonly string[];
+}
+
 export interface AuditEvent {
   readonly id: string;
   readonly timestamp: string;
@@ -46,7 +55,17 @@ export interface AuditEvent {
   readonly requestId: string;
   readonly methodName?: string;
   readonly detail?: string;
+  readonly version?: number;
+  readonly sequence?: number;
+  readonly digest?: string;
+  readonly decision?: AuditDecision;
 }
+
+export type ChainedAuditEvent = AuditEvent & {
+  readonly version: 1;
+  readonly sequence: number;
+  readonly digest: string;
+};
 
 export function createAuditEvent(
   fields: Omit<AuditEvent, "id" | "timestamp">,

--- a/src/domain/serve_audit/audit_event_builder.ts
+++ b/src/domain/serve_audit/audit_event_builder.ts
@@ -19,6 +19,7 @@
 
 import {
   type AuditCategory,
+  type AuditDecision,
   type AuditEvent,
   type AuditOutcome,
   type AuditStage,
@@ -58,6 +59,7 @@ export interface AuditEventInput {
   readonly requestId: string;
   readonly methodName?: string;
   readonly detail?: string;
+  readonly decision?: AuditDecision;
 }
 
 export function buildAuditEvent(input: AuditEventInput): AuditEvent {
@@ -76,5 +78,6 @@ export function buildAuditEvent(input: AuditEventInput): AuditEvent {
     requestId: input.requestId,
     methodName: input.methodName,
     detail: input.detail ? sanitize(input.detail) : undefined,
+    decision: input.decision,
   });
 }

--- a/src/domain/serve_audit/audit_policy.ts
+++ b/src/domain/serve_audit/audit_policy.ts
@@ -1,0 +1,79 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AuditCategory } from "./audit_event.ts";
+
+export type AuditLevel = "none" | "metadata" | "request" | "requestResponse";
+
+export type AuditEventTier = "management" | "data";
+
+export interface AuditPolicyRule {
+  readonly category?: AuditCategory;
+  readonly action?: string;
+  readonly tier?: AuditEventTier;
+  readonly level: AuditLevel;
+}
+
+const MANAGEMENT_ACTIONS = new Set([
+  "audit.query",
+  "audit.verify",
+  "serve.reload",
+  "serve.health",
+]);
+
+export function classifyTier(action: string): AuditEventTier {
+  if (MANAGEMENT_ACTIONS.has(action)) return "management";
+  return "data";
+}
+
+export class AuditPolicy {
+  readonly #rules: readonly AuditPolicyRule[];
+  readonly #defaultLevel: AuditLevel;
+
+  constructor(
+    rules: readonly AuditPolicyRule[] = [],
+    defaultLevel: AuditLevel = "metadata",
+  ) {
+    this.#rules = rules;
+    this.#defaultLevel = defaultLevel;
+  }
+
+  get rules(): readonly AuditPolicyRule[] {
+    return this.#rules;
+  }
+
+  get defaultLevel(): AuditLevel {
+    return this.#defaultLevel;
+  }
+
+  evaluate(category: AuditCategory, action: string): AuditLevel {
+    const tier = classifyTier(action);
+    for (const rule of this.#rules) {
+      if (rule.category !== undefined && rule.category !== category) continue;
+      if (rule.action !== undefined && rule.action !== action) continue;
+      if (rule.tier !== undefined && rule.tier !== tier) continue;
+      return rule.level;
+    }
+    return this.#defaultLevel;
+  }
+}
+
+export const DEFAULT_AUDIT_POLICY = new AuditPolicy([
+  { tier: "management", level: "metadata" },
+]);

--- a/src/domain/serve_audit/audit_policy_test.ts
+++ b/src/domain/serve_audit/audit_policy_test.ts
@@ -1,0 +1,116 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import {
+  AuditPolicy,
+  classifyTier,
+  DEFAULT_AUDIT_POLICY,
+} from "./audit_policy.ts";
+
+Deno.test("classifyTier: management actions", () => {
+  assertEquals(classifyTier("audit.query"), "management");
+  assertEquals(classifyTier("audit.verify"), "management");
+  assertEquals(classifyTier("serve.reload"), "management");
+  assertEquals(classifyTier("serve.health"), "management");
+});
+
+Deno.test("classifyTier: data actions", () => {
+  assertEquals(classifyTier("model.method.run"), "data");
+  assertEquals(classifyTier("vault.get"), "data");
+  assertEquals(classifyTier("data.get"), "data");
+  assertEquals(classifyTier("workflow.run"), "data");
+});
+
+Deno.test("AuditPolicy: returns default level when no rules match", () => {
+  const policy = new AuditPolicy([], "requestResponse");
+  assertEquals(
+    policy.evaluate("execution", "model.method.run"),
+    "requestResponse",
+  );
+});
+
+Deno.test("AuditPolicy: matches by category", () => {
+  const policy = new AuditPolicy([
+    { category: "secrets", level: "requestResponse" },
+  ], "metadata");
+  assertEquals(policy.evaluate("secrets", "vault.get"), "requestResponse");
+  assertEquals(policy.evaluate("execution", "model.method.run"), "metadata");
+});
+
+Deno.test("AuditPolicy: matches by action", () => {
+  const policy = new AuditPolicy([
+    { action: "vault.get", level: "none" },
+  ], "metadata");
+  assertEquals(policy.evaluate("secrets", "vault.get"), "none");
+  assertEquals(policy.evaluate("secrets", "vault.put"), "metadata");
+});
+
+Deno.test("AuditPolicy: matches by tier", () => {
+  const policy = new AuditPolicy([
+    { tier: "management", level: "none" },
+  ], "request");
+  assertEquals(policy.evaluate("admin", "audit.query"), "none");
+  assertEquals(policy.evaluate("execution", "model.method.run"), "request");
+});
+
+Deno.test("AuditPolicy: first matching rule wins", () => {
+  const policy = new AuditPolicy([
+    { category: "secrets", level: "requestResponse" },
+    { category: "secrets", action: "vault.get", level: "none" },
+  ], "metadata");
+  assertEquals(policy.evaluate("secrets", "vault.get"), "requestResponse");
+});
+
+Deno.test("AuditPolicy: combined category and action match", () => {
+  const policy = new AuditPolicy([
+    { category: "secrets", action: "vault.get", level: "requestResponse" },
+    { category: "secrets", level: "metadata" },
+  ], "none");
+  assertEquals(policy.evaluate("secrets", "vault.get"), "requestResponse");
+  assertEquals(policy.evaluate("secrets", "vault.put"), "metadata");
+  assertEquals(policy.evaluate("execution", "model.method.run"), "none");
+});
+
+Deno.test("AuditPolicy: empty rules array uses default", () => {
+  const policy = new AuditPolicy([]);
+  assertEquals(policy.evaluate("auth", "auth.login"), "metadata");
+});
+
+Deno.test("DEFAULT_AUDIT_POLICY: management tier defaults to metadata", () => {
+  assertEquals(
+    DEFAULT_AUDIT_POLICY.evaluate("admin", "audit.query"),
+    "metadata",
+  );
+  assertEquals(
+    DEFAULT_AUDIT_POLICY.evaluate("admin", "audit.verify"),
+    "metadata",
+  );
+});
+
+Deno.test("DEFAULT_AUDIT_POLICY: data tier uses default metadata", () => {
+  assertEquals(
+    DEFAULT_AUDIT_POLICY.evaluate("execution", "model.method.run"),
+    "metadata",
+  );
+  assertEquals(
+    DEFAULT_AUDIT_POLICY.evaluate("secrets", "vault.get"),
+    "metadata",
+  );
+});

--- a/src/domain/serve_audit/audit_query_service.ts
+++ b/src/domain/serve_audit/audit_query_service.ts
@@ -1,0 +1,231 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { ChainedAuditEvent } from "./audit_event.ts";
+import type { AuditStore } from "./audit_store.ts";
+import { CHAIN_SEED_DIGEST, verifyChain } from "./audit_chain.ts";
+
+const MAX_QUERY_LIMIT = 1000;
+const MAX_DATE_RANGE_DAYS = 90;
+const MAX_LOADED_EVENTS = 50_000;
+
+export interface AuditQueryFilters {
+  readonly since?: string;
+  readonly until?: string;
+  readonly principal?: string;
+  readonly category?: string;
+  readonly action?: string;
+  readonly outcome?: string;
+  readonly resource?: string;
+  readonly limit?: number;
+  readonly cursor?: string;
+}
+
+export interface AuditQueryResult {
+  readonly events: readonly ChainedAuditEvent[];
+  readonly cursor?: string;
+  readonly total?: number;
+}
+
+export interface AuditVerifyResult {
+  readonly valid: boolean;
+  readonly eventsChecked: number;
+  readonly brokenAt?: number;
+  readonly message: string;
+}
+
+function dateRange(since?: string, until?: string): string[] {
+  const start = since
+    ? new Date(since)
+    : new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const end = until ? new Date(until) : new Date();
+  if (isNaN(start.getTime())) {
+    throw new Error(`Invalid 'since' date: "${since}"`);
+  }
+  if (isNaN(end.getTime())) {
+    throw new Error(`Invalid 'until' date: "${until}"`);
+  }
+  const dates: string[] = [];
+  const current = new Date(start);
+  current.setUTCHours(0, 0, 0, 0);
+  while (current <= end) {
+    dates.push(current.toISOString().slice(0, 10));
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+  return dates;
+}
+
+async function loadEvents(
+  store: AuditStore,
+  dates: string[],
+  maxEvents = MAX_LOADED_EVENTS,
+): Promise<ChainedAuditEvent[]> {
+  const events: ChainedAuditEvent[] = [];
+  for (const date of dates) {
+    const keys = await store.list(`events/${date}/`);
+    for (const key of keys) {
+      const data = await store.get(key);
+      if (!data) continue;
+      const text = new TextDecoder().decode(data);
+      for (const line of text.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          events.push(JSON.parse(line) as ChainedAuditEvent);
+          if (events.length >= maxEvents) return events;
+        } catch {
+          // skip malformed lines
+        }
+      }
+    }
+  }
+  return events;
+}
+
+function matchesFilters(
+  event: ChainedAuditEvent,
+  filters: AuditQueryFilters,
+): boolean {
+  if (filters.since && event.timestamp < filters.since) return false;
+  if (filters.until && event.timestamp > filters.until) return false;
+  if (filters.principal && event.principalId !== filters.principal) {
+    return false;
+  }
+  if (filters.category && event.category !== filters.category) return false;
+  if (filters.action && event.action !== filters.action) return false;
+  if (filters.outcome && event.outcome !== filters.outcome) return false;
+  if (
+    filters.resource &&
+    `${event.resourceKind}:${event.resourceName}` !== filters.resource
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export class AuditQueryService {
+  readonly #store: AuditStore;
+
+  constructor(store: AuditStore) {
+    this.#store = store;
+  }
+
+  async query(filters: AuditQueryFilters): Promise<AuditQueryResult> {
+    const dates = dateRange(filters.since, filters.until);
+    if (dates.length > MAX_DATE_RANGE_DAYS) {
+      throw new Error(
+        `Date range too wide: ${dates.length} days exceeds maximum of ${MAX_DATE_RANGE_DAYS}`,
+      );
+    }
+    const allEvents = await loadEvents(this.#store, dates);
+
+    allEvents.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+    const filtered = allEvents.filter((e) => matchesFilters(e, filters));
+
+    let cursorIndex = 0;
+    if (filters.cursor) {
+      const idx = filtered.findIndex((e) => e.id === filters.cursor);
+      if (idx === -1) {
+        return { events: [], cursor: undefined, total: filtered.length };
+      }
+      cursorIndex = idx + 1;
+    }
+
+    const limit = Math.min(filters.limit ?? 100, MAX_QUERY_LIMIT);
+    const page = filtered.slice(cursorIndex, cursorIndex + limit);
+    const nextCursor = cursorIndex + limit < filtered.length
+      ? filtered[cursorIndex + limit - 1]?.id
+      : undefined;
+
+    return {
+      events: page,
+      cursor: nextCursor,
+      total: filtered.length,
+    };
+  }
+
+  async verify(
+    since?: string,
+    until?: string,
+  ): Promise<AuditVerifyResult> {
+    const dates = dateRange(since, until);
+    if (dates.length > MAX_DATE_RANGE_DAYS) {
+      throw new Error(
+        `Date range too wide: ${dates.length} days exceeds maximum of ${MAX_DATE_RANGE_DAYS}`,
+      );
+    }
+    const allEvents = await loadEvents(this.#store, dates);
+
+    const chainedEvents = allEvents.filter(
+      (e): e is ChainedAuditEvent =>
+        e.version === 1 &&
+        typeof e.sequence === "number" &&
+        typeof e.digest === "string",
+    );
+
+    chainedEvents.sort((a, b) => a.sequence - b.sequence);
+
+    if (chainedEvents.length === 0) {
+      return {
+        valid: true,
+        eventsChecked: 0,
+        message: "No chained events found in the specified time range",
+      };
+    }
+
+    const isPartialRange = chainedEvents[0].sequence > 1;
+
+    if (isPartialRange && chainedEvents.length === 1) {
+      return {
+        valid: true,
+        eventsChecked: 0,
+        message: `Single event in partial range (sequence ${
+          chainedEvents[0].sequence
+        }) — chain continuity cannot be verified without adjacent events`,
+      };
+    }
+
+    const eventsToVerify = isPartialRange
+      ? chainedEvents.slice(1)
+      : chainedEvents;
+    const verifyStartDigest = isPartialRange
+      ? chainedEvents[0].digest
+      : CHAIN_SEED_DIGEST;
+
+    const result = await verifyChain(eventsToVerify, verifyStartDigest);
+
+    if (result.valid) {
+      return {
+        valid: true,
+        eventsChecked: eventsToVerify.length,
+        message:
+          `Chain integrity verified: ${eventsToVerify.length} events, sequences ${
+            chainedEvents[0].sequence
+          }-${chainedEvents[chainedEvents.length - 1].sequence}`,
+      };
+    }
+
+    return {
+      valid: false,
+      eventsChecked: eventsToVerify.length,
+      brokenAt: result.brokenAt,
+      message: `Chain integrity broken at sequence ${result.brokenAt}`,
+    };
+  }
+}

--- a/src/domain/serve_audit/audit_query_service_test.ts
+++ b/src/domain/serve_audit/audit_query_service_test.ts
@@ -1,0 +1,199 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { AuditQueryService } from "./audit_query_service.ts";
+import { AuditChainState } from "./audit_chain.ts";
+import { createAuditEvent } from "./audit_event.ts";
+import type { AuditCategory, ChainedAuditEvent } from "./audit_event.ts";
+import type { AuditStore } from "./audit_store.ts";
+
+const encoder = new TextEncoder();
+
+function makeChainedEvent(
+  action: string,
+  chain: AuditChainState,
+  overrides: Partial<{
+    category: string;
+    outcome: string;
+    principalId: string;
+    resourceKind: string;
+    resourceName: string;
+    timestamp: string;
+  }> = {},
+): Promise<ChainedAuditEvent> {
+  const event = createAuditEvent({
+    instanceId: "inst-1",
+    category: (overrides.category ?? "execution") as AuditCategory,
+    stage: "response",
+    outcome: (overrides.outcome ?? "success") as
+      | "success"
+      | "failure"
+      | "denied",
+    action,
+    resourceKind: overrides.resourceKind ?? "model",
+    resourceName: overrides.resourceName ?? "test-model",
+    principalKind: "user",
+    principalId: overrides.principalId ?? "user-1",
+    initiatedBy: `user:${overrides.principalId ?? "user-1"}`,
+    sourceIp: "127.0.0.1",
+    requestId: crypto.randomUUID(),
+  });
+  if (overrides.timestamp) {
+    return chain.chain({ ...event, timestamp: overrides.timestamp });
+  }
+  return chain.chain(event);
+}
+
+function createInMemoryStore(
+  events: ChainedAuditEvent[],
+): AuditStore {
+  const dateMap = new Map<string, ChainedAuditEvent[]>();
+  for (const event of events) {
+    const date = event.timestamp.slice(0, 10);
+    const existing = dateMap.get(date) ?? [];
+    existing.push(event);
+    dateMap.set(date, existing);
+  }
+
+  const storage = new Map<string, Uint8Array>();
+  for (const [date, dateEvents] of dateMap) {
+    const jsonl = dateEvents.map((e) => JSON.stringify(e)).join("\n") + "\n";
+    storage.set(`events/${date}/batch.jsonl`, encoder.encode(jsonl));
+  }
+
+  return {
+    put(key: string, data: Uint8Array): Promise<void> {
+      storage.set(key, data);
+      return Promise.resolve();
+    },
+    get(key: string): Promise<Uint8Array | null> {
+      return Promise.resolve(storage.get(key) ?? null);
+    },
+    list(prefix: string): Promise<string[]> {
+      return Promise.resolve(
+        [...storage.keys()].filter((k) => k.startsWith(prefix)),
+      );
+    },
+    delete(key: string): Promise<void> {
+      storage.delete(key);
+      return Promise.resolve();
+    },
+  };
+}
+
+Deno.test("AuditQueryService.query: returns all events with no filters", async () => {
+  const chain = new AuditChainState();
+  const events = [
+    await makeChainedEvent("model.method.run", chain),
+    await makeChainedEvent("vault.get", chain),
+  ];
+  const store = createInMemoryStore(events);
+  const service = new AuditQueryService(store);
+
+  const result = await service.query({});
+  assertEquals(result.events.length, 2);
+});
+
+Deno.test("AuditQueryService.query: filters by principal", async () => {
+  const chain = new AuditChainState();
+  const events = [
+    await makeChainedEvent("a", chain, { principalId: "user-1" }),
+    await makeChainedEvent("b", chain, { principalId: "user-2" }),
+    await makeChainedEvent("c", chain, { principalId: "user-1" }),
+  ];
+  const store = createInMemoryStore(events);
+  const service = new AuditQueryService(store);
+
+  const result = await service.query({ principal: "user-1" });
+  assertEquals(result.events.length, 2);
+});
+
+Deno.test("AuditQueryService.query: filters by action", async () => {
+  const chain = new AuditChainState();
+  const events = [
+    await makeChainedEvent("vault.get", chain),
+    await makeChainedEvent("model.method.run", chain),
+    await makeChainedEvent("vault.get", chain),
+  ];
+  const store = createInMemoryStore(events);
+  const service = new AuditQueryService(store);
+
+  const result = await service.query({ action: "vault.get" });
+  assertEquals(result.events.length, 2);
+});
+
+Deno.test("AuditQueryService.query: respects limit", async () => {
+  const chain = new AuditChainState();
+  const events = [];
+  for (let i = 0; i < 10; i++) {
+    events.push(await makeChainedEvent(`action-${i}`, chain));
+  }
+  const store = createInMemoryStore(events);
+  const service = new AuditQueryService(store);
+
+  const result = await service.query({ limit: 3 });
+  assertEquals(result.events.length, 3);
+  assertEquals(result.total, 10);
+});
+
+Deno.test("AuditQueryService.query: empty store returns empty", async () => {
+  const store = createInMemoryStore([]);
+  const service = new AuditQueryService(store);
+
+  const result = await service.query({});
+  assertEquals(result.events.length, 0);
+});
+
+Deno.test("AuditQueryService.verify: valid chain passes", async () => {
+  const chain = new AuditChainState();
+  const events = [];
+  for (let i = 0; i < 5; i++) {
+    events.push(await makeChainedEvent(`action-${i}`, chain));
+  }
+  const store = createInMemoryStore(events);
+  const service = new AuditQueryService(store);
+
+  const result = await service.verify();
+  assertEquals(result.valid, true);
+  assertEquals(result.eventsChecked, 5);
+});
+
+Deno.test("AuditQueryService.verify: empty store is valid", async () => {
+  const store = createInMemoryStore([]);
+  const service = new AuditQueryService(store);
+
+  const result = await service.verify();
+  assertEquals(result.valid, true);
+  assertEquals(result.eventsChecked, 0);
+});
+
+Deno.test("AuditQueryService.verify: detects tampering", async () => {
+  const chain = new AuditChainState();
+  const events = [];
+  for (let i = 0; i < 3; i++) {
+    events.push(await makeChainedEvent(`action-${i}`, chain));
+  }
+  events[1] = { ...events[1], action: "tampered" } as ChainedAuditEvent;
+  const store = createInMemoryStore(events);
+  const service = new AuditQueryService(store);
+
+  const result = await service.verify();
+  assertEquals(result.valid, false);
+});

--- a/src/domain/serve_audit/audit_store.ts
+++ b/src/domain/serve_audit/audit_store.ts
@@ -21,4 +21,5 @@ export interface AuditStore {
   put(key: string, data: Uint8Array): Promise<void>;
   get(key: string): Promise<Uint8Array | null>;
   list(prefix: string): Promise<string[]>;
+  delete(key: string): Promise<void>;
 }

--- a/src/domain/serve_audit/audit_wal.ts
+++ b/src/domain/serve_audit/audit_wal.ts
@@ -1,0 +1,227 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { join } from "@std/path";
+import type { AuditEvent } from "./audit_event.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["serve", "audit", "wal"]);
+
+const DEFAULT_MAX_WAL_BYTES = 100 * 1024 * 1024;
+
+export interface AuditWalOptions {
+  readonly dir: string;
+  readonly maxWalBytes?: number;
+}
+
+export interface WalCursorState {
+  readonly cursors: Record<string, string>;
+}
+
+export class AuditWal {
+  readonly #dir: string;
+  readonly #maxWalBytes: number;
+  readonly #encoder = new TextEncoder();
+  readonly #decoder = new TextDecoder();
+  #totalBytes = 0;
+  #segments: string[] = [];
+  #eventsDropped = false;
+
+  constructor(options: AuditWalOptions) {
+    this.#dir = options.dir;
+    this.#maxWalBytes = options.maxWalBytes ?? DEFAULT_MAX_WAL_BYTES;
+  }
+
+  get dir(): string {
+    return this.#dir;
+  }
+
+  get totalBytes(): number {
+    return this.#totalBytes;
+  }
+
+  get segmentCount(): number {
+    return this.#segments.length;
+  }
+
+  get isFull(): boolean {
+    return this.#totalBytes >= this.#maxWalBytes;
+  }
+
+  get hasDroppedEvents(): boolean {
+    return this.#eventsDropped;
+  }
+
+  clearDroppedFlag(): void {
+    this.#eventsDropped = false;
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      await Deno.mkdir(this.#dir, { recursive: true });
+    } catch (error: unknown) {
+      if (!(error instanceof Deno.errors.AlreadyExists)) throw error;
+    }
+
+    this.#segments = [];
+    this.#totalBytes = 0;
+
+    const entries: string[] = [];
+    for await (const entry of Deno.readDir(this.#dir)) {
+      if (entry.isFile && entry.name.endsWith(".wal.jsonl")) {
+        entries.push(entry.name);
+      }
+    }
+    entries.sort();
+
+    for (const name of entries) {
+      const path = join(this.#dir, name);
+      const stat = await Deno.stat(path);
+      this.#segments.push(name);
+      this.#totalBytes += stat.size;
+    }
+  }
+
+  async append(events: readonly AuditEvent[]): Promise<string> {
+    if (events.length === 0) {
+      throw new Error("Cannot append empty event list to WAL");
+    }
+
+    const segmentName = `${Date.now()}-${crypto.randomUUID()}.wal.jsonl`;
+    const path = join(this.#dir, segmentName);
+    const jsonl = events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+    const data = this.#encoder.encode(jsonl);
+
+    await Deno.writeFile(path, data);
+    this.#segments.push(segmentName);
+    this.#totalBytes += data.byteLength;
+
+    await this.#enforceLimit();
+
+    return segmentName;
+  }
+
+  async readSegment(segmentName: string): Promise<AuditEvent[]> {
+    const path = join(this.#dir, segmentName);
+    const data = await Deno.readFile(path);
+    const text = this.#decoder.decode(data);
+    const events: AuditEvent[] = [];
+
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+      try {
+        events.push(JSON.parse(trimmed) as AuditEvent);
+      } catch {
+        // Skip partial/corrupt lines from crash recovery
+      }
+    }
+
+    return events;
+  }
+
+  async deleteSegment(segmentName: string): Promise<void> {
+    const path = join(this.#dir, segmentName);
+    try {
+      const stat = await Deno.stat(path);
+      await Deno.remove(path);
+      this.#totalBytes = Math.max(0, this.#totalBytes - stat.size);
+    } catch (error: unknown) {
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+    }
+    this.#segments = this.#segments.filter((s) => s !== segmentName);
+  }
+
+  listSegments(): readonly string[] {
+    return this.#segments;
+  }
+
+  async saveCursors(cursors: WalCursorState): Promise<void> {
+    const path = join(this.#dir, "cursors.json");
+    const data = this.#encoder.encode(JSON.stringify(cursors, null, 2));
+    await Deno.writeFile(path, data);
+  }
+
+  async loadCursors(): Promise<WalCursorState> {
+    const path = join(this.#dir, "cursors.json");
+    try {
+      const data = await Deno.readFile(path);
+      return JSON.parse(this.#decoder.decode(data)) as WalCursorState;
+    } catch (error: unknown) {
+      if (
+        error instanceof Deno.errors.NotFound ||
+        error instanceof SyntaxError
+      ) {
+        if (error instanceof SyntaxError) {
+          logger.warn("Corrupted cursors.json, resetting: {error}", {
+            error: error.message,
+          });
+        }
+        return { cursors: {} };
+      }
+      throw error;
+    }
+  }
+
+  async saveChainState(
+    state: { sequence: number; previousDigest: string },
+  ): Promise<void> {
+    const path = join(this.#dir, "chain-state.json");
+    const data = this.#encoder.encode(JSON.stringify(state, null, 2));
+    await Deno.writeFile(path, data);
+  }
+
+  async loadChainState(): Promise<
+    { sequence: number; previousDigest: string } | null
+  > {
+    const path = join(this.#dir, "chain-state.json");
+    try {
+      const data = await Deno.readFile(path);
+      return JSON.parse(this.#decoder.decode(data)) as {
+        sequence: number;
+        previousDigest: string;
+      };
+    } catch (error: unknown) {
+      if (
+        error instanceof Deno.errors.NotFound ||
+        error instanceof SyntaxError
+      ) {
+        if (error instanceof SyntaxError) {
+          logger.warn("Corrupted chain-state.json, resetting: {error}", {
+            error: error.message,
+          });
+        }
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async #enforceLimit(): Promise<void> {
+    while (this.#totalBytes > this.#maxWalBytes && this.#segments.length > 1) {
+      const oldest = this.#segments[0];
+      logger.warn(
+        "WAL size limit exceeded, dropping oldest segment {segment} (undelivered events may be lost)",
+        { segment: oldest },
+      );
+      this.#eventsDropped = true;
+      await this.deleteSegment(oldest);
+    }
+  }
+}

--- a/src/domain/serve_audit/audit_wal_test.ts
+++ b/src/domain/serve_audit/audit_wal_test.ts
@@ -1,0 +1,287 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertRejects } from "@std/assert";
+import { join } from "@std/path";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import { AuditWal } from "./audit_wal.ts";
+import { createAuditEvent } from "./audit_event.ts";
+
+await initializeLogging({});
+import type { AuditEvent } from "./audit_event.ts";
+
+function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): () => Promise<void> {
+  return async () => {
+    const dir = await Deno.makeTempDir({ prefix: "audit-wal-test-" });
+    try {
+      await fn(dir);
+    } finally {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
+  };
+}
+
+function makeEvent(action: string): AuditEvent {
+  return createAuditEvent({
+    instanceId: "inst-1",
+    category: "auth",
+    stage: "response",
+    outcome: "success",
+    action,
+    resourceKind: "access",
+    resourceName: "*",
+    principalKind: "user",
+    principalId: "test-user",
+    initiatedBy: "user:test-user",
+    sourceIp: "127.0.0.1",
+    requestId: crypto.randomUUID(),
+  });
+}
+
+Deno.test(
+  "AuditWal: initialize creates directory if missing",
+  withTempDir(async (dir) => {
+    const walDir = join(dir, "wal");
+    const wal = new AuditWal({ dir: walDir });
+    await wal.initialize();
+
+    const stat = await Deno.stat(walDir);
+    assertEquals(stat.isDirectory, true);
+    assertEquals(wal.segmentCount, 0);
+    assertEquals(wal.totalBytes, 0);
+  }),
+);
+
+Deno.test(
+  "AuditWal: append creates segment file",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+
+    const segmentName = await wal.append([makeEvent("test")]);
+
+    assertEquals(segmentName.endsWith(".wal.jsonl"), true);
+    assertEquals(wal.segmentCount, 1);
+
+    const stat = await Deno.stat(join(dir, segmentName));
+    assertEquals(stat.isFile, true);
+  }),
+);
+
+Deno.test(
+  "AuditWal: append rejects empty event list",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+
+    await assertRejects(
+      () => wal.append([]),
+      Error,
+      "Cannot append empty event list",
+    );
+  }),
+);
+
+Deno.test(
+  "AuditWal: readSegment round-trips events",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+
+    const events = [makeEvent("a"), makeEvent("b")];
+    const segmentName = await wal.append(events);
+    const read = await wal.readSegment(segmentName);
+
+    assertEquals(read.length, 2);
+    assertEquals(read[0].action, "a");
+    assertEquals(read[1].action, "b");
+  }),
+);
+
+Deno.test(
+  "AuditWal: readSegment handles partial lines gracefully",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+
+    const segmentName = await wal.append([makeEvent("valid")]);
+    const path = join(dir, segmentName);
+    const existing = await Deno.readFile(path);
+    const partial = new TextEncoder().encode('{"truncated": true');
+    const combined = new Uint8Array(existing.length + partial.length);
+    combined.set(existing, 0);
+    combined.set(partial, existing.length);
+    await Deno.writeFile(path, combined);
+
+    const read = await wal.readSegment(segmentName);
+    assertEquals(read.length, 1);
+    assertEquals(read[0].action, "valid");
+  }),
+);
+
+Deno.test(
+  "AuditWal: deleteSegment removes file and updates totals",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+
+    const segmentName = await wal.append([makeEvent("delete-me")]);
+    assertEquals(wal.segmentCount, 1);
+    const bytesBefore = wal.totalBytes;
+
+    await wal.deleteSegment(segmentName);
+
+    assertEquals(wal.segmentCount, 0);
+    assertEquals(wal.totalBytes, bytesBefore > 0 ? 0 : 0);
+
+    const segments = wal.listSegments();
+    assertEquals(segments.length, 0);
+  }),
+);
+
+Deno.test(
+  "AuditWal: deleteSegment is idempotent for missing files",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+
+    await wal.deleteSegment("nonexistent.wal.jsonl");
+    assertEquals(wal.segmentCount, 0);
+  }),
+);
+
+Deno.test(
+  "AuditWal: listSegments returns all segments in order",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+
+    const s1 = await wal.append([makeEvent("first")]);
+    const s2 = await wal.append([makeEvent("second")]);
+
+    const segments = wal.listSegments();
+    assertEquals(segments.length, 2);
+    assertEquals(segments[0], s1);
+    assertEquals(segments[1], s2);
+  }),
+);
+
+Deno.test(
+  "AuditWal: initialize discovers existing segments",
+  withTempDir(async (dir) => {
+    const wal1 = new AuditWal({ dir });
+    await wal1.initialize();
+    await wal1.append([makeEvent("persisted")]);
+
+    const wal2 = new AuditWal({ dir });
+    await wal2.initialize();
+
+    assertEquals(wal2.segmentCount, 1);
+    assertEquals(wal2.totalBytes > 0, true);
+
+    const events = await wal2.readSegment(wal2.listSegments()[0]);
+    assertEquals(events[0].action, "persisted");
+  }),
+);
+
+Deno.test(
+  "AuditWal: enforces max WAL size by dropping oldest segments",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir, maxWalBytes: 1500 });
+    await wal.initialize();
+
+    // Append segments and track which ones survive
+    const s1 = await wal.append([makeEvent("first")]);
+    const bytesPerSegment = wal.totalBytes;
+    await wal.append([makeEvent("second")]);
+    await wal.append([makeEvent("third")]);
+    await wal.append([makeEvent("fourth")]);
+
+    // With 1500 byte limit and ~450-500 bytes per segment,
+    // we expect ~3 segments to fit, oldest evicted
+    const segments = wal.listSegments();
+    assertEquals(segments.includes(s1), false);
+    assertEquals(wal.totalBytes <= 1500 + bytesPerSegment, true);
+    assertEquals(segments.length >= 1, true);
+  }),
+);
+
+Deno.test(
+  "AuditWal: isFull reflects capacity status",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir, maxWalBytes: 100 });
+    await wal.initialize();
+
+    assertEquals(wal.isFull, false);
+
+    await wal.append([makeEvent("fill")]);
+    // A single event's JSONL is likely > 100 bytes
+    assertEquals(wal.isFull, true);
+  }),
+);
+
+Deno.test(
+  "AuditWal: saveCursors and loadCursors round-trip",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+
+    await wal.saveCursors({
+      cursors: { "store-a": "seg-001", "store-b": "seg-002" },
+    });
+
+    const loaded = await wal.loadCursors();
+    assertEquals(loaded.cursors["store-a"], "seg-001");
+    assertEquals(loaded.cursors["store-b"], "seg-002");
+  }),
+);
+
+Deno.test(
+  "AuditWal: loadCursors returns empty state when no file exists",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+
+    const loaded = await wal.loadCursors();
+    assertEquals(loaded, { cursors: {} });
+  }),
+);
+
+Deno.test(
+  "AuditWal: totalBytes tracks across appends and deletes",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+
+    assertEquals(wal.totalBytes, 0);
+
+    const s1 = await wal.append([makeEvent("a")]);
+    const bytesAfterFirst = wal.totalBytes;
+    assertEquals(bytesAfterFirst > 0, true);
+
+    await wal.append([makeEvent("b")]);
+    assertEquals(wal.totalBytes > bytesAfterFirst, true);
+
+    await wal.deleteSegment(s1);
+    assertEquals(wal.totalBytes > 0, true);
+    assertEquals(wal.totalBytes < bytesAfterFirst * 2, true);
+  }),
+);

--- a/src/domain/serve_audit/mod.ts
+++ b/src/domain/serve_audit/mod.ts
@@ -19,9 +19,11 @@
 
 export {
   type AuditCategory,
+  type AuditDecision,
   type AuditEvent,
   type AuditOutcome,
   type AuditStage,
+  type ChainedAuditEvent,
   createAuditEvent,
 } from "./audit_event.ts";
 
@@ -30,7 +32,35 @@ export {
   buildAuditEvent,
 } from "./audit_event_builder.ts";
 
-export { AuditEmitter } from "./audit_emitter.ts";
+export { AuditEmitter, type AuditEmitterOptions } from "./audit_emitter.ts";
+
+export {
+  AuditChainState,
+  CHAIN_SEED_DIGEST,
+  verifyChain,
+} from "./audit_chain.ts";
+
+export {
+  AuditWal,
+  type AuditWalOptions,
+  type WalCursorState,
+} from "./audit_wal.ts";
+
+export {
+  type AuditEventTier,
+  type AuditLevel,
+  AuditPolicy,
+  type AuditPolicyRule,
+  classifyTier,
+  DEFAULT_AUDIT_POLICY,
+} from "./audit_policy.ts";
+
+export {
+  type AuditQueryFilters,
+  type AuditQueryResult,
+  AuditQueryService,
+  type AuditVerifyResult,
+} from "./audit_query_service.ts";
 
 export type { AuditSink } from "./audit_sink.ts";
 

--- a/src/infrastructure/persistence/remote_audit_store.ts
+++ b/src/infrastructure/persistence/remote_audit_store.ts
@@ -68,4 +68,16 @@ export class RemoteAuditStore implements AuditStore {
       throw error;
     }
   }
+
+  async delete(key: string): Promise<void> {
+    try {
+      await this.#store.delete(`${this.#prefix}${key}`);
+    } catch (error: unknown) {
+      logger.warn("Audit store delete failed for {key}: {error}", {
+        key,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
 }

--- a/src/presentation/output/audit_log_output.ts
+++ b/src/presentation/output/audit_log_output.ts
@@ -1,0 +1,113 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, dim, green, red, yellow } from "@std/fmt/colors";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import type { AuditQueryResponse } from "../../serve/protocol.ts";
+import type { OutputMode } from "./output.ts";
+
+function formatTimestamp(iso: string): string {
+  try {
+    const date = new Date(iso);
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    const seconds = String(date.getSeconds()).padStart(2, "0");
+    return `${month}-${day} ${hours}:${minutes}:${seconds}`;
+  } catch {
+    return iso.substring(5, 19);
+  }
+}
+
+function outcomeColor(outcome: string): string {
+  switch (outcome) {
+    case "success":
+      return green(outcome);
+    case "failure":
+      return red(outcome);
+    case "denied":
+      return yellow(outcome);
+    default:
+      return outcome;
+  }
+}
+
+export function renderAuditLog(
+  data: AuditQueryResponse,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  if (data.events.length === 0) {
+    writeOutput("No audit events found matching the filters.");
+    return;
+  }
+
+  const headers = [
+    "TIME",
+    "OUTCOME",
+    "CATEGORY",
+    "ACTION",
+    "PRINCIPAL",
+    "RESOURCE",
+  ];
+  writeOutput(bold(dim(
+    headers.map((h, i) => {
+      const widths = [16, 9, 12, 30, 20, 30];
+      return h.padEnd(widths[i]);
+    }).join("  "),
+  )));
+
+  for (const event of data.events) {
+    const e = event as Record<string, string>;
+    const time = formatTimestamp(e.timestamp ?? "");
+    const outcome = outcomeColor(e.outcome ?? "");
+    const category = e.category ?? "";
+    const action = e.action ?? "";
+    const principal = e.principalId ?? "";
+    const resource = `${e.resourceKind ?? ""}:${e.resourceName ?? ""}`;
+
+    writeOutput(
+      `${dim(time.padEnd(16))}  ${
+        outcome.padEnd(9 + (outcome.length - (e.outcome ?? "").length))
+      }  ${category.padEnd(12)}  ${action.padEnd(30)}  ${
+        principal.padEnd(20)
+      }  ${resource}`,
+    );
+  }
+
+  if (data.total !== undefined) {
+    writeOutput("");
+    if (data.cursor) {
+      writeOutput(
+        dim(
+          `Showing ${data.events.length} of ${data.total} events — next page: --cursor ${data.cursor}`,
+        ),
+      );
+    } else {
+      writeOutput(
+        dim(`Showing ${data.events.length} of ${data.total} events`),
+      );
+    }
+  }
+}

--- a/src/presentation/output/audit_log_output_test.ts
+++ b/src/presentation/output/audit_log_output_test.ts
@@ -1,0 +1,124 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { stripAnsiCode } from "@std/fmt/colors";
+import type { AuditQueryResponse } from "../../serve/protocol.ts";
+import { renderAuditLog } from "./audit_log_output.ts";
+
+function captureLogs(fn: () => void): string {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return stripAnsiCode(logs.join("\n"));
+}
+
+const sampleData: AuditQueryResponse = {
+  events: [
+    {
+      id: "evt-1",
+      timestamp: "2026-09-06T12:00:00.000Z",
+      instanceId: "inst-1",
+      category: "execution",
+      stage: "response",
+      outcome: "success",
+      action: "model.method.run",
+      resourceKind: "model",
+      resourceName: "hello",
+      principalKind: "user",
+      principalId: "user-1",
+      initiatedBy: "user:admin",
+      sourceIp: "127.0.0.1",
+      requestId: "req-1",
+      version: 1,
+      sequence: 1,
+      digest: "abc123",
+    },
+    {
+      id: "evt-2",
+      timestamp: "2026-09-06T12:01:00.000Z",
+      instanceId: "inst-1",
+      category: "secrets",
+      stage: "response",
+      outcome: "denied",
+      action: "vault.get",
+      resourceKind: "vault",
+      resourceName: "prod",
+      principalKind: "user",
+      principalId: "user-2",
+      initiatedBy: "user:reader",
+      sourceIp: "10.0.0.1",
+      requestId: "req-2",
+      version: 1,
+      sequence: 2,
+      digest: "def456",
+    },
+  ],
+  total: 2,
+};
+
+Deno.test("renderAuditLog: json mode outputs valid JSON", () => {
+  const output = captureLogs(() => renderAuditLog(sampleData, "json"));
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.events.length, 2);
+  assertEquals(parsed.total, 2);
+});
+
+Deno.test("renderAuditLog: json mode preserves event fields", () => {
+  const output = captureLogs(() => renderAuditLog(sampleData, "json"));
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.events[0].action, "model.method.run");
+  assertEquals(parsed.events[1].outcome, "denied");
+});
+
+Deno.test("renderAuditLog: log mode includes action names", () => {
+  const output = captureLogs(() => renderAuditLog(sampleData, "log"));
+  assertStringIncludes(output, "model.method.run");
+  assertStringIncludes(output, "vault.get");
+});
+
+Deno.test("renderAuditLog: log mode includes event count", () => {
+  const output = captureLogs(() => renderAuditLog(sampleData, "log"));
+  assertStringIncludes(output, "2 of 2");
+});
+
+Deno.test("renderAuditLog: log mode shows empty message when no events", () => {
+  const emptyData: AuditQueryResponse = { events: [], total: 0 };
+  const output = captureLogs(() => renderAuditLog(emptyData, "log"));
+  assertStringIncludes(output, "No audit events found");
+});
+
+Deno.test("renderAuditLog: log mode includes header row", () => {
+  const output = captureLogs(() => renderAuditLog(sampleData, "log"));
+  assertStringIncludes(output, "TIME");
+  assertStringIncludes(output, "OUTCOME");
+  assertStringIncludes(output, "ACTION");
+});
+
+Deno.test("renderAuditLog: log mode includes date in timestamp", () => {
+  const output = captureLogs(() => renderAuditLog(sampleData, "log"));
+  // The formatter uses local time, so just check that it has MM-DD format
+  // (two digits, dash, two digits pattern somewhere)
+  assertEquals(output.match(/\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}/) !== null, true);
+});

--- a/src/presentation/output/audit_verify_output.ts
+++ b/src/presentation/output/audit_verify_output.ts
@@ -1,0 +1,49 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { bold, dim, green, red } from "@std/fmt/colors";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+import type { AuditVerifyResponse } from "../../serve/protocol.ts";
+import type { OutputMode } from "./output.ts";
+
+export function renderAuditVerify(
+  data: AuditVerifyResponse,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  if (data.valid) {
+    writeOutput(
+      `${green("✓")} ${
+        bold("Chain integrity verified")
+      }: ${data.eventsChecked} events checked`,
+    );
+    if (data.message) writeOutput(dim(data.message));
+  } else {
+    writeOutput(
+      `${red("✗")} ${bold("Chain integrity broken")} at sequence ${
+        data.brokenAt ?? "unknown"
+      }: ${data.eventsChecked} events checked`,
+    );
+    if (data.message) writeOutput(dim(data.message));
+  }
+}

--- a/src/presentation/output/audit_verify_output_test.ts
+++ b/src/presentation/output/audit_verify_output_test.ts
@@ -1,0 +1,74 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { stripAnsiCode } from "@std/fmt/colors";
+import type { AuditVerifyResponse } from "../../serve/protocol.ts";
+import { renderAuditVerify } from "./audit_verify_output.ts";
+
+function captureLogs(fn: () => void): string {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+  try {
+    fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return stripAnsiCode(logs.join("\n"));
+}
+
+const validData: AuditVerifyResponse = {
+  valid: true,
+  eventsChecked: 42,
+  message: "Chain integrity verified: 42 events, sequences 1-42",
+};
+
+const brokenData: AuditVerifyResponse = {
+  valid: false,
+  eventsChecked: 42,
+  brokenAt: 17,
+  message: "Chain integrity broken at sequence 17",
+};
+
+Deno.test("renderAuditVerify: json mode outputs valid JSON for passing chain", () => {
+  const output = captureLogs(() => renderAuditVerify(validData, "json"));
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.valid, true);
+  assertEquals(parsed.eventsChecked, 42);
+});
+
+Deno.test("renderAuditVerify: json mode outputs valid JSON for broken chain", () => {
+  const output = captureLogs(() => renderAuditVerify(brokenData, "json"));
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.valid, false);
+  assertEquals(parsed.brokenAt, 17);
+});
+
+Deno.test("renderAuditVerify: log mode shows checkmark for valid chain", () => {
+  const output = captureLogs(() => renderAuditVerify(validData, "log"));
+  assertStringIncludes(output, "Chain integrity verified");
+  assertStringIncludes(output, "42 events");
+});
+
+Deno.test("renderAuditVerify: log mode shows cross for broken chain", () => {
+  const output = captureLogs(() => renderAuditVerify(brokenData, "log"));
+  assertStringIncludes(output, "Chain integrity broken");
+  assertStringIncludes(output, "sequence 17");
+});

--- a/src/serve/audit_sinks/store_sink.ts
+++ b/src/serve/audit_sinks/store_sink.ts
@@ -27,24 +27,43 @@ const logger = getSwampLogger(["serve", "audit", "store-sink"]);
 const DEFAULT_BATCH_SIZE = 100;
 const DEFAULT_FLUSH_INTERVAL_MS = 5_000;
 
+const DEFAULT_GC_INTERVAL_MS = 60 * 60 * 1000;
+
+export interface AuditStoreWithRetention {
+  readonly store: AuditStore;
+  readonly retentionDays?: number;
+}
+
 export interface StoreSinkOptions {
-  readonly stores: readonly AuditStore[];
+  readonly stores: readonly (AuditStore | AuditStoreWithRetention)[];
   readonly batchSize?: number;
   readonly flushIntervalMs?: number;
   readonly signal?: AbortSignal;
+  readonly gcIntervalMs?: number;
+}
+
+function unwrapStore(
+  s: AuditStore | AuditStoreWithRetention,
+): { store: AuditStore; retentionDays?: number } {
+  if ("store" in s && "put" in (s as AuditStoreWithRetention).store) {
+    const swr = s as AuditStoreWithRetention;
+    return { store: swr.store, retentionDays: swr.retentionDays };
+  }
+  return { store: s as AuditStore };
 }
 
 export class StoreSink implements AuditSink {
   readonly name = "store";
-  readonly #stores: readonly AuditStore[];
+  readonly #stores: readonly { store: AuditStore; retentionDays?: number }[];
   readonly #batchSize: number;
   readonly #flushIntervalMs: number;
   #batch: AuditEvent[] = [];
   #timer: ReturnType<typeof setInterval> | null = null;
+  #gcTimer: ReturnType<typeof setInterval> | null = null;
   readonly #encoder = new TextEncoder();
 
   constructor(options: StoreSinkOptions) {
-    this.#stores = options.stores;
+    this.#stores = options.stores.map(unwrapStore);
     this.#batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
     this.#flushIntervalMs = options.flushIntervalMs ??
       DEFAULT_FLUSH_INTERVAL_MS;
@@ -57,6 +76,21 @@ export class StoreSink implements AuditSink {
       });
     }, this.#flushIntervalMs);
     Deno.unrefTimer(this.#timer);
+
+    const hasRetention = this.#stores.some((s) =>
+      s.retentionDays !== undefined
+    );
+    if (hasRetention) {
+      const gcInterval = options.gcIntervalMs ?? DEFAULT_GC_INTERVAL_MS;
+      this.#gcTimer = setInterval(() => {
+        this.#runGc().catch((error: unknown) => {
+          logger.warn("Audit GC failed: {error}", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      }, gcInterval);
+      Deno.unrefTimer(this.#gcTimer);
+    }
 
     if (options.signal) {
       options.signal.addEventListener("abort", () => {
@@ -87,7 +121,54 @@ export class StoreSink implements AuditSink {
       clearInterval(this.#timer);
       this.#timer = null;
     }
+    if (this.#gcTimer !== null) {
+      clearInterval(this.#gcTimer);
+      this.#gcTimer = null;
+    }
     await this.flush();
+  }
+
+  async #runGc(): Promise<void> {
+    for (const { store, retentionDays } of this.#stores) {
+      if (retentionDays === undefined) continue;
+
+      const cutoff = new Date();
+      cutoff.setUTCDate(cutoff.getUTCDate() - retentionDays);
+      const cutoffDate = cutoff.toISOString().slice(0, 10);
+
+      try {
+        const keys = await store.list("events/");
+        const partitions = new Set<string>();
+        for (const key of keys) {
+          const parts = key.split("/");
+          if (parts.length >= 2) {
+            partitions.add(parts[1]);
+          }
+        }
+
+        for (const partition of partitions) {
+          if (partition < cutoffDate) {
+            const partitionKeys = keys.filter((k) =>
+              k.startsWith(`events/${partition}/`)
+            );
+            for (const key of partitionKeys) {
+              try {
+                await store.delete(key);
+              } catch {
+                // best-effort deletion
+              }
+            }
+            logger.info("Deleted expired audit partition {partition}", {
+              partition,
+            });
+          }
+        }
+      } catch (error: unknown) {
+        logger.warn("Audit GC failed for store: {error}", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
   }
 
   async #writeBatch(): Promise<void> {
@@ -111,7 +192,7 @@ export class StoreSink implements AuditSink {
       const data = this.#encoder.encode(jsonl);
       const key = `events/${dateKey}/${crypto.randomUUID()}.jsonl`;
 
-      for (const store of this.#stores) {
+      for (const { store } of this.#stores) {
         try {
           await store.put(key, data);
         } catch (error: unknown) {

--- a/src/serve/audit_sinks/store_sink_test.ts
+++ b/src/serve/audit_sinks/store_sink_test.ts
@@ -70,6 +70,10 @@ function createMockStore(): AuditStore & {
         [...written.keys()].filter((k) => k.startsWith(prefix)),
       );
     },
+    delete(key: string): Promise<void> {
+      written.delete(key);
+      return Promise.resolve();
+    },
   };
 }
 
@@ -161,6 +165,9 @@ Deno.test("StoreSink: store failure does not crash", async () => {
     list(): Promise<string[]> {
       return Promise.resolve([]);
     },
+    delete(): Promise<void> {
+      return Promise.resolve();
+    },
   };
   const goodStore = createMockStore();
   const sink = new StoreSink({
@@ -251,6 +258,9 @@ Deno.test("StoreSink: slow store does not block subsequent batches", async () =>
     },
     list(): Promise<string[]> {
       return Promise.resolve([]);
+    },
+    delete(): Promise<void> {
+      return Promise.resolve();
     },
   };
   const sink = new StoreSink({

--- a/src/serve/audit_sinks/wal_sink.ts
+++ b/src/serve/audit_sinks/wal_sink.ts
@@ -1,0 +1,133 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import type { AuditEvent } from "../../domain/serve_audit/audit_event.ts";
+import type { AuditSink } from "../../domain/serve_audit/audit_sink.ts";
+import type { AuditWal } from "../../domain/serve_audit/audit_wal.ts";
+
+const logger = getSwampLogger(["serve", "audit", "wal-sink"]);
+
+export interface WalSinkOptions {
+  readonly wal: AuditWal;
+  readonly downstream: AuditSink;
+}
+
+export class WalSink implements AuditSink {
+  readonly name = "wal";
+  readonly #wal: AuditWal;
+  readonly #downstream: AuditSink;
+  readonly #delivered = new Set<string>();
+
+  constructor(options: WalSinkOptions) {
+    this.#wal = options.wal;
+    this.#downstream = options.downstream;
+  }
+
+  get wal(): AuditWal {
+    return this.#wal;
+  }
+
+  async write(events: readonly AuditEvent[]): Promise<void> {
+    if (events.length === 0) return;
+
+    const segmentName = await this.#wal.append(events);
+
+    try {
+      await this.#downstream.write(events);
+      this.#delivered.add(segmentName);
+    } catch (error: unknown) {
+      logger.warn(
+        "Downstream sink failed, events persisted to WAL segment {segment}: {error}",
+        {
+          segment: segmentName,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  }
+
+  async flush(): Promise<void> {
+    let flushSucceeded = false;
+    try {
+      await this.#downstream.flush();
+      flushSucceeded = true;
+    } catch (error: unknown) {
+      logger.warn("Downstream flush failed: {error}", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    if (!flushSucceeded) return;
+
+    const deleted: string[] = [];
+    for (const segmentName of this.#delivered) {
+      try {
+        await this.#wal.deleteSegment(segmentName);
+        deleted.push(segmentName);
+      } catch (error: unknown) {
+        logger.warn(
+          "Failed to delete delivered WAL segment {segment}: {error}",
+          {
+            segment: segmentName,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    }
+    for (const name of deleted) {
+      this.#delivered.delete(name);
+    }
+  }
+
+  async replay(): Promise<number> {
+    const segments = this.#wal.listSegments();
+    let replayedCount = 0;
+
+    for (const segmentName of segments) {
+      try {
+        const events = await this.#wal.readSegment(segmentName);
+        if (events.length === 0) {
+          await this.#wal.deleteSegment(segmentName);
+          continue;
+        }
+
+        await this.#downstream.write(events);
+        await this.#wal.deleteSegment(segmentName);
+        replayedCount += events.length;
+      } catch (error: unknown) {
+        logger.warn(
+          "Failed to replay WAL segment {segment}, will retry later: {error}",
+          {
+            segment: segmentName,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        break;
+      }
+    }
+
+    return replayedCount;
+  }
+
+  async close(): Promise<void> {
+    await this.flush();
+    await this.#downstream.close();
+  }
+}

--- a/src/serve/audit_sinks/wal_sink_test.ts
+++ b/src/serve/audit_sinks/wal_sink_test.ts
@@ -1,0 +1,276 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import type { AuditEvent } from "../../domain/serve_audit/audit_event.ts";
+import { createAuditEvent } from "../../domain/serve_audit/audit_event.ts";
+import type { AuditSink } from "../../domain/serve_audit/audit_sink.ts";
+import { AuditWal } from "../../domain/serve_audit/audit_wal.ts";
+import { WalSink } from "./wal_sink.ts";
+
+await initializeLogging({});
+
+function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): () => Promise<void> {
+  return async () => {
+    const dir = await Deno.makeTempDir({ prefix: "wal-sink-test-" });
+    try {
+      await fn(dir);
+    } finally {
+      await Deno.remove(dir, { recursive: true }).catch(() => {});
+    }
+  };
+}
+
+function makeEvent(action: string): AuditEvent {
+  return createAuditEvent({
+    instanceId: "inst-1",
+    category: "auth",
+    stage: "response",
+    outcome: "success",
+    action,
+    resourceKind: "access",
+    resourceName: "*",
+    principalKind: "user",
+    principalId: "test-user",
+    initiatedBy: "user:test-user",
+    sourceIp: "127.0.0.1",
+    requestId: crypto.randomUUID(),
+  });
+}
+
+function createMockSink(): AuditSink & {
+  written: AuditEvent[][];
+  flushed: number;
+  closed: boolean;
+} {
+  const sink = {
+    name: "mock-downstream",
+    written: [] as AuditEvent[][],
+    flushed: 0,
+    closed: false,
+    write(events: readonly AuditEvent[]): Promise<void> {
+      sink.written.push([...events]);
+      return Promise.resolve();
+    },
+    flush(): Promise<void> {
+      sink.flushed++;
+      return Promise.resolve();
+    },
+    close(): Promise<void> {
+      sink.closed = true;
+      return Promise.resolve();
+    },
+  };
+  return sink;
+}
+
+function createFailingSink(): AuditSink & { failWrites: boolean } {
+  return {
+    name: "failing-downstream",
+    failWrites: true,
+    write(): Promise<void> {
+      if (this.failWrites) {
+        return Promise.reject(new Error("downstream unavailable"));
+      }
+      return Promise.resolve();
+    },
+    flush(): Promise<void> {
+      return Promise.resolve();
+    },
+    close(): Promise<void> {
+      return Promise.resolve();
+    },
+  };
+}
+
+Deno.test(
+  "WalSink: writes to downstream and WAL, then cleans up on flush",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+    const downstream = createMockSink();
+    const sink = new WalSink({ wal, downstream });
+
+    await sink.write([makeEvent("test")]);
+    assertEquals(downstream.written.length, 1);
+    assertEquals(wal.segmentCount, 1);
+
+    await sink.flush();
+    assertEquals(wal.segmentCount, 0);
+  }),
+);
+
+Deno.test(
+  "WalSink: persists to WAL when downstream fails",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+    const downstream = createFailingSink();
+    const sink = new WalSink({ wal, downstream });
+
+    await sink.write([makeEvent("persisted")]);
+
+    assertEquals(wal.segmentCount, 1);
+    const events = await wal.readSegment(wal.listSegments()[0]);
+    assertEquals(events[0].action, "persisted");
+  }),
+);
+
+Deno.test(
+  "WalSink: WAL segments not deleted when downstream fails",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+    const downstream = createFailingSink();
+    const sink = new WalSink({ wal, downstream });
+
+    await sink.write([makeEvent("keep-me")]);
+    await sink.flush();
+
+    assertEquals(wal.segmentCount, 1);
+  }),
+);
+
+Deno.test(
+  "WalSink: replay delivers undelivered WAL segments to downstream",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+    await wal.append([makeEvent("orphaned-1")]);
+    await wal.append([makeEvent("orphaned-2")]);
+
+    const downstream = createMockSink();
+    const sink = new WalSink({ wal, downstream });
+
+    const count = await sink.replay();
+
+    assertEquals(count, 2);
+    assertEquals(downstream.written.length, 2);
+    assertEquals(wal.segmentCount, 0);
+  }),
+);
+
+Deno.test(
+  "WalSink: replay stops at first failure and retains remaining segments",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+    await wal.append([makeEvent("first")]);
+    await wal.append([makeEvent("second")]);
+
+    let writeCount = 0;
+    const failOnSecond: AuditSink = {
+      name: "fail-on-second",
+      write(): Promise<void> {
+        writeCount++;
+        if (writeCount >= 2) {
+          return Promise.reject(new Error("fail on second"));
+        }
+        return Promise.resolve();
+      },
+      flush(): Promise<void> {
+        return Promise.resolve();
+      },
+      close(): Promise<void> {
+        return Promise.resolve();
+      },
+    };
+    const sink = new WalSink({ wal, downstream: failOnSecond });
+
+    const count = await sink.replay();
+
+    assertEquals(count, 1);
+    assertEquals(wal.segmentCount, 1);
+  }),
+);
+
+Deno.test(
+  "WalSink: replay with no segments returns zero",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+    const downstream = createMockSink();
+    const sink = new WalSink({ wal, downstream });
+
+    const count = await sink.replay();
+    assertEquals(count, 0);
+    assertEquals(downstream.written.length, 0);
+  }),
+);
+
+Deno.test(
+  "WalSink: close flushes and closes downstream",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+    const downstream = createMockSink();
+    const sink = new WalSink({ wal, downstream });
+
+    await sink.write([makeEvent("before-close")]);
+    await sink.close();
+
+    assertEquals(downstream.closed, true);
+    assertEquals(wal.segmentCount, 0);
+  }),
+);
+
+Deno.test(
+  "WalSink: multiple writes create multiple WAL segments",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+    const downstream = createMockSink();
+    const sink = new WalSink({ wal, downstream });
+
+    await sink.write([makeEvent("a")]);
+    await sink.write([makeEvent("b")]);
+    await sink.write([makeEvent("c")]);
+
+    assertEquals(wal.segmentCount, 3);
+    assertEquals(downstream.written.length, 3);
+
+    await sink.flush();
+    assertEquals(wal.segmentCount, 0);
+  }),
+);
+
+Deno.test(
+  "WalSink: replay skips empty segments from partial writes",
+  withTempDir(async (dir) => {
+    const wal = new AuditWal({ dir });
+    await wal.initialize();
+
+    // Write a valid segment then create an empty one
+    await wal.append([makeEvent("valid")]);
+    const emptyName = `${Date.now()}-${crypto.randomUUID()}.wal.jsonl`;
+    await Deno.writeTextFile(`${dir}/${emptyName}`, "");
+    await wal.initialize();
+
+    const downstream = createMockSink();
+    const sink = new WalSink({ wal, downstream });
+
+    const count = await sink.replay();
+    assertEquals(count, 1);
+    assertEquals(downstream.written.length, 1);
+    assertEquals(wal.segmentCount, 0);
+  }),
+);

--- a/src/serve/audited.ts
+++ b/src/serve/audited.ts
@@ -24,6 +24,7 @@ import {
   type Principal,
   principalToString,
 } from "../domain/access/principal.ts";
+import { clearRequestErrored, wasRequestErrored } from "./handlers/shared.ts";
 
 export interface AuditedOptions {
   readonly emitter: AuditEmitter | undefined;
@@ -37,6 +38,7 @@ export interface AuditedOptions {
   readonly requestId: string;
   readonly methodName?: string;
   readonly resolvedUserNames?: Record<string, string>;
+  readonly socket?: WebSocket;
 }
 
 export function audited(
@@ -58,11 +60,17 @@ export function audited(
     : "ghost";
 
   return handler.then(() => {
+    const errored = options.socket
+      ? wasRequestErrored(options.socket, options.requestId)
+      : false;
+    if (errored && options.socket) {
+      clearRequestErrored(options.socket, options.requestId);
+    }
     options.emitter!.emit(buildAuditEvent({
       instanceId: options.instanceId,
       category: options.category,
       stage: "response",
-      outcome: "success",
+      outcome: errored ? "failure" : "success",
       action: options.action,
       resourceKind: options.resourceKind,
       resourceName: options.resourceName,
@@ -72,8 +80,12 @@ export function audited(
       sourceIp: options.sourceIp,
       requestId: options.requestId,
       methodName: options.methodName,
+      detail: errored ? "handler sent error response" : undefined,
     }));
   }, (error: unknown) => {
+    if (options.socket) {
+      clearRequestErrored(options.socket, options.requestId);
+    }
     options.emitter!.emit(buildAuditEvent({
       instanceId: options.instanceId,
       category: options.category,

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -27,6 +27,7 @@ import type { ServerRequest } from "./protocol.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import type { Principal } from "../domain/access/principal.ts";
 import { audited, type AuditedOptions } from "./audited.ts";
+import { AuditQueryService } from "../domain/serve_audit/audit_query_service.ts";
 import {
   GIT_SHA as SERVER_GIT_SHA,
   VERSION as SERVER_VERSION,
@@ -441,6 +442,31 @@ const AuditTimelineRequestSchema = z.object({
     sessionId: z.string().optional(),
     includeDiagnostic: z.boolean().optional(),
   }).optional(),
+});
+
+const AuditQueryRequestSchema = z.object({
+  type: z.literal("audit.query"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    since: z.string().optional(),
+    until: z.string().optional(),
+    principal: z.string().optional(),
+    category: z.string().optional(),
+    action: z.string().optional(),
+    outcome: z.string().optional(),
+    resource: z.string().optional(),
+    limit: z.number().int().min(1).max(1000).optional(),
+    cursor: z.string().optional(),
+  }),
+});
+
+const AuditVerifyRequestSchema = z.object({
+  type: z.literal("audit.verify"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    since: z.string().optional(),
+    until: z.string().optional(),
+  }),
 });
 
 const SummariseRequestSchema = z.object({
@@ -1176,6 +1202,8 @@ const ServerRequestSchema = z.discriminatedUnion("type", [
   VaultPutRequestSchema,
   VaultDeleteRequestSchema,
   AuditTimelineRequestSchema,
+  AuditQueryRequestSchema,
+  AuditVerifyRequestSchema,
   SummariseRequestSchema,
   ReportGetRequestSchema,
   ReportSearchRequestSchema,
@@ -1438,6 +1466,21 @@ export function handleMessage(
   activeRequests.set(request.id, controller);
 
   if (
+    ctx.auditEmitter && ctx.auditFailOpen === false &&
+    (ctx.auditWal?.isFull === true ||
+      ctx.auditWal?.hasDroppedEvents === true)
+  ) {
+    sendError(
+      socket,
+      request.id,
+      "audit_unavailable",
+      "Request rejected: audit subsystem cannot durably record events (fail-secure mode)",
+    );
+    activeRequests.delete(request.id);
+    return;
+  }
+
+  if (
     isRestrictedCommand(request.type, ctx.authConfig.restrictedCommands)
   ) {
     if (
@@ -1452,7 +1495,7 @@ export function handleMessage(
           fields: {},
         },
         ctx,
-      )
+      ).allowed
     ) {
       activeRequests.delete(request.id);
       return;
@@ -1477,18 +1520,22 @@ export function handleMessage(
       requestId: request.id,
       methodName,
       resolvedUserNames: ctx.resolvedUserNames,
+      socket,
     };
   }
 
   let task: Promise<void>;
   switch (request.type) {
     case "server.version":
-      task = Promise.resolve(
-        send(socket, {
-          type: "server.version",
-          id: request.id,
-          payload: { version: SERVER_VERSION, gitSha: SERVER_GIT_SHA },
-        }),
+      task = audited(
+        Promise.resolve(
+          send(socket, {
+            type: "server.version",
+            id: request.id,
+            payload: { version: SERVER_VERSION, gitSha: SERVER_GIT_SHA },
+          }),
+        ),
+        auditOpts("admin", "server", "*"),
       );
       break;
     case "workflow.run":
@@ -1504,7 +1551,7 @@ export function handleMessage(
         auditOpts(
           "execution",
           "workflow",
-          request.payload?.workflowIdOrName ?? "*",
+          "*",
         ),
       );
       break;
@@ -1598,53 +1645,68 @@ export function handleMessage(
       );
       break;
     case "data.get":
-      task = handleDataGet(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleDataGet(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "data", request.payload?.modelIdOrName ?? "*"),
       );
       break;
     case "data.query":
-      task = handleDataQuery(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleDataQuery(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "data", "*"),
       );
       break;
     case "data.list":
-      task = handleDataList(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleDataList(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "data", request.payload?.modelIdOrName ?? "*"),
       );
       break;
     case "data.search":
-      task = handleDataSearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleDataSearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("data", "data", "*"),
       );
       break;
     case "data.versions":
-      task = handleDataVersions(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleDataVersions(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "data", request.payload?.modelIdOrName ?? "*"),
       );
       break;
     case "data.delete":
@@ -1661,52 +1723,67 @@ export function handleMessage(
       );
       break;
     case "data.rename":
-      task = handleDataRename(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleDataRename(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "data", request.payload?.modelIdOrName ?? "*"),
       );
       break;
     case "model.search":
-      task = handleModelSearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleModelSearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("data", "model", "*"),
       );
       break;
     case "model.method.describe":
-      task = handleModelMethodDescribe(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleModelMethodDescribe(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "model", request.payload?.modelIdOrName ?? "*"),
       );
       break;
     case "workflow.search":
-      task = handleWorkflowSearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleWorkflowSearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("data", "workflow", "*"),
       );
       break;
     case "workflow.approvals":
-      task = handleWorkflowApprovals(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
+      task = audited(
+        handleWorkflowApprovals(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "workflow", "*"),
       );
       break;
     case "vault.get":
@@ -1719,7 +1796,7 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("secrets", "vault", request.payload?.vaultNameOrId ?? "*"),
+        auditOpts("secrets", "vault", "*"),
       );
       break;
     case "vault.put":
@@ -1749,73 +1826,177 @@ export function handleMessage(
       );
       break;
     case "audit.timeline":
-      task = handleAuditTimeline(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleAuditTimeline(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("admin", "audit", "*"),
+      );
+      break;
+    case "audit.query":
+      if (
+        !authorizeOrReject(
+          socket,
+          request.id,
+          principal,
+          "admin",
+          { kind: "access", name: "audit", fields: {} },
+          ctx,
+        ).allowed
+      ) {
+        task = Promise.resolve();
+        activeRequests.delete(request.id);
+        break;
+      }
+      task = audited(
+        (async () => {
+          if (!ctx.auditStores || ctx.auditStores.length === 0) {
+            send(socket, {
+              type: "audit.query",
+              id: request.id,
+              payload: { events: [], total: 0 },
+            });
+            return;
+          }
+          const queryService = new AuditQueryService(ctx.auditStores[0]);
+          const result = await queryService.query(request.payload);
+          send(socket, {
+            type: "audit.query",
+            id: request.id,
+            payload: {
+              events: result.events as unknown as Record<string, unknown>[],
+              cursor: result.cursor,
+              total: result.total,
+            },
+          });
+        })(),
+        auditOpts("admin", "access", "audit"),
+      );
+      break;
+    case "audit.verify":
+      if (
+        !authorizeOrReject(
+          socket,
+          request.id,
+          principal,
+          "admin",
+          { kind: "access", name: "audit", fields: {} },
+          ctx,
+        ).allowed
+      ) {
+        task = Promise.resolve();
+        activeRequests.delete(request.id);
+        break;
+      }
+      task = audited(
+        (async () => {
+          if (!ctx.auditStores || ctx.auditStores.length === 0) {
+            send(socket, {
+              type: "audit.verify",
+              id: request.id,
+              payload: {
+                valid: true,
+                eventsChecked: 0,
+                message: "No audit stores configured",
+              },
+            });
+            return;
+          }
+          const verifyService = new AuditQueryService(ctx.auditStores[0]);
+          const verifyResult = await verifyService.verify(
+            request.payload.since,
+            request.payload.until,
+          );
+          send(socket, {
+            type: "audit.verify",
+            id: request.id,
+            payload: verifyResult,
+          });
+        })(),
+        auditOpts("admin", "access", "audit"),
       );
       break;
     case "summarise":
-      task = handleSummarise(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleSummarise(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("data", "data", "*"),
       );
       break;
     case "report.get":
-      task = handleReportGet(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleReportGet(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "report", request.payload?.reportName ?? "*"),
       );
       break;
     case "report.search":
-      task = handleReportSearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleReportSearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("data", "report", "*"),
       );
       break;
     case "report.describe":
-      task = handleReportDescribe(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleReportDescribe(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "report", request.payload?.reportName ?? "*"),
       );
       break;
     case "report.type.search":
-      task = handleReportTypeSearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleReportTypeSearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("data", "report", "*"),
       );
       break;
     case "model.get":
-      task = handleModelGet(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleModelGet(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "model", request.payload?.modelIdOrName ?? "*"),
       );
       break;
     case "model.create":
@@ -1845,470 +2026,614 @@ export function handleMessage(
       );
       break;
     case "model.output.get":
-      task = handleModelOutputGet(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleModelOutputGet(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "model", "*"),
       );
       break;
     case "model.output.data":
-      task = handleModelOutputData(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleModelOutputData(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "model", "*"),
       );
       break;
     case "model.output.logs":
-      task = handleModelOutputLogs(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleModelOutputLogs(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "model", "*"),
       );
       break;
     case "model.output.search":
-      task = handleModelOutputSearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleModelOutputSearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("data", "model", "*"),
       );
       break;
     case "model.method.history.get":
-      task = handleModelMethodHistoryGet(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleModelMethodHistoryGet(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "model", "*"),
       );
       break;
     case "model.method.history.logs":
-      task = handleModelMethodHistoryLogs(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleModelMethodHistoryLogs(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "model", "*"),
       );
       break;
     case "model.method.history.search":
-      task = handleModelMethodHistorySearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleModelMethodHistorySearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("data", "model", "*"),
       );
       break;
     case "model.validate":
-      task = handleModelValidate(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleModelValidate(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("data", "model", "*"),
       );
       break;
     case "model.evaluate":
-      task = handleModelEvaluate(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleModelEvaluate(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("execution", "model", "*"),
       );
       break;
     case "workflow.get":
-      task = handleWorkflowGet(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleWorkflowGet(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "workflow", "*"),
       );
       break;
     case "workflow.history.get":
-      task = handleWorkflowHistoryGet(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleWorkflowHistoryGet(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "workflow", "*"),
       );
       break;
     case "workflow.history.logs":
-      task = handleWorkflowHistoryLogs(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleWorkflowHistoryLogs(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "workflow", request.payload?.runIdOrWorkflow ?? "*"),
       );
       break;
     case "workflow.history.search":
-      task = handleWorkflowHistorySearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleWorkflowHistorySearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("data", "workflow", "*"),
       );
       break;
     case "workflow.run.search":
-      task = handleWorkflowRunSearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleWorkflowRunSearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("data", "workflow", "*"),
       );
       break;
     case "workflow.schema":
-      task = handleWorkflowSchema(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleWorkflowSchema(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "workflow", "*"),
       );
       break;
     case "workflow.approve":
-      task = handleWorkflowApprove(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleWorkflowApprove(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("execution", "workflow", request.payload?.runId ?? "*"),
       );
       break;
     case "workflow.reject":
-      task = handleWorkflowReject(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleWorkflowReject(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("execution", "workflow", request.payload?.runId ?? "*"),
       );
       break;
     case "workflow.resume":
-      task = handleWorkflowResume(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleWorkflowResume(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("execution", "workflow", request.payload?.runId ?? "*"),
       );
       break;
     case "vault.describe":
-      task = handleVaultDescribe(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleVaultDescribe(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("secrets", "vault", "*"),
       );
       break;
     case "vault.inspect":
-      task = handleVaultInspect(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleVaultInspect(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("secrets", "vault", request.payload?.vaultName ?? "*"),
       );
       break;
     case "vault.list-keys":
-      task = handleVaultListKeys(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleVaultListKeys(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("secrets", "vault", "*"),
       );
       break;
     case "vault.search":
-      task = handleVaultSearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleVaultSearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("secrets", "vault", "*"),
       );
       break;
     case "vault.annotate":
-      task = handleVaultAnnotate(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleVaultAnnotate(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("secrets", "vault", request.payload?.vaultName ?? "*"),
       );
       break;
     case "worker.list":
-      task = handleWorkerList(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleWorkerList(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("admin", "worker", "*"),
       );
       break;
     case "worker.queue.list":
-      task = handleWorkerQueueList(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
+      task = audited(
+        handleWorkerQueueList(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "worker", "*"),
       );
       break;
     case "worker.verify":
-      task = handleWorkerVerify(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleWorkerVerify(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "worker", "*"),
       );
       break;
     case "datastore.status":
-      task = handleDatastoreStatus(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
+      task = audited(
+        handleDatastoreStatus(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "datastore", "*"),
       );
       break;
     case "datastore.setup.extension":
-      task = handleDatastoreSetupExtension(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleDatastoreSetupExtension(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "datastore", "*"),
       );
       break;
     case "vault.migrate":
-      task = handleVaultMigrate(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleVaultMigrate(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "vault", "*"),
       );
       break;
     case "extension.list":
-      task = handleExtensionList(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
+      task = audited(
+        handleExtensionList(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "extension", "*"),
       );
       break;
     case "extension.search":
-      task = handleExtensionSearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleExtensionSearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("admin", "extension", "*"),
       );
       break;
     case "extension.info":
-      task = handleExtensionInfo(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleExtensionInfo(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "extension", request.payload?.extensionName ?? "*"),
       );
       break;
     case "extension.install":
-      task = handleExtensionInstall(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
+      task = audited(
+        handleExtensionInstall(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "extension", "*"),
       );
       break;
     case "extension.pull":
-      task = handleExtensionPull(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleExtensionPull(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "extension", request.payload?.extensionName ?? "*"),
       );
       break;
     case "extension.rm":
-      task = handleExtensionRm(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleExtensionRm(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "extension", request.payload?.extensionName ?? "*"),
       );
       break;
     case "extension.outdated":
-      task = handleExtensionOutdated(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
+      task = audited(
+        handleExtensionOutdated(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "extension", "*"),
       );
       break;
     case "extension.update":
-      task = handleExtensionUpdate(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleExtensionUpdate(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "extension", request.payload?.extensionName ?? "*"),
       );
       break;
     case "doctor.datastores":
-      task = handleDoctorDatastores(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
+      task = audited(
+        handleDoctorDatastores(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "doctor", "*"),
       );
       break;
     case "doctor.vaults":
-      task = handleDoctorVaults(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
+      task = audited(
+        handleDoctorVaults(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "doctor", "*"),
       );
       break;
     case "doctor.secrets":
-      task = handleDoctorSecrets(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
+      task = audited(
+        handleDoctorSecrets(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "doctor", "*"),
       );
       break;
     case "doctor.workflows":
-      task = handleDoctorWorkflows(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
+      task = audited(
+        handleDoctorWorkflows(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "doctor", "*"),
       );
       break;
     case "doctor.extensions":
-      task = handleDoctorExtensions(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
+      task = audited(
+        handleDoctorExtensions(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "doctor", "*"),
       );
       break;
     case "run.history":
-      task = Promise.resolve(handleRunHistory(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        principal,
-      ));
+      task = audited(
+        Promise.resolve(handleRunHistory(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          principal,
+        )),
+        auditOpts("execution", "run", "*"),
+      );
       break;
     case "run.doctor":
-      task = Promise.resolve(handleRunDoctor(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        principal,
-      ));
+      task = audited(
+        Promise.resolve(handleRunDoctor(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          principal,
+        )),
+        auditOpts("execution", "run", "*"),
+      );
       break;
     case "run.attach":
-      task = handleRunAttach(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleRunAttach(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("execution", "run", request.payload?.runId ?? "*"),
       );
       break;
     case "access.token.list":
-      task = handleAccessTokenList(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
+      task = audited(
+        handleAccessTokenList(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("access", "access", "*"),
       );
       break;
     case "access.token.revoke":
-      task = handleAccessTokenRevoke(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleAccessTokenRevoke(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("access", "access", "*"),
       );
       break;
     case "access.token.rotate":
-      task = handleAccessTokenRotate(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleAccessTokenRotate(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("access", "access", "*"),
       );
       break;
     case "model.edit":
@@ -2325,23 +2650,29 @@ export function handleMessage(
       );
       break;
     case "model.type.describe":
-      task = handleModelTypeDescribe(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
+      task = audited(
+        handleModelTypeDescribe(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "model", request.payload?.typeArg ?? "*"),
       );
       break;
     case "model.type.search":
-      task = handleModelTypeSearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
+      task = audited(
+        handleModelTypeSearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("data", "model", "*"),
       );
       break;
     case "workflow.create":
@@ -2370,7 +2701,7 @@ export function handleMessage(
         auditOpts(
           "admin",
           "workflow",
-          request.payload?.workflowIdOrName ?? "*",
+          "*",
         ),
       );
       break;
@@ -2387,195 +2718,252 @@ export function handleMessage(
         auditOpts(
           "admin",
           "workflow",
-          request.payload?.workflowIdOrName ?? "*",
+          "*",
         ),
       );
       break;
     case "workflow.validate":
-      task = handleWorkflowValidate(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "workflow.evaluate":
-      task = handleWorkflowEvaluate(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "workflow.trigger.set":
-      task = handleWorkflowTriggerSet(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "workflow.trigger.get":
-      task = handleWorkflowTriggerGet(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "workflow.trigger.remove":
-      task = handleWorkflowTriggerRemove(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "vault.create":
-      task = handleVaultCreate(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "vault.edit":
-      task = handleVaultEdit(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "vault.audit-trail":
-      task = handleVaultAuditTrail(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "vault.read-secret":
-      task = handleVaultReadSecret(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "vault.type.search":
-      task = handleVaultTypeSearch(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-        request.payload,
-      );
-      break;
-    case "worker.token.create":
-      task = handleWorkerTokenCreate(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "worker.token.list":
-      task = handleWorkerTokenList(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-      );
-      break;
-    case "worker.token.revoke":
-      task = handleWorkerTokenRevoke(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "data.gc":
-      task = handleDataGc(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "data.prune":
-      task = handleDataPrune(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "run.gc":
-      task = handleRunGc(
-        socket,
-        ctx,
-        request.id,
-        request.payload,
-        controller,
-        principal,
-      );
-      break;
-    case "datastore.namespace.list":
-      task = handleDatastoreNamespaceList(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-      );
-      break;
-    case "cluster.instances":
-      task = handleClusterInstances(
-        socket,
-        ctx,
-        request.id,
-        controller,
-        principal,
-      );
-      break;
-    case "serve.config":
-      task = Promise.resolve(
-        handleServeConfig(
+      task = audited(
+        handleWorkflowValidate(
           socket,
           ctx,
           request.id,
+          request.payload,
+          controller,
           principal,
         ),
+        auditOpts("data", "workflow", "*"),
+      );
+      break;
+    case "workflow.evaluate":
+      task = audited(
+        handleWorkflowEvaluate(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("execution", "workflow", "*"),
+      );
+      break;
+    case "workflow.trigger.set":
+      task = audited(
+        handleWorkflowTriggerSet(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "workflow", "*"),
+      );
+      break;
+    case "workflow.trigger.get":
+      task = audited(
+        handleWorkflowTriggerGet(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("data", "workflow", "*"),
+      );
+      break;
+    case "workflow.trigger.remove":
+      task = audited(
+        handleWorkflowTriggerRemove(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "workflow", "*"),
+      );
+      break;
+    case "vault.create":
+      task = audited(
+        handleVaultCreate(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "vault", request.payload?.name ?? "*"),
+      );
+      break;
+    case "vault.edit":
+      task = audited(
+        handleVaultEdit(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "vault", "*"),
+      );
+      break;
+    case "vault.audit-trail":
+      task = audited(
+        handleVaultAuditTrail(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("secrets", "vault", request.payload?.vaultName ?? "*"),
+      );
+      break;
+    case "vault.read-secret":
+      task = audited(
+        handleVaultReadSecret(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("secrets", "vault", request.payload?.vaultName ?? "*"),
+      );
+      break;
+    case "vault.type.search":
+      task = audited(
+        handleVaultTypeSearch(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+          request.payload,
+        ),
+        auditOpts("secrets", "vault", "*"),
+      );
+      break;
+    case "worker.token.create":
+      task = audited(
+        handleWorkerTokenCreate(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "worker", "*"),
+      );
+      break;
+    case "worker.token.list":
+      task = audited(
+        handleWorkerTokenList(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "worker", "*"),
+      );
+      break;
+    case "worker.token.revoke":
+      task = audited(
+        handleWorkerTokenRevoke(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "worker", "*"),
+      );
+      break;
+    case "data.gc":
+      task = audited(
+        handleDataGc(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "data", "*"),
+      );
+      break;
+    case "data.prune":
+      task = audited(
+        handleDataPrune(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "data", "*"),
+      );
+      break;
+    case "run.gc":
+      task = audited(
+        handleRunGc(
+          socket,
+          ctx,
+          request.id,
+          request.payload,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "run", "*"),
+      );
+      break;
+    case "datastore.namespace.list":
+      task = audited(
+        handleDatastoreNamespaceList(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "datastore", "*"),
+      );
+      break;
+    case "cluster.instances":
+      task = audited(
+        handleClusterInstances(
+          socket,
+          ctx,
+          request.id,
+          controller,
+          principal,
+        ),
+        auditOpts("admin", "cluster", "*"),
+      );
+      break;
+    case "serve.config":
+      task = audited(
+        Promise.resolve(
+          handleServeConfig(
+            socket,
+            ctx,
+            request.id,
+            principal,
+          ),
+        ),
+        auditOpts("admin", "server", "*"),
       );
       break;
     default: {
@@ -2629,7 +3017,7 @@ async function handleCancelRun(
         fields: cancelFields,
       },
       ctx,
-    )
+    ).allowed
   ) {
     ctx.activeRunRegistry!.cancel(requestId);
   }
@@ -2692,7 +3080,7 @@ async function handleRunAttach(
               fields: remoteFields,
             },
             ctx,
-          )
+          ).allowed
         ) return;
 
         const heartbeatData = await ctx.controlPlaneStore.get(
@@ -2751,7 +3139,7 @@ async function handleRunAttach(
         fields: localFields,
       },
       ctx,
-    )
+    ).allowed
   ) return;
 
   send(socket, {

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -104,7 +104,7 @@ export async function handleAccessGrantList(
       kind: "access",
       name: "grant",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -226,7 +226,7 @@ export async function handleAccessGroupList(
       kind: "access",
       name: "group",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -291,7 +291,7 @@ export async function handleAccessGroupListIdp(
       kind: "access",
       name: "group",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -365,7 +365,7 @@ export function handleAccessCheck(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return Promise.resolve();
 
   try {
@@ -557,7 +557,7 @@ export async function handleAccessReload(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   const logger = getSwampLogger(["access", "reload"]);
@@ -802,7 +802,7 @@ export async function handleAccessTokenList(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -853,7 +853,7 @@ export async function handleAccessTokenRevoke(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -906,7 +906,7 @@ export async function handleAccessTokenRotate(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -172,7 +172,7 @@ export async function handleWorkerList(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -223,7 +223,7 @@ export async function handleWorkerQueueList(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -273,7 +273,7 @@ export async function handleWorkerVerify(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   if (!ctx.workerGateway) {
@@ -354,7 +354,7 @@ export async function handleDatastoreStatus(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -402,7 +402,7 @@ export async function handleExtensionList(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -452,7 +452,7 @@ export async function handleExtensionSearch(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -538,7 +538,7 @@ export async function handleExtensionInfo(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -601,7 +601,7 @@ export async function handleExtensionInstall(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -663,7 +663,7 @@ export async function handleExtensionPull(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   let catalog: ExtensionCatalogStore | undefined;
@@ -790,7 +790,7 @@ export async function handleExtensionRm(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   let deps: Awaited<ReturnType<typeof createExtensionRmDeps>> | undefined;
@@ -862,7 +862,7 @@ export async function handleExtensionOutdated(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -937,7 +937,7 @@ export async function handleExtensionUpdate(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   let catalog: ExtensionCatalogStore | undefined;
@@ -1062,7 +1062,7 @@ export async function handleDatastoreSetupExtension(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1155,7 +1155,7 @@ export async function handleVaultMigrate(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1231,7 +1231,7 @@ export async function handleDoctorVaults(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1280,7 +1280,7 @@ export async function handleDoctorDatastores(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1368,7 +1368,7 @@ export async function handleDoctorSecrets(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1417,7 +1417,7 @@ export async function handleDoctorWorkflows(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1470,7 +1470,7 @@ export async function handleDoctorExtensions(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   const logger = getSwampLogger(["serve", "doctor", "extensions"]);
@@ -1622,7 +1622,7 @@ export function handleRunHistory(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
   if (!ctx.runTracker) {
     sendError(socket, requestId, "not_available", "Run tracker not available");
@@ -1669,7 +1669,7 @@ export function handleRunDoctor(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
   if (!ctx.runTracker) {
     sendError(socket, requestId, "not_available", "Run tracker not available");
@@ -1732,7 +1732,7 @@ export async function handleAuditTimeline(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1789,7 +1789,7 @@ export async function handleServeReload(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   if (!ctx.hotReload) {
@@ -1860,7 +1860,7 @@ export async function handleWorkerTokenCreate(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1917,7 +1917,7 @@ export async function handleWorkerTokenList(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1968,7 +1968,7 @@ export async function handleWorkerTokenRevoke(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -2020,7 +2020,7 @@ export async function handleDatastoreNamespaceList(
       kind: "data",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -2183,7 +2183,7 @@ export async function handleClusterInstances(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -2253,7 +2253,7 @@ export function handleServeConfig(
       kind: "access",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   if (!ctx.serveOptions) {

--- a/src/serve/handlers/data_handlers.ts
+++ b/src/serve/handlers/data_handlers.ts
@@ -117,7 +117,7 @@ export async function handleDataGet(
       kind: "data",
       name: resourceName,
       fields: dataFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -185,7 +185,7 @@ export async function handleDataQuery(
       kind: "data",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -253,7 +253,7 @@ export async function handleDataList(
       kind: "data",
       name: resourceName,
       fields: listFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -319,7 +319,7 @@ export async function handleDataSearch(
       kind: "data",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -397,7 +397,7 @@ export async function handleDataVersions(
       kind: "data",
       name: resourceName,
       fields: versionFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -463,7 +463,7 @@ export async function handleDataDelete(
       kind: "data",
       name: payload.modelIdOrName,
       fields: deleteFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -530,7 +530,7 @@ export async function handleDataRename(
       kind: "data",
       name: payload.modelIdOrName,
       fields: renameFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -593,7 +593,7 @@ export async function handleSummarise(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -656,7 +656,7 @@ export async function handleDataGc(
       kind: "data",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -710,7 +710,7 @@ export async function handleDataPrune(
       kind: "data",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -764,7 +764,7 @@ export async function handleRunGc(
       kind: "data",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -176,7 +176,7 @@ export async function handleModelMethodRun(
             kind: "access",
             name: "*",
             fields: modelFields,
-          }, ctx)
+          }, ctx).allowed
         ) return;
       } else {
         if (
@@ -184,7 +184,7 @@ export async function handleModelMethodRun(
             kind: "model",
             name: payload.modelIdOrName,
             fields: modelFields,
-          }, ctx)
+          }, ctx).allowed
         ) return;
 
         if (payload.typeArg) {
@@ -197,7 +197,7 @@ export async function handleModelMethodRun(
               kind: "model",
               name: executionTarget,
               fields: {},
-            }, ctx)
+            }, ctx).allowed
           ) return;
         }
       }
@@ -372,7 +372,7 @@ export async function handleModelMethodRun(
         kind: "access",
         name: "*",
         fields: modelFields,
-      }, ctx)
+      }, ctx).allowed
     ) return;
   } else {
     if (
@@ -380,7 +380,7 @@ export async function handleModelMethodRun(
         kind: "model",
         name: payload.modelIdOrName,
         fields: modelFields,
-      }, ctx)
+      }, ctx).allowed
     ) return;
 
     if (payload.typeArg) {
@@ -393,7 +393,7 @@ export async function handleModelMethodRun(
           kind: "model",
           name: executionTarget,
           fields: {},
-        }, ctx)
+        }, ctx).allowed
       ) return;
     }
   }
@@ -618,7 +618,7 @@ export async function handleModelSearch(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -674,7 +674,7 @@ export async function handleModelMethodDescribe(
       kind: "model",
       name: payload.modelIdOrName,
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -735,7 +735,7 @@ export async function handleModelGet(
       kind: "model",
       name: payload.modelIdOrName,
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -797,7 +797,7 @@ export async function handleModelCreate(
         kind: "access",
         name: "*",
         fields: {},
-      }, ctx)
+      }, ctx).allowed
     ) return;
   } else {
     if (
@@ -805,7 +805,7 @@ export async function handleModelCreate(
         kind: "model",
         name: payload.name ?? payload.typeArg,
         fields: {},
-      }, ctx)
+      }, ctx).allowed
     ) return;
   }
 
@@ -881,7 +881,7 @@ export async function handleModelDelete(
       kind: "model",
       name: payload.modelIdOrName,
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -974,7 +974,7 @@ export async function handleModelOutputGet(
       kind: "model",
       name: payload.outputIdOrModelName,
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1029,7 +1029,7 @@ export async function handleModelOutputData(
       kind: "model",
       name: payload.outputIdArg,
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1093,7 +1093,7 @@ export async function handleModelOutputLogs(
       kind: "model",
       name: payload.outputIdArg,
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1155,7 +1155,7 @@ export async function handleModelOutputSearch(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1215,7 +1215,7 @@ export async function handleModelMethodHistoryGet(
       kind: "model",
       name: payload.outputIdOrModelName,
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1275,7 +1275,7 @@ export async function handleModelMethodHistoryLogs(
       kind: "model",
       name: payload.outputIdOrModelName,
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1344,7 +1344,7 @@ export async function handleModelMethodHistorySearch(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1409,7 +1409,7 @@ export async function handleModelValidate(
       kind: "model",
       name: payload?.modelIdOrName ?? "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1470,7 +1470,7 @@ export async function handleModelEvaluate(
       kind: "model",
       name: payload?.modelIdOrName ?? "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1527,7 +1527,7 @@ export async function handleModelEdit(
       kind: "model",
       name: payload.modelIdOrName,
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1580,7 +1580,7 @@ export async function handleModelTypeDescribe(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1631,7 +1631,7 @@ export async function handleModelTypeSearch(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {

--- a/src/serve/handlers/report_handlers.ts
+++ b/src/serve/handlers/report_handlers.ts
@@ -65,7 +65,7 @@ export async function handleReportGet(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -152,7 +152,7 @@ export async function handleReportSearch(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -233,7 +233,7 @@ export async function handleReportDescribe(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -294,7 +294,7 @@ export async function handleReportTypeSearch(
       kind: "model",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -42,12 +42,19 @@ import {
   principalToString,
 } from "../../domain/access/principal.ts";
 import type { Action } from "../../domain/access/action.ts";
-import type { AccessResource } from "../../domain/access/access_decision_service.ts";
+import type {
+  AccessDecision,
+  AccessResource,
+} from "../../domain/access/access_decision_service.ts";
 import type { ScheduledExecutionService } from "../../libswamp/mod.ts";
 import type { MergedServeOptions } from "../serve_config.ts";
 import type { HealthCollector } from "../health_collector.ts";
 import type { AuditEmitter } from "../../domain/serve_audit/audit_emitter.ts";
+import type { AuditDecision } from "../../domain/serve_audit/audit_event.ts";
 import { buildAuditEvent } from "../../domain/serve_audit/audit_event_builder.ts";
+import type { AuditStore } from "../../domain/serve_audit/audit_store.ts";
+import type { AuditPolicy } from "../../domain/serve_audit/audit_policy.ts";
+import type { AuditWal } from "../../domain/serve_audit/audit_wal.ts";
 
 export const MAX_CLIENT_ERROR_LENGTH = 200;
 
@@ -165,6 +172,14 @@ export interface ConnectionContext {
   managedDefinitionsDir?: string;
   /** Audit emitter — present when audit config is set in serve.yaml. */
   auditEmitter?: AuditEmitter;
+  /** Audit stores — present when audit config is set in serve.yaml. */
+  auditStores?: readonly AuditStore[];
+  /** Audit policy — controls detail level per event category/action. */
+  auditPolicy?: AuditPolicy;
+  /** When false, refuse requests that cannot be durably audited. */
+  auditFailOpen?: boolean;
+  /** WAL instance — used to check health for fail-secure mode. */
+  auditWal?: AuditWal;
 }
 
 // SECURITY: Authorization must operate on canonical (normalized) model types,
@@ -302,6 +317,11 @@ export function getConnectionSourceIp(socket: WebSocket): string {
   return connectionSourceIp.get(socket) ?? "unknown";
 }
 
+export interface AuthorizationResult {
+  readonly allowed: boolean;
+  readonly decision: AccessDecision | null;
+}
+
 export function authorizeOrReject(
   socket: WebSocket,
   requestId: string,
@@ -309,8 +329,10 @@ export function authorizeOrReject(
   action: Action,
   resource: AccessResource,
   ctx: ConnectionContext,
-): boolean {
-  if (ctx.authConfig.mode === "none") return true;
+): AuthorizationResult {
+  if (ctx.authConfig.mode === "none") {
+    return { allowed: true, decision: null };
+  }
 
   if (!ctx.policySnapshotLoader) {
     sendError(
@@ -327,8 +349,10 @@ export function authorizeOrReject(
       action,
       resource,
       "access_not_configured",
+      null,
+      [],
     );
-    return false;
+    return { allowed: false, decision: null };
   }
 
   if (!principal) {
@@ -346,8 +370,10 @@ export function authorizeOrReject(
       action,
       resource,
       "no_principal",
+      null,
+      [],
     );
-    return false;
+    return { allowed: false, decision: null };
   }
 
   const collectives = connectionCollectives.get(socket) ?? [];
@@ -359,7 +385,9 @@ export function authorizeOrReject(
     resource,
   );
 
-  if (decision && decision.effect === "allow") return true;
+  if (decision && decision.effect === "allow") {
+    return { allowed: true, decision };
+  }
 
   if (!decision) {
     const adminDecision = service.decide(
@@ -367,7 +395,9 @@ export function authorizeOrReject(
       "admin",
       { kind: "access", name: "*", fields: {} },
     );
-    if (adminDecision && adminDecision.effect === "allow") return true;
+    if (adminDecision && adminDecision.effect === "allow") {
+      return { allowed: true, decision: adminDecision };
+    }
   }
 
   const principalStr = resolveDisplayPrincipal(principal, ctx);
@@ -394,8 +424,26 @@ export function authorizeOrReject(
     action,
     resource,
     "unauthorized",
+    decision,
+    groups,
   );
-  return false;
+  return { allowed: false, decision: decision ?? null };
+}
+
+function buildAuditDecision(
+  action: Action,
+  resource: AccessResource,
+  decision: AccessDecision | null,
+  groups: readonly string[],
+): AuditDecision {
+  return {
+    action: String(action),
+    resourceKind: resource.kind,
+    resourceName: resource.name,
+    effect: decision?.effect ?? "deny",
+    grantId: decision?.grantId ?? null,
+    principalGroups: groups,
+  };
 }
 
 function emitDenial(
@@ -406,6 +454,8 @@ function emitDenial(
   action: Action,
   resource: AccessResource,
   detail: string,
+  accessDecision: AccessDecision | null,
+  groups: readonly string[],
 ): void {
   if (!ctx.auditEmitter) return;
   ctx.auditEmitter.emit(buildAuditEvent({
@@ -426,6 +476,7 @@ function emitDenial(
     sourceIp: getConnectionSourceIp(socket),
     requestId,
     detail,
+    decision: buildAuditDecision(action, resource, accessDecision, groups),
   }));
 }
 
@@ -445,6 +496,9 @@ export function send(socket: WebSocket, message: ServerMessage): void {
   }
 }
 
+const MAX_ERRORED_REQUESTS = 10_000;
+const erroredRequests = new WeakMap<WebSocket, Set<string>>();
+
 export function sendError(
   socket: WebSocket,
   id: string,
@@ -452,11 +506,35 @@ export function sendError(
   message: string,
   details?: unknown,
 ): void {
+  let errors = erroredRequests.get(socket);
+  if (!errors) {
+    errors = new Set();
+    erroredRequests.set(socket, errors);
+  }
+  errors.add(id);
+  if (errors.size > MAX_ERRORED_REQUESTS) {
+    const first = errors.values().next().value!;
+    errors.delete(first);
+  }
   send(socket, {
     type: "error",
     id,
     error: { code, message, ...(details !== undefined && { details }) },
   });
+}
+
+export function wasRequestErrored(
+  socket: WebSocket,
+  requestId: string,
+): boolean {
+  return erroredRequests.get(socket)?.has(requestId) ?? false;
+}
+
+export function clearRequestErrored(
+  socket: WebSocket,
+  requestId: string,
+): void {
+  erroredRequests.get(socket)?.delete(requestId);
 }
 
 export function createSocketSubscriber(

--- a/src/serve/handlers/vault_handlers.ts
+++ b/src/serve/handlers/vault_handlers.ts
@@ -114,7 +114,7 @@ export async function handleVaultGet(
       kind: "data",
       name: "vault",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -172,7 +172,7 @@ export async function handleVaultPut(
         kind: "data",
         name: "vault",
         fields: {},
-      }, ctx)
+      }, ctx).allowed
     ) return;
   } else {
     if (
@@ -180,7 +180,7 @@ export async function handleVaultPut(
         kind: "data",
         name: "vault",
         fields: {},
-      }, ctx)
+      }, ctx).allowed
     ) return;
   }
 
@@ -290,7 +290,7 @@ export async function handleVaultDelete(
       kind: "data",
       name: "vault",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   let flush: (() => Promise<void>) | undefined;
@@ -413,7 +413,7 @@ export async function handleVaultDescribe(
       kind: "data",
       name: "vault",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -470,7 +470,7 @@ export async function handleVaultInspect(
       kind: "data",
       name: "vault",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -530,7 +530,7 @@ export async function handleVaultListKeys(
       kind: "data",
       name: "vault",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -582,7 +582,7 @@ export async function handleVaultSearch(
       kind: "data",
       name: "vault",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -636,7 +636,7 @@ export async function handleVaultAnnotate(
       kind: "data",
       name: "vault",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -712,7 +712,7 @@ export async function handleVaultCreate(
       kind: "data",
       name: payload.name,
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -768,7 +768,7 @@ export async function handleVaultEdit(
       kind: "data",
       name: payload.vaultNameOrId,
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -821,7 +821,7 @@ export async function handleVaultAuditTrail(
       kind: "data",
       name: payload?.vaultName ?? "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -880,7 +880,7 @@ export async function handleVaultReadSecret(
       kind: "data",
       name: payload.vaultName,
       fields: { key: payload.secretKey },
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -936,7 +936,7 @@ export async function handleVaultTypeSearch(
       kind: "data",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -179,7 +179,7 @@ export async function handleWorkflowRun(
       kind: "workflow",
       name: payload.workflowIdOrName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   const initiatedBy = principal ? principalToString(principal) : "ghost";
@@ -427,7 +427,7 @@ export async function handleWorkflowSearch(
       kind: "workflow",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -478,7 +478,7 @@ export async function handleWorkflowApprovals(
       kind: "workflow",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -548,7 +548,7 @@ export async function handleWorkflowGet(
       kind: "workflow",
       name: payload.workflowIdOrName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -607,7 +607,7 @@ export async function handleWorkflowHistoryGet(
       kind: "workflow",
       name: payload.workflowIdOrName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -675,7 +675,7 @@ export async function handleWorkflowHistoryLogs(
       kind: "workflow",
       name: payload.runIdOrWorkflow,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -743,7 +743,7 @@ export async function handleWorkflowHistorySearch(
       kind: "workflow",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -809,7 +809,7 @@ export async function handleWorkflowRunSearch(
       kind: "workflow",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -872,7 +872,7 @@ export async function handleWorkflowSchema(
       kind: "workflow",
       name: "*",
       fields: {},
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -924,7 +924,7 @@ export async function handleWorkflowApprove(
       kind: "workflow",
       name: payload.workflowIdOrName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -997,7 +997,7 @@ export async function handleWorkflowReject(
       kind: "workflow",
       name: payload.workflowIdOrName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1071,7 +1071,7 @@ export async function handleWorkflowResume(
       kind: "workflow",
       name: payload.workflowIdOrName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   const registry = ctx.activeRunRegistry;
@@ -1449,7 +1449,7 @@ export async function handleWorkflowCreate(
       kind: "workflow",
       name: payload.name,
       fields: { name: payload.name },
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1503,7 +1503,7 @@ export async function handleWorkflowDelete(
       kind: "workflow",
       name: payload.workflowIdOrName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1559,7 +1559,7 @@ export async function handleWorkflowEdit(
       kind: "workflow",
       name: payload.workflowIdOrName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1619,7 +1619,7 @@ export async function handleWorkflowValidate(
       kind: "workflow",
       name: resourceName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1679,7 +1679,7 @@ export async function handleWorkflowEvaluate(
       kind: "workflow",
       name: resourceName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1742,7 +1742,7 @@ export async function handleWorkflowTriggerSet(
       kind: "workflow",
       name: payload.workflowName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1792,7 +1792,7 @@ export async function handleWorkflowTriggerGet(
       kind: "workflow",
       name: payload.workflowName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {
@@ -1856,7 +1856,7 @@ export async function handleWorkflowTriggerRemove(
       kind: "workflow",
       name: payload.workflowName,
       fields: workflowFields,
-    }, ctx)
+    }, ctx).allowed
   ) return;
 
   try {

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -156,6 +156,23 @@ export interface AuditTimelinePayload {
   includeDiagnostic?: boolean;
 }
 
+export interface AuditQueryPayload {
+  since?: string;
+  until?: string;
+  principal?: string;
+  category?: string;
+  action?: string;
+  outcome?: string;
+  resource?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface AuditVerifyPayload {
+  since?: string;
+  until?: string;
+}
+
 export interface SummarisePayload {
   since?: string;
   limit?: number;
@@ -731,6 +748,8 @@ export type ServerRequest =
   | { type: "vault.search"; id: string; payload?: VaultSearchPayload }
   | { type: "vault.annotate"; id: string; payload: VaultAnnotatePayload }
   | { type: "audit.timeline"; id: string; payload?: AuditTimelinePayload }
+  | { type: "audit.query"; id: string; payload: AuditQueryPayload }
+  | { type: "audit.verify"; id: string; payload: AuditVerifyPayload }
   | { type: "summarise"; id: string; payload?: SummarisePayload }
   | { type: "report.get"; id: string; payload: ReportGetPayload }
   | { type: "report.search"; id: string; payload?: ReportSearchPayload }
@@ -1143,6 +1162,19 @@ export interface AuditTimelineResponse {
   data: Record<string, unknown>;
 }
 
+export interface AuditQueryResponse {
+  events: readonly Record<string, unknown>[];
+  cursor?: string;
+  total?: number;
+}
+
+export interface AuditVerifyResponse {
+  valid: boolean;
+  eventsChecked: number;
+  brokenAt?: number;
+  message: string;
+}
+
 export interface SummariseResponse {
   data: Record<string, unknown>;
 }
@@ -1518,6 +1550,8 @@ export type ServerMessage =
   | { type: "vault.search"; id: string; payload: VaultSearchResponse }
   | { type: "vault.annotate"; id: string; payload: VaultAnnotateResponse }
   | { type: "audit.timeline"; id: string; payload: AuditTimelineResponse }
+  | { type: "audit.query"; id: string; payload: AuditQueryResponse }
+  | { type: "audit.verify"; id: string; payload: AuditVerifyResponse }
   | { type: "summarise"; id: string; payload: SummariseResponse }
   | { type: "report.get"; id: string; payload: ReportGetResponse }
   | { type: "report.search"; id: string; payload: ReportSearchResponse }

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -125,6 +125,20 @@ export interface ServeConfigFile {
     stores?: AuditStoreConfigEntry[];
     "batch-size"?: number;
     "flush-interval"?: string;
+    "fail-open"?: boolean;
+    policy?: {
+      "default-level"?: string;
+      rules?: Array<{
+        category?: string;
+        action?: string;
+        tier?: string;
+        level: string;
+      }>;
+    };
+    wal?: {
+      directory?: string;
+      "max-size"?: string;
+    };
   };
 }
 
@@ -132,12 +146,25 @@ export interface AuditStoreConfigEntry {
   readonly target: string;
   readonly type?: string;
   readonly config?: Record<string, unknown>;
+  readonly retention?: {
+    readonly days: number;
+  };
 }
 
 export interface AuditConfig {
   readonly stores: readonly AuditStoreConfigEntry[];
   readonly batchSize: number;
   readonly flushIntervalMs: number;
+  readonly failOpen: boolean;
+  readonly walDir: string;
+  readonly walMaxBytes: number;
+  readonly policyDefaultLevel: string;
+  readonly policyRules: readonly {
+    readonly category?: string;
+    readonly action?: string;
+    readonly tier?: string;
+    readonly level: string;
+  }[];
 }
 
 // ── Known Keys ────────────────────────────────────────────────────────
@@ -1137,7 +1164,14 @@ export async function writeServeConfigFile(
 
 // ── Audit Config ─────────────────────────────────────────────────────
 
-const KNOWN_AUDIT_KEYS = new Set(["stores", "batch-size", "flush-interval"]);
+const KNOWN_AUDIT_KEYS = new Set([
+  "stores",
+  "batch-size",
+  "flush-interval",
+  "fail-open",
+  "policy",
+  "wal",
+]);
 
 function validateAuditConfig(audit: unknown, path: string): void {
   if (typeof audit !== "object" || audit === null || Array.isArray(audit)) {
@@ -1189,6 +1223,136 @@ function validateAuditConfig(audit: unknown, path: string): void {
       ) {
         throw new UserError(
           `Invalid audit store at index ${i} in ${path}: type and config must both be present for a dedicated audit store`,
+        );
+      }
+      if (storeObj.retention !== undefined) {
+        if (
+          typeof storeObj.retention !== "object" ||
+          storeObj.retention === null ||
+          Array.isArray(storeObj.retention)
+        ) {
+          throw new UserError(
+            `Invalid audit store at index ${i} in ${path}: retention must be an object`,
+          );
+        }
+        const retention = storeObj.retention as Record<string, unknown>;
+        if (
+          typeof retention.days !== "number" ||
+          !Number.isInteger(retention.days) ||
+          retention.days < 1
+        ) {
+          throw new UserError(
+            `Invalid audit store at index ${i} in ${path}: retention.days must be a positive integer`,
+          );
+        }
+      }
+    }
+  }
+
+  if (obj["fail-open"] !== undefined) {
+    if (typeof obj["fail-open"] !== "boolean") {
+      throw new UserError(
+        `Invalid audit.fail-open in ${path}: expected boolean`,
+      );
+    }
+  }
+
+  if (obj.policy !== undefined) {
+    if (
+      typeof obj.policy !== "object" || obj.policy === null ||
+      Array.isArray(obj.policy)
+    ) {
+      throw new UserError(
+        `Invalid audit.policy in ${path}: expected mapping`,
+      );
+    }
+    const policy = obj.policy as Record<string, unknown>;
+    const validLevels = new Set([
+      "none",
+      "metadata",
+      "request",
+      "requestResponse",
+    ]);
+    if (
+      policy["default-level"] !== undefined &&
+      (typeof policy["default-level"] !== "string" ||
+        !validLevels.has(policy["default-level"]))
+    ) {
+      throw new UserError(
+        `Invalid audit.policy.default-level in ${path}: expected one of none, metadata, request, requestResponse`,
+      );
+    }
+    if (policy.rules !== undefined) {
+      if (!Array.isArray(policy.rules)) {
+        throw new UserError(
+          `Invalid audit.policy.rules in ${path}: expected array`,
+        );
+      }
+      const validTiers = new Set(["management", "data"]);
+      for (let i = 0; i < policy.rules.length; i++) {
+        const rule = policy.rules[i] as Record<string, unknown>;
+        if (typeof rule !== "object" || rule === null || Array.isArray(rule)) {
+          throw new UserError(
+            `Invalid audit.policy.rules[${i}] in ${path}: expected object`,
+          );
+        }
+        if (
+          typeof rule.level !== "string" || !validLevels.has(rule.level)
+        ) {
+          throw new UserError(
+            `Invalid audit.policy.rules[${i}].level in ${path}: expected one of none, metadata, request, requestResponse`,
+          );
+        }
+        if (
+          rule.category !== undefined && typeof rule.category !== "string"
+        ) {
+          throw new UserError(
+            `Invalid audit.policy.rules[${i}].category in ${path}: expected string`,
+          );
+        }
+        if (rule.action !== undefined && typeof rule.action !== "string") {
+          throw new UserError(
+            `Invalid audit.policy.rules[${i}].action in ${path}: expected string`,
+          );
+        }
+        if (
+          rule.tier !== undefined &&
+          (typeof rule.tier !== "string" || !validTiers.has(rule.tier))
+        ) {
+          throw new UserError(
+            `Invalid audit.policy.rules[${i}].tier in ${path}: expected one of management, data`,
+          );
+        }
+      }
+    }
+  }
+
+  if (obj.wal !== undefined) {
+    if (
+      typeof obj.wal !== "object" || obj.wal === null ||
+      Array.isArray(obj.wal)
+    ) {
+      throw new UserError(
+        `Invalid audit.wal in ${path}: expected mapping`,
+      );
+    }
+    const wal = obj.wal as Record<string, unknown>;
+    if (wal.directory !== undefined && typeof wal.directory !== "string") {
+      throw new UserError(
+        `Invalid audit.wal.directory in ${path}: expected string`,
+      );
+    }
+    if (wal["max-size"] !== undefined) {
+      if (typeof wal["max-size"] !== "string") {
+        throw new UserError(
+          `Invalid audit.wal.max-size in ${path}: expected string (e.g. "100MB", "1GB")`,
+        );
+      }
+      if (parseByteSize(wal["max-size"]) === null) {
+        throw new UserError(
+          `Invalid audit.wal.max-size in ${path}: expected format like "100MB" or "1GB", got "${
+            wal["max-size"]
+          }"`,
         );
       }
     }
@@ -1245,10 +1409,21 @@ export function parseAuditConfig(
     if (parsed !== null) flushIntervalMs = parsed;
   }
 
+  let walMaxBytes = 100 * 1024 * 1024; // 100MB default
+  if (audit.wal?.["max-size"]) {
+    const parsed = parseByteSize(audit.wal["max-size"]);
+    if (parsed !== null) walMaxBytes = parsed;
+  }
+
   return {
     stores: audit.stores,
     batchSize: audit["batch-size"] ?? 100,
     flushIntervalMs,
+    failOpen: audit["fail-open"] ?? true,
+    walDir: audit.wal?.directory ?? ".swamp/audit-wal",
+    walMaxBytes,
+    policyDefaultLevel: audit.policy?.["default-level"] ?? "metadata",
+    policyRules: audit.policy?.rules ?? [],
   };
 }
 
@@ -1263,6 +1438,22 @@ function parseDuration(value: string): number | null {
       return num * 1_000;
     case "m":
       return num * 60_000;
+    default:
+      return null;
+  }
+}
+
+function parseByteSize(value: string): number | null {
+  const match = value.match(/^(\d+)(KB|MB|GB)$/i);
+  if (!match) return null;
+  const num = parseInt(match[1], 10);
+  switch (match[2].toUpperCase()) {
+    case "KB":
+      return num * 1024;
+    case "MB":
+      return num * 1024 * 1024;
+    case "GB":
+      return num * 1024 * 1024 * 1024;
     default:
       return null;
   }

--- a/src/serve/serve_config_test.ts
+++ b/src/serve/serve_config_test.ts
@@ -1413,6 +1413,281 @@ Deno.test("loadServeConfig: rejects non-object audit block", () => {
   }
 });
 
+// ── Phase 2 audit config fields ──────────────────────────────────────
+
+Deno.test("parseAuditConfig: returns Phase 2 defaults", () => {
+  const result = parseAuditConfig({
+    audit: { stores: [{ target: "default" }] },
+  });
+  assertEquals(result?.failOpen, true);
+  assertEquals(result?.walDir, ".swamp/audit-wal");
+  assertEquals(result?.walMaxBytes, 100 * 1024 * 1024);
+  assertEquals(result?.policyDefaultLevel, "metadata");
+  assertEquals(result?.policyRules, []);
+});
+
+Deno.test("parseAuditConfig: parses fail-open false", () => {
+  const result = parseAuditConfig({
+    audit: { stores: [{ target: "a" }], "fail-open": false },
+  });
+  assertEquals(result?.failOpen, false);
+});
+
+Deno.test("parseAuditConfig: parses wal config", () => {
+  const result = parseAuditConfig({
+    audit: {
+      stores: [{ target: "a" }],
+      wal: { directory: "custom/wal", "max-size": "50MB" },
+    },
+  });
+  assertEquals(result?.walDir, "custom/wal");
+  assertEquals(result?.walMaxBytes, 50 * 1024 * 1024);
+});
+
+Deno.test("parseAuditConfig: parses wal max-size KB", () => {
+  const result = parseAuditConfig({
+    audit: {
+      stores: [{ target: "a" }],
+      wal: { "max-size": "512KB" },
+    },
+  });
+  assertEquals(result?.walMaxBytes, 512 * 1024);
+});
+
+Deno.test("parseAuditConfig: parses wal max-size GB", () => {
+  const result = parseAuditConfig({
+    audit: {
+      stores: [{ target: "a" }],
+      wal: { "max-size": "1GB" },
+    },
+  });
+  assertEquals(result?.walMaxBytes, 1024 * 1024 * 1024);
+});
+
+Deno.test("parseAuditConfig: parses wal max-size case-insensitive", () => {
+  const result = parseAuditConfig({
+    audit: {
+      stores: [{ target: "a" }],
+      wal: { "max-size": "100mb" },
+    },
+  });
+  assertEquals(result?.walMaxBytes, 100 * 1024 * 1024);
+});
+
+Deno.test("parseAuditConfig: parses policy config", () => {
+  const result = parseAuditConfig({
+    audit: {
+      stores: [{ target: "a" }],
+      policy: {
+        "default-level": "requestResponse",
+        rules: [
+          { category: "secrets", level: "requestResponse" },
+          { tier: "management", level: "none" },
+          { action: "vault.get", level: "request" },
+        ],
+      },
+    },
+  });
+  assertEquals(result?.policyDefaultLevel, "requestResponse");
+  assertEquals(result?.policyRules.length, 3);
+  assertEquals(result?.policyRules[0], {
+    category: "secrets",
+    level: "requestResponse",
+  });
+  assertEquals(result?.policyRules[1], {
+    tier: "management",
+    level: "none",
+  });
+});
+
+Deno.test("parseAuditConfig: parses store retention", () => {
+  const result = parseAuditConfig({
+    audit: {
+      stores: [{ target: "a", retention: { days: 90 } }],
+    },
+  });
+  const store = result?.stores[0] as { retention?: { days: number } };
+  assertEquals(store?.retention?.days, 90);
+});
+
+Deno.test("loadServeConfig: rejects non-boolean fail-open", () => {
+  const dir = Deno.makeTempDirSync();
+  try {
+    const path = join(dir, ".swamp", "serve.yaml");
+    Deno.mkdirSync(join(dir, ".swamp"), { recursive: true });
+    Deno.writeTextFileSync(
+      path,
+      stringifyYaml({
+        audit: { stores: [{ target: "default" }], "fail-open": "yes" },
+      }),
+    );
+    assertThrows(
+      () => loadServeConfig(path, dir),
+      Error,
+      "fail-open",
+    );
+  } finally {
+    try {
+      Deno.removeSync(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
+});
+
+Deno.test("loadServeConfig: rejects invalid policy default-level", () => {
+  const dir = Deno.makeTempDirSync();
+  try {
+    const path = join(dir, ".swamp", "serve.yaml");
+    Deno.mkdirSync(join(dir, ".swamp"), { recursive: true });
+    Deno.writeTextFileSync(
+      path,
+      stringifyYaml({
+        audit: {
+          stores: [{ target: "default" }],
+          policy: { "default-level": "verbose" },
+        },
+      }),
+    );
+    assertThrows(
+      () => loadServeConfig(path, dir),
+      Error,
+      "default-level",
+    );
+  } finally {
+    try {
+      Deno.removeSync(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
+});
+
+Deno.test("loadServeConfig: rejects invalid policy rule level", () => {
+  const dir = Deno.makeTempDirSync();
+  try {
+    const path = join(dir, ".swamp", "serve.yaml");
+    Deno.mkdirSync(join(dir, ".swamp"), { recursive: true });
+    Deno.writeTextFileSync(
+      path,
+      stringifyYaml({
+        audit: {
+          stores: [{ target: "default" }],
+          policy: { rules: [{ level: "invalid" }] },
+        },
+      }),
+    );
+    assertThrows(
+      () => loadServeConfig(path, dir),
+      Error,
+      "level",
+    );
+  } finally {
+    try {
+      Deno.removeSync(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
+});
+
+Deno.test("loadServeConfig: rejects invalid policy rule tier", () => {
+  const dir = Deno.makeTempDirSync();
+  try {
+    const path = join(dir, ".swamp", "serve.yaml");
+    Deno.mkdirSync(join(dir, ".swamp"), { recursive: true });
+    Deno.writeTextFileSync(
+      path,
+      stringifyYaml({
+        audit: {
+          stores: [{ target: "default" }],
+          policy: { rules: [{ level: "metadata", tier: "invalid" }] },
+        },
+      }),
+    );
+    assertThrows(
+      () => loadServeConfig(path, dir),
+      Error,
+      "tier",
+    );
+  } finally {
+    try {
+      Deno.removeSync(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
+});
+
+Deno.test("loadServeConfig: rejects invalid wal max-size format", () => {
+  const dir = Deno.makeTempDirSync();
+  try {
+    const path = join(dir, ".swamp", "serve.yaml");
+    Deno.mkdirSync(join(dir, ".swamp"), { recursive: true });
+    Deno.writeTextFileSync(
+      path,
+      stringifyYaml({
+        audit: {
+          stores: [{ target: "default" }],
+          wal: { "max-size": "100bytes" },
+        },
+      }),
+    );
+    assertThrows(
+      () => loadServeConfig(path, dir),
+      Error,
+      "max-size",
+    );
+  } finally {
+    try {
+      Deno.removeSync(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
+});
+
+Deno.test("loadServeConfig: rejects non-integer retention days", () => {
+  const dir = Deno.makeTempDirSync();
+  try {
+    const path = join(dir, ".swamp", "serve.yaml");
+    Deno.mkdirSync(join(dir, ".swamp"), { recursive: true });
+    Deno.writeTextFileSync(
+      path,
+      stringifyYaml({
+        audit: {
+          stores: [{ target: "default", retention: { days: 0 } }],
+        },
+      }),
+    );
+    assertThrows(
+      () => loadServeConfig(path, dir),
+      Error,
+      "retention.days",
+    );
+  } finally {
+    try {
+      Deno.removeSync(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
+});
+
+Deno.test("loadServeConfig: rejects non-string wal directory", () => {
+  const dir = Deno.makeTempDirSync();
+  try {
+    const path = join(dir, ".swamp", "serve.yaml");
+    Deno.mkdirSync(join(dir, ".swamp"), { recursive: true });
+    Deno.writeTextFileSync(
+      path,
+      stringifyYaml({
+        audit: {
+          stores: [{ target: "default" }],
+          wal: { directory: 123 },
+        },
+      }),
+    );
+    assertThrows(
+      () => loadServeConfig(path, dir),
+      Error,
+      "directory",
+    );
+  } finally {
+    try {
+      Deno.removeSync(dir, { recursive: true });
+    } catch { /* Windows EBUSY */ }
+  }
+});
+
 Deno.test("readServeConfigFile: returns null when file does not exist", async () => {
   const dir = await Deno.makeTempDir();
   try {


### PR DESCRIPTION
## Summary

Phase 2 of the serve audit log (#2028). Builds on Phase 1 (#2379).

Chain hashing, WAL, audit policy, fail-secure, query API with cursor pagination,
CLI commands, complete handler coverage, per-store retention, single-sink guard.

## Test plan

- [x] 11,286 tests, 0 lint, build 9/9
- [x] All three reviews pass (UX, code, adversarial)
- [x] Live tested: OAuth + Minio S3

Closes #2028

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgMqX7oyyNHBKimeJmBsRB