### PR TITLE
fix(access): filter search/list results by grant scope instead of rejecting on wildcard (swamp-club#2042)

### DIFF
--- a/design/enablers/access-control.md
+++ b/design/enablers/access-control.md
@@ -246,6 +246,36 @@ request — there is no request-level locking or snapshot versioning.
 
 Implementation: `src/domain/access/policy_snapshot_loader.ts`.
 
+## Collection operations and grant-scoped filtering
+
+Single-resource operations (`model.get`, `workflow.run`, `data.get`) authorize
+against the specific resource name — e.g., `model:@acme/deploy`. Collection
+operations (`model.search`, `workflow.search`, `data.search`, `data.query`, and
+their history/output/approval variants) cannot name a single resource upfront
+because they return multiple results.
+
+These handlers use **post-query filtering**: they run the query, then filter each
+result item through `decide()` using the item's resource name. A user with
+`model:@acme/*` running `model search` sees only models whose names match that
+pattern. A user with `model:*` sees everything (unchanged behavior). A user with
+no `read` grants for the resource kind sees an empty result set.
+
+Metadata-only endpoints that return type definitions or schemas (e.g.,
+`model.type.search`, `workflow.schema`) require at least one `read` grant for
+the resource kind but do not filter per item — they return static metadata, not
+per-resource data.
+
+**CEL conditions and search results**: search result items carry a subset of the
+fields available to the condition evaluator (typically `name` and `modelType`).
+Conditional grants that reference fields not present in search results (e.g.,
+`resource.tags`) fail closed — the condition evaluator returns `false` for
+unknown variables, so the grant does not match. This means conditional grants may
+be more restrictive for collection operations than for single-resource
+operations where the full field set is available.
+
+Implementation: `filterByAuthorization` and `authorizeAnyOrReject` in
+`src/serve/handlers/shared.ts`.
+
 ## Workflow execution context
 
 Authorization is checked at the serve handler boundary, not at the domain layer.

--- a/src/domain/access/access_decision_service.ts
+++ b/src/domain/access/access_decision_service.ts
@@ -53,4 +53,10 @@ export interface AccessDecisionService {
     action: Action,
     resource: AccessResource,
   ): AccessDecision[];
+
+  hasAnyGrantForKind(
+    principal: AccessPrincipal,
+    action: Action,
+    kind: ResourceKind,
+  ): boolean;
 }

--- a/src/domain/access/grant_based_access_decision_service.ts
+++ b/src/domain/access/grant_based_access_decision_service.ts
@@ -29,7 +29,10 @@ import type { Action } from "./action.ts";
 import type { PolicySnapshot } from "./policy_snapshot.ts";
 import { principalToString } from "./principal.ts";
 import type { PrincipalContext } from "./principal_context.ts";
-import { resourceSelectorMatches } from "./resource_selector.ts";
+import {
+  type ResourceKind,
+  resourceSelectorMatches,
+} from "./resource_selector.ts";
 
 export const MAX_AGGREGATE_CONDITIONS = 100;
 
@@ -240,5 +243,25 @@ export class GrantBasedAccessDecisionService implements AccessDecisionService {
     }
 
     return [...denyDecisions, ...allowDecisions];
+  }
+
+  hasAnyGrantForKind(
+    principal: AccessPrincipal,
+    action: Action,
+    kind: ResourceKind,
+  ): boolean {
+    const snapshot = this.#snapshot;
+    const principalKey = principalToString(principal.principal);
+    const localGroups = snapshot.groupsForPrincipal(principalKey);
+    const subjects = resolveSubjects(principal, localGroups);
+    const candidates = snapshot.grantsForSubjects(subjects);
+
+    for (const grant of candidates) {
+      if (grant.effect !== "allow") continue;
+      if (grant.resource.kind !== kind) continue;
+      if (!grantMatchesAction(grant, action)) continue;
+      return true;
+    }
+    return false;
   }
 }

--- a/src/domain/access/grant_based_access_decision_service_test.ts
+++ b/src/domain/access/grant_based_access_decision_service_test.ts
@@ -760,3 +760,93 @@ Deno.test("explain: run-implies-approve flows through explain", () => {
   assertEquals(results.length, 1);
   assertEquals(results[0].effect, "allow");
 });
