### PR TITLE
fix(datastore): wire markDirty into definition and workflow repos so deletions propagate to S3 (swamp-club#2045)

### DIFF
--- a/design/enablers/datastores.md
+++ b/design/enablers/datastores.md
@@ -970,6 +970,10 @@ markDirty-then-slow-walk is always recoverable; a lost dirty-flip is not.
 | `collectGarbage` (non-dry-run)             | one signal per removed version directory, or the data-name directory when the whole name goes |
 | `pruneExcessVersions` (write-time cap)     | one signal per removed version directory                         |
 | Yaml repos: `save`, `delete`, `deleteOlderThan` | per-yaml file path                                          |
+| Definition repo: `save`, `delete`          | target file path                                                 |
+| Workflow repo: `save`, `delete`            | target file path                                                 |
+| Evaluated workflow repo: `save`, `delete`  | target file path                                                 |
+| Evaluated workflow repo: `clear`           | `undefined` (bulk)                                               |
 | `deleteAllByWorkflowId`, `clearAll`        | `undefined` (bulk)                                               |
 
 `advanceLatestMarkers` and `rollbackVersions` emit nothing — they rely on the

--- a/src/cli/commands/model_delete.ts
+++ b/src/cli/commands/model_delete.ts
@@ -138,7 +138,12 @@ export const modelDeleteCommand = withRemoteOptions(
 
     try {
       const ctx = createLibSwampContext({ logger: cliCtx.logger });
-      const deps = createModelDeleteDeps(repoDir, datastoreResolver);
+      const deps = createModelDeleteDeps(
+        repoDir,
+        datastoreResolver,
+        undefined,
+        repoContext.markDirty,
+      );
       const force = !!options.force;
 
       // Phase 1: Preview — gather what will be affected (under lock)

--- a/src/cli/commands/workflow_delete.ts
+++ b/src/cli/commands/workflow_delete.ts
@@ -92,13 +92,18 @@ export const workflowDeleteCommand = withRemoteOptions(
       return;
     }
 
-    const { repoDir, datastoreResolver } = await requireInitializedRepo({
-      repoDir: resolveRepoDir(options.repoDir),
-      outputMode: cliCtx.outputMode,
-    });
+    const { repoDir, repoContext, datastoreResolver } =
+      await requireInitializedRepo({
+        repoDir: resolveRepoDir(options.repoDir),
+        outputMode: cliCtx.outputMode,
+      });
 
     const ctx = createLibSwampContext({ logger: cliCtx.logger });
-    const deps = createWorkflowDeleteDeps(repoDir, datastoreResolver);
+    const deps = createWorkflowDeleteDeps(
+      repoDir,
+      datastoreResolver,
+      repoContext.markDirty,
+    );
 
     // Phase 1: Preview
     let preview;

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -432,11 +432,13 @@ export function createRepositoryContext(
     enableIndexing ? eventBus : undefined,
     definitionsDir,
     autoDefDir,
+    markDirty,
   );
   const yamlWorkflowRepo = new YamlWorkflowRepository(
     repoDir,
     enableIndexing ? eventBus : undefined,
     yamlWorkflowsDir,
+    markDirty,
   );
 
   // Create composite workflow repo if extension workflows dir is provided

--- a/src/infrastructure/persistence/yaml_definition_repository.ts
+++ b/src/infrastructure/persistence/yaml_definition_repository.ts
@@ -38,6 +38,7 @@ import {
   swampPath,
 } from "./paths.ts";
 import type { DefinitionRepository } from "../../domain/definitions/repositories.ts";
+import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import { ModelType } from "../../domain/models/model_type.ts";
 import {
   createDefinitionId,
@@ -82,12 +83,17 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     baseDir?: string,
     /** Pass `false` to disable secondary search. Omit to auto-compute from repoDir. */
     secondaryBaseDir?: string | false,
+    private readonly markDirtyHook?: MarkDirtyHook,
   ) {
     this.baseDir = baseDir ?? resolveEffectiveDefinitionsDir(repoDir);
     this.secondaryBaseDir = secondaryBaseDir === false
       ? undefined
       : (secondaryBaseDir ??
         swampPath(repoDir, SWAMP_SUBDIRS.autoDefinitions));
+  }
+
+  private async notifyDirty(relPath?: string): Promise<void> {
+    if (this.markDirtyHook) await this.markDirtyHook(relPath);
   }
 
   async findById(
@@ -458,6 +464,7 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     await ensureDir(dir);
 
     const targetPath = this.resolveWritePath(type, definition);
+    await this.notifyDirty(targetPath);
     const previousPath = this.idToActualPath.get(definition.id);
 
     // Check if this is a new definition or an update
@@ -636,6 +643,9 @@ export class YamlDefinitionRepository implements DefinitionRepository {
     if (definitionName && isFilenameSafeDefinitionName(definitionName)) {
       pathsToTry.add(this.getNamePath(type, definitionName));
     }
+
+    const resolvedPath = cachedPath ?? this.getLegacyPath(type, id);
+    await this.notifyDirty(resolvedPath);
 
     let deleted = false;
     for (const path of pathsToTry) {

--- a/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_evaluated_workflow_repository.ts
@@ -29,6 +29,7 @@ import {
   Workflow,
   type WorkflowData,
 } from "../../domain/workflows/workflow.ts";
+import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 
 /**
  * Repository for storing evaluated workflows.
@@ -41,9 +42,17 @@ export class YamlEvaluatedWorkflowRepository {
   private readonly baseDir: string;
   private readonly idToActualPath = new Map<WorkflowId, string>();
 
-  constructor(private readonly repoDir: string, baseDir?: string) {
+  constructor(
+    private readonly repoDir: string,
+    baseDir?: string,
+    private readonly markDirtyHook?: MarkDirtyHook,
+  ) {
     this.baseDir = baseDir ??
       swampPath(repoDir, SWAMP_SUBDIRS.workflowsEvaluated);
+  }
+
+  private async notifyDirty(relPath?: string): Promise<void> {
+    if (this.markDirtyHook) await this.markDirtyHook(relPath);
   }
 
   async findById(id: WorkflowId): Promise<Workflow | null> {
@@ -151,6 +160,7 @@ export class YamlEvaluatedWorkflowRepository {
     await ensureDir(dir);
 
     const targetPath = this.resolveWritePath(workflow);
+    await this.notifyDirty(targetPath);
     const data = workflow.toData();
     // Remove undefined values since YAML can't stringify them
     const cleanData = JSON.parse(JSON.stringify(data));
@@ -195,6 +205,9 @@ export class YamlEvaluatedWorkflowRepository {
       pathsToTry.add(this.getNamePath(workflow.name));
     }
 
+    const resolvedPath = cachedPath ?? this.getLegacyPath(id);
+    await this.notifyDirty(resolvedPath);
+
     for (const path of pathsToTry) {
       try {
         await Deno.remove(path);
@@ -212,6 +225,7 @@ export class YamlEvaluatedWorkflowRepository {
    * Clears all evaluated workflows.
    */
   async clear(): Promise<void> {
+    await this.notifyDirty();
     const dir = this.getWorkflowsDir();
     try {
       await Deno.remove(dir, { recursive: true });

--- a/src/infrastructure/persistence/yaml_workflow_repository.ts
+++ b/src/infrastructure/persistence/yaml_workflow_repository.ts
@@ -37,6 +37,7 @@ import {
 } from "../../domain/workflows/workflow.ts";
 import { UserError } from "../../domain/errors.ts";
 import type { EventBus } from "../../domain/events/event_bus.ts";
+import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import {
   createWorkflowCreated,
   createWorkflowDeleted,
@@ -62,8 +63,13 @@ export class YamlWorkflowRepository implements WorkflowRepository {
     private readonly repoDir: string,
     private readonly eventBus?: EventBus,
     baseDir?: string,
+    private readonly markDirtyHook?: MarkDirtyHook,
   ) {
     this.baseDir = baseDir ?? resolveEffectiveWorkflowsDir(repoDir);
+  }
+
+  private async notifyDirty(relPath?: string): Promise<void> {
+    if (this.markDirtyHook) await this.markDirtyHook(relPath);
   }
 
   async findById(id: WorkflowId): Promise<Workflow | null> {
@@ -189,6 +195,7 @@ export class YamlWorkflowRepository implements WorkflowRepository {
     await ensureDir(dir);
 
     const targetPath = this.resolveWritePath(workflow);
+    await this.notifyDirty(targetPath);
     const previousPath = this.idToActualPath.get(workflow.id);
 
     // Check if this is a new workflow or an update
@@ -278,6 +285,9 @@ export class YamlWorkflowRepository implements WorkflowRepository {
     ]);
     const cachedPath = this.idToActualPath.get(id);
     if (cachedPath) pathsToTry.add(cachedPath);
+
+    const resolvedPath = cachedPath ?? this.getLegacyPath(id);
+    await this.notifyDirty(resolvedPath);
 
     let deleted = false;
     for (const path of pathsToTry) {

--- a/src/libswamp/models/delete.ts
+++ b/src/libswamp/models/delete.ts
@@ -24,6 +24,7 @@ import type { ModelType } from "../../domain/models/model_type.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
+import { YamlEvaluatedDefinitionRepository } from "../../infrastructure/persistence/yaml_evaluated_definition_repository.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { FileSystemUnifiedDataRepository } from "../../infrastructure/persistence/unified_data_repository.ts";
 import { YamlOutputRepository } from "../../infrastructure/persistence/yaml_output_repository.ts";
@@ -104,6 +105,10 @@ export interface ModelDeleteDeps {
     name: string,
   ) => Promise<void>;
   deleteDefinition: (type: ModelType, id: DefinitionId) => Promise<void>;
+  deleteEvaluatedDefinition: (
+    type: ModelType,
+    id: DefinitionId,
+  ) => Promise<void>;
   isExpired?: (data: Data) => Promise<boolean>;
 }
 
@@ -116,7 +121,18 @@ export function createModelDeleteDeps(
 ): ModelDeleteDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const definitionRepo = new YamlDefinitionRepository(
+    repoDir,
+    undefined,
+    undefined,
+    undefined,
+    markDirty,
+  );
+  const evaluatedDefinitionRepo = new YamlEvaluatedDefinitionRepository(
+    repoDir,
+    dsPath(SWAMP_SUBDIRS.definitionsEvaluated),
+    markDirty,
+  );
   const workflowRepo = new YamlWorkflowRepository(repoDir);
   // Reuse an injected shared data repo (e.g. serve's process-scoped
   // RepositoryContext) so we don't open a new file-based catalog store — and
@@ -155,6 +171,8 @@ export function createModelDeleteDeps(
     deleteData: (type, defId, name) =>
       unifiedDataRepo.delete(type, defId, name),
     deleteDefinition: (type, id) => definitionRepo.delete(type, id),
+    deleteEvaluatedDefinition: (type, id) =>
+      evaluatedDefinitionRepo.delete(type, id),
     isExpired: (data) => lifecycleService.isExpired(data),
   };
 }
@@ -342,6 +360,20 @@ export async function* modelDelete(
         dataDeleted = true;
       }
 
+      // Delete evaluated definition
+      let evaluatedInputDeleted = false;
+      try {
+        ctx.logger.debug`Deleting evaluated definition: ${definition.id}`;
+        await deps.deleteEvaluatedDefinition(modelType, definition.id);
+        evaluatedInputDeleted = true;
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          ctx.logger.warn`Failed to delete evaluated definition: ${
+            error instanceof Error ? error.message : String(error)
+          }`;
+        }
+      }
+
       // Delete definition
       ctx.logger.debug`Deleting definition: ${definition.id}`;
       await deps.deleteDefinition(modelType, definition.id);
@@ -355,7 +387,7 @@ export async function* modelDelete(
           inputPath: definitionPath,
           resourceDeleted: false,
           outputsDeleted,
-          evaluatedInputDeleted: false,
+          evaluatedInputDeleted,
           dataDeleted,
           expiredDataAutoCollected,
         },

--- a/src/libswamp/models/delete.ts
+++ b/src/libswamp/models/delete.ts
@@ -149,11 +149,13 @@ export function createModelDeleteDeps(
   const outputRepo = new YamlOutputRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.outputs),
+    markDirty,
   );
   const workflowRunRepo = new YamlWorkflowRunRepository(
     repoDir,
     undefined,
     dsPath(SWAMP_SUBDIRS.workflowRuns),
+    markDirty,
   );
   const lifecycleService = new DefaultDataLifecycleService(
     unifiedDataRepo,
@@ -361,18 +363,9 @@ export async function* modelDelete(
       }
 
       // Delete evaluated definition
-      let evaluatedInputDeleted = false;
-      try {
-        ctx.logger.debug`Deleting evaluated definition: ${definition.id}`;
-        await deps.deleteEvaluatedDefinition(modelType, definition.id);
-        evaluatedInputDeleted = true;
-      } catch (error) {
-        if (!(error instanceof Deno.errors.NotFound)) {
-          ctx.logger.warn`Failed to delete evaluated definition: ${
-            error instanceof Error ? error.message : String(error)
-          }`;
-        }
-      }
+      ctx.logger.debug`Deleting evaluated definition: ${definition.id}`;
+      await deps.deleteEvaluatedDefinition(modelType, definition.id);
+      const evaluatedInputDeleted = true;
 
       // Delete definition
       ctx.logger.debug`Deleting definition: ${definition.id}`;

--- a/src/libswamp/models/delete_test.ts
+++ b/src/libswamp/models/delete_test.ts
@@ -110,6 +110,7 @@ function makeDeps(overrides: Partial<ModelDeleteDeps> = {}): ModelDeleteDeps {
     deleteOutput: () => Promise.resolve(),
     deleteData: () => Promise.resolve(),
     deleteDefinition: () => Promise.resolve(),
+    deleteEvaluatedDefinition: () => Promise.resolve(),
     ...overrides,
   };
 }

--- a/src/libswamp/workflows/delete.ts
+++ b/src/libswamp/workflows/delete.ts
@@ -27,6 +27,7 @@ import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
 import { SWAMP_SUBDIRS } from "../../infrastructure/persistence/paths.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
+import type { MarkDirtyHook } from "../../domain/datastore/datastore_sync_service.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
@@ -81,10 +82,16 @@ export interface WorkflowDeleteDeps {
 export function createWorkflowDeleteDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  markDirty?: MarkDirtyHook,
 ): WorkflowDeleteDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const workflowRepo = new YamlWorkflowRepository(repoDir);
+  const workflowRepo = new YamlWorkflowRepository(
+    repoDir,
+    undefined,
+    undefined,
+    markDirty,
+  );
   const workflowRunRepo = new YamlWorkflowRunRepository(
     repoDir,
     undefined,
@@ -93,6 +100,7 @@ export function createWorkflowDeleteDeps(
   const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.workflowsEvaluated),
+    markDirty,
   );
   return {
     findById: (id) => workflowRepo.findById(id),

--- a/src/libswamp/workflows/delete.ts
+++ b/src/libswamp/workflows/delete.ts
@@ -96,6 +96,7 @@ export function createWorkflowDeleteDeps(
     repoDir,
     undefined,
     dsPath(SWAMP_SUBDIRS.workflowRuns),
+    markDirty,
   );
   const evaluatedWorkflowRepo = new YamlEvaluatedWorkflowRepository(
     repoDir,

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -890,6 +890,7 @@ export async function handleModelDelete(
       ctx.repoDir,
       ctx.datastoreResolver,
       ctx.repoContext.unifiedDataRepo,
+      ctx.repoContext.markDirty,
     );
 
     const preview = await modelDeletePreview(

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -1508,7 +1508,11 @@ export async function handleWorkflowDelete(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createWorkflowDeleteDeps(ctx.repoDir, ctx.datastoreResolver);
+    const deps = createWorkflowDeleteDeps(
+      ctx.repoDir,
+      ctx.datastoreResolver,
+      ctx.repoContext.markDirty,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(


### PR DESCRIPTION
## Summary

- Wire `MarkDirtyHook` into `YamlDefinitionRepository`, `YamlWorkflowRepository`, and `YamlEvaluatedWorkflowRepository` so `save()` and `delete()` operations signal the datastore sync layer
- Add evaluated definition cleanup to the model delete cascade (`evaluatedInputDeleted` was hardcoded to `false`)
- Wire `markDirty` through `repository_factory.ts`, both delete dep factories, CLI commands, and serve handlers
- Pass `markDirty` to `YamlOutputRepository` and `YamlWorkflowRunRepository` in delete dep factories (caught by adversarial review)
- Update `design/enablers/datastores.md` per-call granularity table

Fixes swamp-club#2045 — corrupt managedConfig entries cannot be removed via CLI because deleted definition files rehydrate from S3 on every sync.

**Root cause:** `YamlDefinitionRepository.delete()` never called `markDirty`, so `pushChanged()` didn't know to delete the S3 object. The next `pullChanged()` re-downloaded it. Same gap existed in `YamlWorkflowRepository` and `YamlEvaluatedWorkflowRepository`.

**Verified:** Reproduced with minio S3 backend + `managedConfig: true`. After fix, `model delete --force` reports `Committed 1 file(s) to datastore index` (was `no index changes`) and the S3 object is removed.

Co-authored-by: Blake Irvin <bixu@users.noreply.github.com>

## Test plan

- [x] `deno check` passes on all changed files
- [x] `deno run test` passes (72 tests across 3 test files)
- [x] Minio reproduction: model delete propagates to S3, no rehydration on sync
- [x] Verification workflow: build 9/9, reviews 3/3 pass
- [x] Attestation posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)