### PR TITLE
fix(paths): throw on silent fallback in managedConfig registry (swamp-club#2034)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -198,7 +198,6 @@ import {
 } from "../../infrastructure/persistence/run_tracker_store.ts";
 import {
   getSwampConfigDir,
-  registerManagedConfig,
   swampPath,
 } from "../../infrastructure/persistence/paths.ts";
 import { DefaultDatastorePathResolver } from "../../infrastructure/persistence/default_datastore_path_resolver.ts";
@@ -1422,7 +1421,6 @@ export const serveCommand = new Command()
       repoDir: resolvedRepoDir,
       repoContext,
       datastoreConfig,
-      datastoreResolver: initialResolver,
       syncService,
       lockfilePath: managedLockfilePath,
     } = await requireInitializedRepoUnlocked({
@@ -1439,11 +1437,6 @@ export const serveCommand = new Command()
     } catch {
       // Not in a swamp repo or marker unreadable — resolveModelsDir(null) returns the default
     }
-    registerManagedConfig(
-      resolvedRepoDir,
-      repoMarker?.datastore?.managedConfig === true,
-      initialResolver.resolvePath("config"),
-    );
     const extensionLockfilePath = managedLockfilePath;
 
     // Remote-execution control plane: capability verbs, worker enrollment,

--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -128,6 +128,11 @@ export function registerManagedConfig(
   active: boolean,
   configBasePath?: string,
 ): void {
+  if (active && !configBasePath) {
+    throw new Error(
+      "registerManagedConfig: active is true but configBasePath is missing",
+    );
+  }
   const key = resolve(repoDir);
   const existing = managedConfigRegistry.get(key);
   if (typeof existing === "string") return;
@@ -139,8 +144,8 @@ export function registerManagedConfig(
 }
 
 export function isManagedConfig(repoDir: string): boolean {
-  return managedConfigRegistry.get(resolve(repoDir)) !== false &&
-    managedConfigRegistry.get(resolve(repoDir)) !== undefined;
+  const val = managedConfigRegistry.get(resolve(repoDir));
+  return typeof val === "string";
 }
 
 export function getManagedConfigBase(repoDir: string): string | undefined {
@@ -163,17 +168,10 @@ export function resolveEffectiveVaultsDir(repoDir: string): string {
   return base ? join(base, "vaults") : join(repoDir, "vaults");
 }
 
-/**
- * Resolves the pulled-extensions root for a repository.
- * When managedConfig is explicitly passed, uses that value.
- * Otherwise checks the module-level registry.
- */
 export function resolvePulledExtensionsRoot(
   repoDir: string,
-  managedConfig?: boolean,
 ): string {
-  const active = managedConfig ?? isManagedConfig(repoDir);
-  return active
+  return isManagedConfig(repoDir)
     ? swampPath(repoDir, "config", "pulled-extensions")
     : swampPath(repoDir, "pulled-extensions");
 }

--- a/src/infrastructure/persistence/paths_test.ts
+++ b/src/infrastructure/persistence/paths_test.ts
@@ -25,7 +25,9 @@ import {
   globalTelemetryDir,
   homeDirectory,
   homeDirectoryIsSet,
+  isManagedConfig,
   managedConfigLockfilePath,
+  registerManagedConfig,
   resolvePulledExtensionsRoot,
   SWAMP_DATA_DIR,
   SWAMP_MARKER_FILE,
@@ -559,19 +561,68 @@ Deno.test("bundleNamespace: returns 8-char hex string", () => {
   assertEquals(/^[0-9a-f]{8}$/.test(hash), true);
 });
 
-// --- resolvePulledExtensionsRoot / managedConfigLockfilePath ---
+// --- registerManagedConfig / isManagedConfig ---
 
-Deno.test("resolvePulledExtensionsRoot: managedConfig=false returns .swamp/pulled-extensions", () => {
-  assertPathEquals(
-    resolvePulledExtensionsRoot("/repo", false),
-    "/repo/.swamp/pulled-extensions",
+Deno.test("registerManagedConfig: throws on active with no configBasePath", () => {
+  assertThrows(
+    () => registerManagedConfig("/repo/throw-test-1", true),
+    Error,
+    "active is true but configBasePath is missing",
   );
 });
 
-Deno.test("resolvePulledExtensionsRoot: managedConfig=true returns .swamp/config/pulled-extensions", () => {
+Deno.test("registerManagedConfig: throws on active with undefined configBasePath", () => {
+  assertThrows(
+    () => registerManagedConfig("/repo/throw-test-2", true, undefined),
+    Error,
+    "active is true but configBasePath is missing",
+  );
+});
+
+Deno.test("isManagedConfig: returns false when registry has no entry", () => {
+  assertEquals(isManagedConfig("/repo/unregistered-test-1"), false);
+});
+
+Deno.test("isManagedConfig: returns false when registered as inactive", () => {
+  registerManagedConfig("/repo/inactive-test-1", false);
+  assertEquals(isManagedConfig("/repo/inactive-test-1"), false);
+});
+
+Deno.test("isManagedConfig: returns true when registered as active", () => {
+  registerManagedConfig(
+    "/repo/active-test-1",
+    true,
+    "/repo/active-test-1/.swamp/config",
+  );
+  assertEquals(isManagedConfig("/repo/active-test-1"), true);
+});
+
+// --- resolvePulledExtensionsRoot / managedConfigLockfilePath ---
+
+Deno.test("resolvePulledExtensionsRoot: unregistered returns .swamp/pulled-extensions", () => {
   assertPathEquals(
-    resolvePulledExtensionsRoot("/repo", true),
-    "/repo/.swamp/config/pulled-extensions",
+    resolvePulledExtensionsRoot("/repo/unregistered-test-2"),
+    "/repo/unregistered-test-2/.swamp/pulled-extensions",
+  );
+});
+
+Deno.test("resolvePulledExtensionsRoot: inactive returns .swamp/pulled-extensions", () => {
+  registerManagedConfig("/repo/inactive-test-2", false);
+  assertPathEquals(
+    resolvePulledExtensionsRoot("/repo/inactive-test-2"),
+    "/repo/inactive-test-2/.swamp/pulled-extensions",
+  );
+});
+
+Deno.test("resolvePulledExtensionsRoot: active returns .swamp/config/pulled-extensions", () => {
+  registerManagedConfig(
+    "/repo/active-test-2",
+    true,
+    "/repo/active-test-2/.swamp/config",
+  );
+  assertPathEquals(
+    resolvePulledExtensionsRoot("/repo/active-test-2"),
+    "/repo/active-test-2/.swamp/config/pulled-extensions",
   );
 });
 


### PR DESCRIPTION
## Summary

Fixes the module-level `managedConfig` registry in `paths.ts` which silently downgraded bad input and had redundant registration paths, causing "Unknown model type" errors on serve pods with `managedConfig` active.

- `registerManagedConfig` now throws on `active && !configBasePath` instead of silently writing `false`
- Removed redundant `registerManagedConfig` call from `serve.ts` — already handled by `requireInitializedRepoUnlocked` via `resolveManagedConfigPaths` with `skipSentinelCheck: true`
- Removed dead `managedConfig` parameter from `resolvePulledExtensionsRoot` — unused by all 16 non-test callers
- `isManagedConfig` simplified to `typeof val === "string"` check (returns `false` for unregistered repos — throwing would break 86 tests across 12 files)
- Filed #2043 for the cross-process sentinel disagreement (separate design decision)

Closes swamp-club#2034

## Test plan

- [x] 46 unit tests in `paths_test.ts` pass (8 new: throw guards, registry states, pulled-extensions resolution)
- [x] 11,197 total tests pass
- [x] Lint, fmt, type-check clean
- [x] Compile + binary smoke test pass
- [x] Code review: pass (0 findings)
- [x] Adversarial review: pass (0 findings)
- [x] UX review: pass (no user-visible changes)
- [x] Attestation posted: `7479e07f-18c9-4d9d-a747-8c3ce5e764f8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)