+
+Deno.test("hasAnyGrantForKind: returns true when user has matching grant", () => {
+  const grant = makeGrant({
+    actions: ["read"],
+    resource: { kind: "model", pattern: "@acme/*" },
+  });
+  const snapshot = new PolicySnapshot([grant], []);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  assertEquals(
+    service.hasAnyGrantForKind(makePrincipal("adam"), "read", "model"),
+    true,
+  );
+});
+
+Deno.test("hasAnyGrantForKind: returns false for wrong kind", () => {
+  const grant = makeGrant({
+    actions: ["read"],
+    resource: { kind: "model", pattern: "@acme/*" },
+  });
+  const snapshot = new PolicySnapshot([grant], []);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  assertEquals(
+    service.hasAnyGrantForKind(makePrincipal("adam"), "read", "workflow"),
+    false,
+  );
+});
+
+Deno.test("hasAnyGrantForKind: returns false for wrong action", () => {
+  const grant = makeGrant({
+    actions: ["read"],
+    resource: { kind: "model", pattern: "*" },
+  });
+  const snapshot = new PolicySnapshot([grant], []);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  assertEquals(
+    service.hasAnyGrantForKind(makePrincipal("adam"), "write", "model"),
+    false,
+  );
+});
+
+Deno.test("hasAnyGrantForKind: returns false for deny-only grants", () => {
+  const grant = makeGrant({
+    effect: "deny",
+    actions: ["read"],
+    resource: { kind: "model", pattern: "@secret/*" },
+  });
+  const snapshot = new PolicySnapshot([grant], []);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  assertEquals(
+    service.hasAnyGrantForKind(makePrincipal("adam"), "read", "model"),
+    false,
+  );
+});
+
+Deno.test("hasAnyGrantForKind: returns false when no grants exist", () => {
+  const snapshot = new PolicySnapshot([], []);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  assertEquals(
+    service.hasAnyGrantForKind(makePrincipal("adam"), "read", "model"),
+    false,
+  );
+});
+
+Deno.test("hasAnyGrantForKind: matches via group membership", () => {
+  const grant = makeGrant({
+    subject: { kind: "group", name: "readers" },
+    actions: ["read"],
+    resource: { kind: "model", pattern: "@acme/*" },
+  });
+  const group = makeGroup("readers", ["adam"]);
+  const snapshot = new PolicySnapshot([grant], [group]);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  assertEquals(
+    service.hasAnyGrantForKind(makePrincipal("adam"), "read", "model"),
+    true,
+  );
+});
+
+Deno.test("hasAnyGrantForKind: run implies approve", () => {
+  const grant = makeGrant({
+    actions: ["run"],
+    resource: { kind: "workflow", pattern: "@acme/*" },
+  });
+  const snapshot = new PolicySnapshot([grant], []);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  assertEquals(
+    service.hasAnyGrantForKind(makePrincipal("adam"), "approve", "workflow"),
+    true,
+  );
+});

--- a/src/serve/handlers/access_handlers_test.ts
+++ b/src/serve/handlers/access_handlers_test.ts
@@ -58,6 +58,9 @@ function createMockDecisionService(): {
       calls.push({ principal, action, resource });
       return [];
     },
+    hasAnyGrantForKind() {
+      return true;
+    },
   };
   return { service, calls };
 }

--- a/src/serve/handlers/data_handlers.ts
+++ b/src/serve/handlers/data_handlers.ts
@@ -67,9 +67,11 @@ import { ModelType } from "../../domain/models/model_type.ts";
 import { findLatestItemsFromCatalog } from "../../infrastructure/persistence/catalog_search_adapter.ts";
 import type { Principal } from "../../domain/access/principal.ts";
 import {
+  authorizeAnyOrReject,
   authorizeOrReject,
   type ConnectionContext,
   DEFAULT_QUERY_LIMIT,
+  filterByAuthorization,
   MAX_QUERY_RESULTS,
   sanitizeErrorForClient,
   send,
@@ -180,13 +182,26 @@ export async function handleDataQuery(
   controller: AbortController,
   principal: Principal | null,
 ): Promise<void> {
-  if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "data",
-      name: "*",
-      fields: {},
-    }, ctx).allowed
-  ) return;
+  if (payload.select) {
+    if (
+      !authorizeOrReject(socket, requestId, principal, "read", {
+        kind: "data",
+        name: "*",
+        fields: {},
+      }, ctx).allowed
+    ) return;
+  } else {
+    if (
+      !authorizeAnyOrReject(
+        socket,
+        requestId,
+        principal,
+        "read",
+        "data",
+        ctx,
+      )
+    ) return;
+  }
 
   try {
     const libCtx = createLibSwampContext();
@@ -225,10 +240,28 @@ export async function handleDataQuery(
       return;
     }
 
+    const data = (result ?? {}) as {
+      results?: Array<{ modelName: string; modelType: string }>;
+      total?: number;
+    };
+    if (!payload.select && data.results) {
+      data.results = filterByAuthorization(
+        data.results,
+        (item) => item.modelName,
+        (item) => ({ name: item.modelName, modelType: item.modelType }),
+        socket,
+        principal,
+        "read",
+        "data",
+        ctx,
+      );
+      data.total = data.results.length;
+    }
+
     send(socket, {
       type: "data.query",
       id: requestId,
-      payload: { data: result ?? {} },
+      payload: { data },
     });
   } catch (error) {
     const message = sanitizeErrorForClient(error);
@@ -245,16 +278,30 @@ export async function handleDataList(
   principal: Principal | null,
 ): Promise<void> {
   const resourceName = payload.modelIdOrName ?? "*";
-  const listFields = resourceName !== "*"
-    ? await resolveDataFields(ctx.repoContext.definitionRepo, resourceName)
-    : {};
-  if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "data",
-      name: resourceName,
-      fields: listFields,
-    }, ctx).allowed
-  ) return;
+  if (resourceName !== "*") {
+    const listFields = await resolveDataFields(
+      ctx.repoContext.definitionRepo,
+      resourceName,
+    );
+    if (
+      !authorizeOrReject(socket, requestId, principal, "read", {
+        kind: "data",
+        name: resourceName,
+        fields: listFields,
+      }, ctx).allowed
+    ) return;
+  } else {
+    if (
+      !authorizeAnyOrReject(
+        socket,
+        requestId,
+        principal,
+        "read",
+        "data",
+        ctx,
+      )
+    ) return;
+  }
 
   try {
     const libCtx = createLibSwampContext();
@@ -295,6 +342,57 @@ export async function handleDataList(
       return;
     }
 
+    if (resourceName === "*") {
+      const listData = result as {
+        modelName?: string;
+        modelType?: string;
+        groups?: Array<{
+          type: string;
+          items: Array<{ modelName: string; modelType: string }>;
+        }>;
+        total?: number;
+      };
+      if (listData.modelName) {
+        const filtered = filterByAuthorization(
+          [listData],
+          (item) => item.modelName,
+          (item) => ({
+            name: item.modelName,
+            modelType: item.modelType,
+          }),
+          socket,
+          principal,
+          "read",
+          "data",
+          ctx,
+        );
+        if (filtered.length === 0) {
+          sendError(socket, requestId, "not_found", "No data found");
+          return;
+        }
+      } else if (listData.groups) {
+        let total = 0;
+        for (const group of listData.groups) {
+          group.items = filterByAuthorization(
+            group.items,
+            (item) => item.modelName,
+            (item) => ({
+              name: item.modelName,
+              modelType: item.modelType,
+            }),
+            socket,
+            principal,
+            "read",
+            "data",
+            ctx,
+          );
+          total += group.items.length;
+        }
+        listData.groups = listData.groups.filter((g) => g.items.length > 0);
+        listData.total = total;
+      }
+    }
+
     send(socket, {
       type: "data.list",
       id: requestId,
@@ -315,11 +413,14 @@ export async function handleDataSearch(
   payload?: DataSearchPayload,
 ): Promise<void> {
   if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "data",
-      name: "*",
-      fields: {},
-    }, ctx).allowed
+    !authorizeAnyOrReject(
+      socket,
+      requestId,
+      principal,
+      "read",
+      "data",
+      ctx,
+    )
   ) return;
 
   try {
@@ -368,10 +469,28 @@ export async function handleDataSearch(
       return;
     }
 
+    const data = (result ?? { results: [], total: 0 }) as {
+      results?: Array<{ modelName: string; modelType: string }>;
+      total?: number;
+    };
+    if (data.results) {
+      data.results = filterByAuthorization(
+        data.results,
+        (item) => item.modelName,
+        (item) => ({ name: item.modelName, modelType: item.modelType }),
+        socket,
+        principal,
+        "read",
+        "data",
+        ctx,
+      );
+      data.total = data.results.length;
+    }
+
     send(socket, {
       type: "data.search",
       id: requestId,
-      payload: { data: result ?? { items: [], totalCount: 0 } },
+      payload: { data },
     });
   } catch (error) {
     const message = sanitizeErrorForClient(error);

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -105,9 +105,11 @@ import { RunEventBuffer } from "../run_event_buffer.ts";
 import { deleteActiveRun, writeActiveRun } from "../active_run_tracker.ts";
 import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import {
+  authorizeAnyOrReject,
   authorizeOrReject,
   type ConnectionContext,
   exceptionTypeForClient,
+  filterByAuthorization,
   isAdminOnlyModelType,
   lockTimeoutErrorForClient,
   sanitizeErrorForClient,
@@ -614,11 +616,14 @@ export async function handleModelSearch(
   payload?: ModelSearchPayload,
 ): Promise<void> {
   if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "model",
-      name: "*",
-      fields: {},
-    }, ctx).allowed
+    !authorizeAnyOrReject(
+      socket,
+      requestId,
+      principal,
+      "read",
+      "model",
+      ctx,
+    )
   ) return;
 
   try {
@@ -650,10 +655,26 @@ export async function handleModelSearch(
       return;
     }
 
+    const data = (result ?? {}) as {
+      results?: Array<{ name: string; type: string }>;
+    };
+    if (data.results) {
+      data.results = filterByAuthorization(
+        data.results,
+        (item) => item.name,
+        (item) => ({ name: item.name, modelType: item.type }),
+        socket,
+        principal,
+        "read",
+        "model",
+        ctx,
+      );
+    }
+
     send(socket, {
       type: "model.search",
       id: requestId,
-      payload: { data: result ?? {} },
+      payload: { data },
     });
   } catch (error) {
     const message = sanitizeErrorForClient(error);
@@ -1151,11 +1172,14 @@ export async function handleModelOutputSearch(
   payload?: ModelOutputSearchPayload,
 ): Promise<void> {
   if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "model",
-      name: "*",
-      fields: {},
-    }, ctx).allowed
+    !authorizeAnyOrReject(
+      socket,
+      requestId,
+      principal,
+      "read",
+      "model",
+      ctx,
+    )
   ) return;
 
   try {
@@ -1191,10 +1215,26 @@ export async function handleModelOutputSearch(
       return;
     }
 
+    const data = (result ?? {}) as {
+      results?: Array<{ modelName?: string; type: string }>;
+    };
+    if (data.results) {
+      data.results = filterByAuthorization(
+        data.results,
+        (item) => item.modelName,
+        (item) => ({ name: item.modelName, modelType: item.type }),
+        socket,
+        principal,
+        "read",
+        "model",
+        ctx,
+      );
+    }
+
     send(socket, {
       type: "model.output.search",
       id: requestId,
-      payload: { data: result ?? {} },
+      payload: { data },
     });
   } catch (error) {
     const message = sanitizeErrorForClient(error);
@@ -1340,11 +1380,14 @@ export async function handleModelMethodHistorySearch(
   payload?: ModelMethodHistorySearchPayload,
 ): Promise<void> {
   if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "model",
-      name: "*",
-      fields: {},
-    }, ctx).allowed
+    !authorizeAnyOrReject(
+      socket,
+      requestId,
+      principal,
+      "read",
+      "model",
+      ctx,
+    )
   ) return;
 
   try {
@@ -1380,10 +1423,26 @@ export async function handleModelMethodHistorySearch(
       return;
     }
 
+    const data = (result ?? {}) as {
+      results?: Array<{ modelName?: string; type: string }>;
+    };
+    if (data.results) {
+      data.results = filterByAuthorization(
+        data.results,
+        (item) => item.modelName,
+        (item) => ({ name: item.modelName, modelType: item.type }),
+        socket,
+        principal,
+        "read",
+        "model",
+        ctx,
+      );
+    }
+
     send(socket, {
       type: "model.method.history.search",
       id: requestId,
-      payload: { data: result ?? {} },
+      payload: { data },
     });
   } catch (error) {
     const message = sanitizeErrorForClient(error);
@@ -1576,11 +1635,14 @@ export async function handleModelTypeDescribe(
   principal: Principal | null,
 ): Promise<void> {
   if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "model",
-      name: "*",
-      fields: {},
-    }, ctx).allowed
+    !authorizeAnyOrReject(
+      socket,
+      requestId,
+      principal,
+      "read",
+      "model",
+      ctx,
+    )
   ) return;
 
   try {
@@ -1627,11 +1689,14 @@ export async function handleModelTypeSearch(
   payload?: ModelTypeSearchPayload,
 ): Promise<void> {
   if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "model",
-      name: "*",
-      fields: {},
-    }, ctx).allowed
+    !authorizeAnyOrReject(
+      socket,
+      requestId,
+      principal,
+      "read",
+      "model",
+      ctx,
+    )
   ) return;
 
   try {

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -44,8 +44,10 @@ import {
 import type { Action } from "../../domain/access/action.ts";
 import type {
   AccessDecision,
+  AccessPrincipal,
   AccessResource,
 } from "../../domain/access/access_decision_service.ts";
+import type { ResourceKind } from "../../domain/access/resource_selector.ts";
 import type { ScheduledExecutionService } from "../../libswamp/mod.ts";
 import type { MergedServeOptions } from "../serve_config.ts";
 import type { HealthCollector } from "../health_collector.ts";
@@ -488,6 +490,135 @@ function resolveDisplayPrincipal(
     return `user:${ctx.resolvedUserNames[principal.id]}`;
   }
   return principalToString(principal);
+}
+
+export function filterByAuthorization<T>(
+  items: T[],
+  nameExtractor: (item: T) => string | undefined,
+  fieldsExtractor: (item: T) => Record<string, unknown>,
+  socket: WebSocket,
+  principal: Principal | null,
+  action: Action,
+  kind: ResourceKind,
+  ctx: ConnectionContext,
+): T[] {
+  if (ctx.authConfig.mode === "none") return items;
+  if (!ctx.policySnapshotLoader || !principal) return [];
+
+  const collectives = connectionCollectives.get(socket) ?? [];
+  const groups = connectionGroups.get(socket) ?? [];
+  const service = ctx.policySnapshotLoader.decisionService;
+  const accessPrincipal: AccessPrincipal = { principal, collectives, groups };
+
+  const adminDecision = service.decide(
+    accessPrincipal,
+    "admin",
+    { kind: "access", name: "*", fields: {} },
+  );
+  const isAdmin = adminDecision !== null && adminDecision.effect === "allow";
+
+  return items.filter((item) => {
+    const name = nameExtractor(item);
+    if (name === undefined) return false;
+    const resource: AccessResource = {
+      kind,
+      name,
+      fields: fieldsExtractor(item),
+    };
+    const decision = service.decide(accessPrincipal, action, resource);
+    if (decision && decision.effect === "allow") return true;
+    if (decision && decision.effect === "deny") return false;
+    return isAdmin;
+  });
+}
+
+export function authorizeAnyOrReject(
+  socket: WebSocket,
+  requestId: string,
+  principal: Principal | null,
+  action: Action,
+  kind: ResourceKind,
+  ctx: ConnectionContext,
+): boolean {
+  if (ctx.authConfig.mode === "none") return true;
+
+  const resource: AccessResource = { kind, name: "*", fields: {} };
+
+  if (!ctx.policySnapshotLoader) {
+    sendError(
+      socket,
+      requestId,
+      "access_not_configured",
+      "Authorization enforcement is enabled but no policy snapshot is available",
+    );
+    emitDenial(
+      socket,
+      ctx,
+      requestId,
+      principal,
+      action,
+      resource,
+      "access_not_configured",
+      null,
+      [],
+    );
+    return false;
+  }
+
+  if (!principal) {
+    sendError(
+      socket,
+      requestId,
+      "unauthorized",
+      `Access denied: no authenticated principal for '${action}' on ${kind}:*`,
+    );
+    emitDenial(
+      socket,
+      ctx,
+      requestId,
+      null,
+      action,
+      resource,
+      "no_principal",
+      null,
+      [],
+    );
+    return false;
+  }
+
+  const collectives = connectionCollectives.get(socket) ?? [];
+  const groups = connectionGroups.get(socket) ?? [];
+  const service = ctx.policySnapshotLoader.decisionService;
+  const accessPrincipal: AccessPrincipal = { principal, collectives, groups };
+
+  if (service.hasAnyGrantForKind(accessPrincipal, action, kind)) return true;
+
+  const adminDecision = service.decide(
+    accessPrincipal,
+    "admin",
+    { kind: "access", name: "*", fields: {} },
+  );
+  if (adminDecision && adminDecision.effect === "allow") return true;
+
+  const principalStr = resolveDisplayPrincipal(principal, ctx);
+  sendError(
+    socket,
+    requestId,
+    "unauthorized",
+    `Access denied: ${principalStr} does not have '${action}' on ${kind}:*`,
+  );
+  emitDenial(
+    socket,
+    ctx,
+    requestId,
+    principal,
+    action,
+    resource,
+    "unauthorized",
+    null,
+    groups,
+  );
+  return false;
 }
 
 export function send(socket: WebSocket, message: ServerMessage): void {

--- a/src/serve/handlers/shared_test.ts
+++ b/src/serve/handlers/shared_test.ts
@@ -1,0 +1,338 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import type { Grant } from "../../domain/models/access/grant_model.ts";
+import { GrantBasedAccessDecisionService } from "../../domain/access/grant_based_access_decision_service.ts";
+import { PolicySnapshot } from "../../domain/access/policy_snapshot.ts";
+import type { PolicySnapshotLoader } from "../../domain/access/policy_snapshot_loader.ts";
+import type { Principal } from "../../domain/access/principal.ts";
+import {
+  authorizeAnyOrReject,
+  type ConnectionContext,
+  filterByAuthorization,
+  setConnectionCollectives,
+} from "./shared.ts";
+
+function makeGrant(overrides: Partial<Grant> = {}): Grant {
+  return {
+    id: crypto.randomUUID(),
+    subject: { kind: "user", name: "adam" },
+    effect: "allow",
+    actions: ["read"],
+    resource: { kind: "model", pattern: "*" },
+    state: "active",
+    source: "method",
+    createdBy: { kind: "user", id: "admin" },
+    createdAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makePrincipal(id: string): Principal {
+  return { kind: "user", id };
+}
+
+function makeCtx(
+  grants: Grant[],
+  mode: "none" | "token" | "oauth" = "token",
+): ConnectionContext {
+  const snapshot = new PolicySnapshot(grants, []);
+  const service = new GrantBasedAccessDecisionService(snapshot);
+  return {
+    repoDir: "/tmp/test",
+    repoContext: {} as ConnectionContext["repoContext"],
+    datastoreConfig: {
+      type: "filesystem",
+    } as ConnectionContext["datastoreConfig"],
+    datastoreResolver: {} as ConnectionContext["datastoreResolver"],
+    policySnapshotLoader: {
+      decisionService: service,
+    } as unknown as PolicySnapshotLoader,
+    authConfig: {
+      mode,
+      admins: [],
+      allowedCollectives: [],
+      allowedUsers: [],
+      oauthProvider: "",
+      groupsField: "groups",
+      restrictedModelTypes: [],
+      restrictedCommands: [],
+    },
+  };
+}
+
+function makeSocket(): WebSocket {
+  return {
+    readyState: 1,
+    send: () => {},
+    OPEN: 1,
+  } as unknown as WebSocket;
+}
+
+type TestItem = { name: string; type: string };
+
+const testItems: TestItem[] = [
+  { name: "@acme/deploy", type: "@acme" },
+  { name: "@acme/build", type: "@acme" },
+  { name: "@other/run", type: "@other" },
+];
+
+Deno.test("filterByAuthorization: returns all items when auth mode is none", () => {
+  const socket = makeSocket();
+  setConnectionCollectives(socket, [], []);
+  const ctx = makeCtx([], "none");
+  const result = filterByAuthorization(
+    testItems,
+    (item) => item.name,
+    (item) => ({ name: item.name }),
+    socket,
+    makePrincipal("adam"),
+    "read",
+    "model",
+    ctx,
+  );
+  assertEquals(result.length, 3);
+});
+
+Deno.test("filterByAuthorization: returns empty when no principal", () => {
+  const socket = makeSocket();
+  setConnectionCollectives(socket, [], []);
+  const ctx = makeCtx([
+    makeGrant({ resource: { kind: "model", pattern: "*" } }),
+  ]);
+  const result = filterByAuthorization(
+    testItems,
+    (item) => item.name,
+    (item) => ({ name: item.name }),
+    socket,
+    null,
+    "read",
+    "model",
+    ctx,
+  );
+  assertEquals(result.length, 0);
+});
+
+Deno.test("filterByAuthorization: returns all items for admin user", () => {
+  const socket = makeSocket();
+  setConnectionCollectives(socket, [], []);
+  const ctx = makeCtx([
+    makeGrant({
+      actions: ["admin"],
+      resource: { kind: "access", pattern: "*" },
+    }),
+  ]);
+  const result = filterByAuthorization(
+    testItems,
+    (item) => item.name,
+    (item) => ({ name: item.name }),
+    socket,
+    makePrincipal("adam"),
+    "read",
+    "model",
+    ctx,
+  );
+  assertEquals(result.length, 3);
+});
+
+Deno.test("filterByAuthorization: filters by scoped grant", () => {
+  const socket = makeSocket();
+  setConnectionCollectives(socket, [], []);
+  const ctx = makeCtx([
+    makeGrant({ resource: { kind: "model", pattern: "@acme/*" } }),
+  ]);
+  const result = filterByAuthorization(
+    testItems,
+    (item) => item.name,
+    (item) => ({ name: item.name }),
+    socket,
+    makePrincipal("adam"),
+    "read",
+    "model",
+    ctx,
+  );
+  assertEquals(result.length, 2);
+  assertEquals(result[0].name, "@acme/deploy");
+  assertEquals(result[1].name, "@acme/build");
+});
+
+Deno.test("filterByAuthorization: excludes items with undefined name", () => {
+  const socket = makeSocket();
+  setConnectionCollectives(socket, [], []);
+  const ctx = makeCtx([
+    makeGrant({ resource: { kind: "model", pattern: "*" } }),
+  ]);
+  const items = [
+    { modelName: "@acme/deploy" },
+    { modelName: undefined },
+  ];
+  const result = filterByAuthorization(
+    items,
+    (item) => item.modelName,
+    (item) => ({ name: item.modelName }),
+    socket,
+    makePrincipal("adam"),
+    "read",
+    "model",
+    ctx,
+  );
+  assertEquals(result.length, 1);
+});
+
+Deno.test("filterByAuthorization: deny grant excludes matching items", () => {
+  const socket = makeSocket();
+  setConnectionCollectives(socket, [], []);
+  const ctx = makeCtx([
+    makeGrant({ resource: { kind: "model", pattern: "*" } }),
+    makeGrant({
+      effect: "deny",
+      resource: { kind: "model", pattern: "@other/*" },
+    }),
+  ]);
+  const result = filterByAuthorization(
+    testItems,
+    (item) => item.name,
+    (item) => ({ name: item.name }),
+    socket,
+    makePrincipal("adam"),
+    "read",
+    "model",
+    ctx,
+  );
+  assertEquals(result.length, 2);
+  assertEquals(result[0].name, "@acme/deploy");
+  assertEquals(result[1].name, "@acme/build");
+});
+
+Deno.test("filterByAuthorization: admin with deny grant respects deny", () => {
+  const socket = makeSocket();
+  setConnectionCollectives(socket, [], []);
+  const ctx = makeCtx([
+    makeGrant({
+      actions: ["admin"],
+      resource: { kind: "access", pattern: "*" },
+    }),
+    makeGrant({
+      effect: "deny",
+      actions: ["read"],
+      resource: { kind: "model", pattern: "@secret/*" },
+    }),
+  ]);
+  const itemsWithSecret: TestItem[] = [
+    ...testItems,
+    { name: "@secret/keys", type: "@secret" },
+  ];
+  const result = filterByAuthorization(
+    itemsWithSecret,
+    (item) => item.name,
+    (item) => ({ name: item.name }),
+    socket,
+    makePrincipal("adam"),
+    "read",
+    "model",
+    ctx,
+  );
+  assertEquals(result.length, 3);
+  assertEquals(result[0].name, "@acme/deploy");
+  assertEquals(result[1].name, "@acme/build");
+  assertEquals(result[2].name, "@other/run");
+});
+
+Deno.test("authorizeAnyOrReject: returns true when auth mode is none", () => {
+  const socket = makeSocket();
+  setConnectionCollectives(socket, [], []);
+  const ctx = makeCtx([], "none");
+  const result = authorizeAnyOrReject(
+    socket,
+    "req-1",
+    makePrincipal("adam"),
+    "read",
+    "model",
+    ctx,
+  );
+  assertEquals(result, true);
+});
+
+Deno.test("authorizeAnyOrReject: returns false when no principal", () => {
+  const socket = makeSocket();
+  setConnectionCollectives(socket, [], []);
+  const ctx = makeCtx([]);
+  const result = authorizeAnyOrReject(
+    socket,
+    "req-1",
+    null,
+    "read",
+    "model",
+    ctx,
+  );
+  assertEquals(result, false);
+});
+
+Deno.test("authorizeAnyOrReject: returns true when user has scoped grant", () => {
+  const socket = makeSocket();
+  setConnectionCollectives(socket, [], []);
+  const ctx = makeCtx([
+    makeGrant({ resource: { kind: "model", pattern: "@acme/*" } }),
+  ]);
+  const result = authorizeAnyOrReject(
+    socket,
+    "req-1",
+    makePrincipal("adam"),
+    "read",
+    "model",
+    ctx,
+  );
+  assertEquals(result, true);
+});
+
+Deno.test("authorizeAnyOrReject: returns false when no grants exist", () => {
+  const socket = makeSocket();
+  setConnectionCollectives(socket, [], []);
+  const ctx = makeCtx([]);
+  const result = authorizeAnyOrReject(
+    socket,
+    "req-1",
+    makePrincipal("adam"),
+    "read",
+    "model",
+    ctx,
+  );
+  assertEquals(result, false);
+});
+
+Deno.test("authorizeAnyOrReject: returns true for admin fallback", () => {
+  const socket = makeSocket();
+  setConnectionCollectives(socket, [], []);
+  const ctx = makeCtx([
+    makeGrant({
+      actions: ["admin"],
+      resource: { kind: "access", pattern: "*" },
+    }),
+  ]);
+  const result = authorizeAnyOrReject(
+    socket,
+    "req-1",
+    makePrincipal("adam"),
+    "read",
+    "model",
+    ctx,
+  );
+  assertEquals(result, true);
+});

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -119,9 +119,11 @@ import {
   writeActiveRun,
 } from "../active_run_tracker.ts";
 import {
+  authorizeAnyOrReject,
   authorizeOrReject,
   type ConnectionContext,
   exceptionTypeForClient,
+  filterByAuthorization,
   lockTimeoutErrorForClient,
   sanitizeErrorForClient,
   send,
@@ -423,11 +425,14 @@ export async function handleWorkflowSearch(
   payload?: WorkflowSearchPayload,
 ): Promise<void> {
   if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "workflow",
-      name: "*",
-      fields: {},
-    }, ctx).allowed
+    !authorizeAnyOrReject(
+      socket,
+      requestId,
+      principal,
+      "read",
+      "workflow",
+      ctx,
+    )
   ) return;
 
   try {
@@ -455,10 +460,26 @@ export async function handleWorkflowSearch(
       return;
     }
 
+    const data = (result ?? {}) as {
+      results?: Array<{ name: string }>;
+    };
+    if (data.results) {
+      data.results = filterByAuthorization(
+        data.results,
+        (item) => item.name,
+        (item) => ({ name: item.name }),
+        socket,
+        principal,
+        "read",
+        "workflow",
+        ctx,
+      );
+    }
+
     send(socket, {
       type: "workflow.search",
       id: requestId,
-      payload: { data: result ?? {} },
+      payload: { data },
     });
   } catch (error) {
     const message = sanitizeErrorForClient(error);
@@ -474,11 +495,14 @@ export async function handleWorkflowApprovals(
   principal: Principal | null,
 ): Promise<void> {
   if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "workflow",
-      name: "*",
-      fields: {},
-    }, ctx).allowed
+    !authorizeAnyOrReject(
+      socket,
+      requestId,
+      principal,
+      "read",
+      "workflow",
+      ctx,
+    )
   ) return;
 
   try {
@@ -520,10 +544,26 @@ export async function handleWorkflowApprovals(
       return;
     }
 
+    const data = (result ?? {}) as {
+      approvals?: Array<{ workflowName: string }>;
+    };
+    if (data.approvals) {
+      data.approvals = filterByAuthorization(
+        data.approvals,
+        (item) => item.workflowName,
+        (item) => ({ name: item.workflowName }),
+        socket,
+        principal,
+        "read",
+        "workflow",
+        ctx,
+      );
+    }
+
     send(socket, {
       type: "workflow.approvals",
       id: requestId,
-      payload: { data: result ?? {} },
+      payload: { data },
     });
   } catch (error) {
     const message = sanitizeErrorForClient(error);
@@ -739,11 +779,14 @@ export async function handleWorkflowHistorySearch(
   payload?: WorkflowHistorySearchPayload,
 ): Promise<void> {
   if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "workflow",
-      name: "*",
-      fields: {},
-    }, ctx).allowed
+    !authorizeAnyOrReject(
+      socket,
+      requestId,
+      principal,
+      "read",
+      "workflow",
+      ctx,
+    )
   ) return;
 
   try {
@@ -780,10 +823,26 @@ export async function handleWorkflowHistorySearch(
       return;
     }
 
+    const data = (result ?? {}) as {
+      results?: Array<{ workflowName: string }>;
+    };
+    if (data.results) {
+      data.results = filterByAuthorization(
+        data.results,
+        (item) => item.workflowName,
+        (item) => ({ name: item.workflowName }),
+        socket,
+        principal,
+        "read",
+        "workflow",
+        ctx,
+      );
+    }
+
     send(socket, {
       type: "workflow.history.search",
       id: requestId,
-      payload: { data: result ?? {} },
+      payload: { data },
     });
   } catch (error) {
     const message = sanitizeErrorForClient(error);
@@ -805,11 +864,14 @@ export async function handleWorkflowRunSearch(
   payload?: WorkflowRunSearchPayload,
 ): Promise<void> {
   if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "workflow",
-      name: "*",
-      fields: {},
-    }, ctx).allowed
+    !authorizeAnyOrReject(
+      socket,
+      requestId,
+      principal,
+      "read",
+      "workflow",
+      ctx,
+    )
   ) return;
 
   try {
@@ -848,10 +910,26 @@ export async function handleWorkflowRunSearch(
       return;
     }
 
+    const data = (result ?? {}) as {
+      results?: Array<{ workflowName: string }>;
+    };
+    if (data.results) {
+      data.results = filterByAuthorization(
+        data.results,
+        (item) => item.workflowName,
+        (item) => ({ name: item.workflowName }),
+        socket,
+        principal,
+        "read",
+        "workflow",
+        ctx,
+      );
+    }
+
     send(socket, {
       type: "workflow.run.search",
       id: requestId,
-      payload: { data: result ?? {} },
+      payload: { data },
     });
   } catch (error) {
     const message = sanitizeErrorForClient(error);
@@ -868,11 +946,14 @@ export async function handleWorkflowSchema(
   principal: Principal | null,
 ): Promise<void> {
   if (
-    !authorizeOrReject(socket, requestId, principal, "read", {
-      kind: "workflow",
-      name: "*",
-      fields: {},
-    }, ctx).allowed
+    !authorizeAnyOrReject(
+      socket,
+      requestId,
+      principal,
+      "read",
+      "workflow",
+      ctx,
+    )
   ) return;
 
   try {


### PR DESCRIPTION
## Summary

- Search/list handlers checked authorization against a hardcoded wildcard
  resource (`name: "*"`), requiring callers to hold a global grant like
  `model:*`. Users with scoped grants (e.g. `model:@xero/segment/*`) were
  denied entirely.
- Replace the upfront wildcard gate with post-query filtering: each result
  item is authorized individually against the caller's grants, and only
  accessible items are returned.
- Metadata-only endpoints (type search, workflow schema) use a
  `hasAnyGrantForKind` check — any read grant for the resource kind is
  sufficient.
- Admin users with explicit deny grants are correctly denied on matching
  items (deny wins over admin fallback, matching `authorizeOrReject`
  semantics).
- Projected `data.query` (with `select`) and `summarise` keep the original
  wildcard gate since their results can't be meaningfully filtered per-item.

## Changes

- **`AccessDecisionService`**: Added `hasAnyGrantForKind(principal, action, kind)` — returns true if the principal has at least one allow grant for the kind+action
- **`shared.ts`**: Added `filterByAuthorization()` (per-item filtering with admin fallback respecting deny grants) and `authorizeAnyOrReject()` (coarse gate with audit emission)
- **13 handlers updated** across `model_handlers.ts`, `workflow_handlers.ts`, `data_handlers.ts`
- **Design doc**: New "Collection operations and grant-scoped filtering" section in `access-control.md`
- **Tests**: 7 unit tests for `hasAnyGrantForKind`, 12 unit tests for the shared helpers

## Test plan

- [x] `deno check` — all modified files type-check clean
- [x] `deno lint` — no lint errors
- [x] `deno run test` — 283 tests pass (18 new)
- [x] Verification workflow: build 9/9, code review pass, adversarial review pass, UX review pass
- [ ] UAT: swamp-club/swamp-uat#367 filed for end-to-end scoped-grant search testing

Closes swamp-club#2042

🤖 Generated with [Claude Code](https://claude.com/claude-code)