### PR TITLE
fix(extensions): resolve managed config paths for custom datastores (swamp-club#2048)

### DIFF
--- a/design/enablers/datastores.md
+++ b/design/enablers/datastores.md
@@ -1384,8 +1384,11 @@ process left a lock that hasn't expired yet.
   extension lockfile and pulled extensions into the datastore `config/` tier
   and set `managedConfig: true`; once the sentinel exists,
   `resolveManagedConfigPaths` (`src/cli/repo_context.ts`) points the
-  pulled-extensions root and lockfile at `.swamp/config/`
-  (`datastore_config_migrate.ts`).
+  pulled-extensions root and lockfile at the datastore-resolved config path.
+  For custom datastores (S3, GCS), `ensureManagedConfigBase` resolves the
+  datastore config to derive the cache-relative config path — extension
+  commands call it before `resolveManagedConfigPaths` so the module-level
+  registry is populated correctly (`datastore_config_migrate.ts`).
 - `swamp doctor datastores [--repair [-y]]` — health check plus optional
   repair of catalog completeness, root-level unmigrated data and foreign
   namespace contamination, the last via the optional

--- a/src/cli/commands/doctor_extensions.ts
+++ b/src/cli/commands/doctor_extensions.ts
@@ -82,7 +82,10 @@ import {
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { DoctorExtensionsResponse } from "../../serve/protocol.ts";
-import { resolveManagedConfigPaths } from "../repo_context.ts";
+import {
+  ensureManagedConfigBase,
+  resolveManagedConfigPaths,
+} from "../repo_context.ts";
 import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
@@ -193,6 +196,7 @@ export const doctorExtensionsCommand = withRemoteOptions(
   const repoPath = RepoPath.create(repoDir);
   const markerRepo = new RepoMarkerRepository();
   const marker = await markerRepo.read(repoPath);
+  await ensureManagedConfigBase(repoDir, marker);
   const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
 
   // A single shared catalog connection for all doctor phases

--- a/src/cli/commands/doctor_workflows.ts
+++ b/src/cli/commands/doctor_workflows.ts
@@ -33,7 +33,10 @@ import {
 } from "../context.ts";
 import { resolveDatastoreForRepo } from "../repo_context.ts";
 import { resolveWorkflowsDir } from "../resolve_workflows_dir.ts";
-import { resolveManagedConfigPaths } from "../repo_context.ts";
+import {
+  ensureManagedConfigBase,
+  resolveManagedConfigPaths,
+} from "../repo_context.ts";
 import {
   collectDirsForKind,
   expandSourcePaths,
@@ -125,6 +128,7 @@ export const doctorWorkflowsCommand = withRemoteOptions(
 
   const sourceWorkflowDirs = await getSourceWorkflowDirs(repoDir);
 
+  await ensureManagedConfigBase(repoDir, marker);
   const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
   const pulledWorkflowDirs = await enumeratePulledExtensionDirs(
     lockfilePath,

--- a/src/cli/commands/extension_list.ts
+++ b/src/cli/commands/extension_list.ts
@@ -34,7 +34,10 @@ import {
   result,
   warnLegacyExtensionLayout,
 } from "../../libswamp/mod.ts";
-import { resolveManagedConfigPaths } from "../repo_context.ts";
+import {
+  ensureManagedConfigBase,
+  resolveManagedConfigPaths,
+} from "../repo_context.ts";
 import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
@@ -150,6 +153,7 @@ export const extensionListCommand = withRemoteOptions(
   const repoPath = RepoPath.create(repoDir);
   const markerRepo = new RepoMarkerRepository();
   const marker = await markerRepo.read(repoPath);
+  await ensureManagedConfigBase(repoDir, marker);
   const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
   const tool = resolvePrimaryTool(marker);
   const skillsDirRelative = relative(

--- a/src/cli/commands/extension_outdated.ts
+++ b/src/cli/commands/extension_outdated.ts
@@ -23,8 +23,11 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepoReadOnly } from "../repo_context.ts";
-import { resolveManagedConfigPaths } from "../repo_context.ts";
+import {
+  ensureManagedConfigBase,
+  requireInitializedRepoReadOnly,
+  resolveManagedConfigPaths,
+} from "../repo_context.ts";
 import {
   RepoMarkerRepository,
 } from "../../infrastructure/persistence/repo_marker_repository.ts";
@@ -153,6 +156,7 @@ export const extensionOutdatedCommand = withRemoteOptions(
   const repoPath = RepoPath.create(repoDir);
   const markerRepo = new RepoMarkerRepository();
   const marker = await markerRepo.read(repoPath);
+  await ensureManagedConfigBase(repoDir, marker);
   const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
 
   const ctx = createLibSwampContext({ logger: cliCtx.logger });

--- a/src/cli/commands/extension_pull.ts
+++ b/src/cli/commands/extension_pull.ts
@@ -31,8 +31,11 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireRepoMarker } from "../repo_context.ts";
-import { resolveManagedConfigPaths } from "../repo_context.ts";
+import {
+  ensureManagedConfigBase,
+  requireRepoMarker,
+  resolveManagedConfigPaths,
+} from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { resolveUniqueLocalSkillsDirs } from "../../domain/repo/skill_dirs.ts";
 import { loadIdentity } from "../load_identity.ts";
@@ -273,7 +276,11 @@ export const extensionPullCommand = withRemoteOptions(
 
   // 3. Validate name format
   validateExtensionName(ref.name);
-  const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
+  await ensureManagedConfigBase(repoDir, marker);
+  const { lockfilePath, pulledExtensionsRoot } = resolveManagedConfigPaths(
+    repoDir,
+    marker,
+  );
 
   const tools = marker?.tools?.length ? marker.tools : ["claude"];
   const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
@@ -300,7 +307,7 @@ export const extensionPullCommand = withRemoteOptions(
       lockfilePath,
       skillsDirs,
       repoDir,
-      { identity },
+      { identity, pulledExtensionsRoot },
     );
     const repository = new ExtensionRepository({
       catalog,

--- a/src/cli/commands/extension_report_dispatcher.ts
+++ b/src/cli/commands/extension_report_dispatcher.ts
@@ -41,7 +41,10 @@ import {
 import { resolvePulledExtensionsRoot } from "../../infrastructure/persistence/paths.ts";
 import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
 import { RepoPath } from "../../domain/repo/repo_path.ts";
-import { resolveManagedConfigPaths } from "../repo_context.ts";
+import {
+  ensureManagedConfigBase,
+  resolveManagedConfigPaths,
+} from "../repo_context.ts";
 import { readSwampSources } from "../../infrastructure/persistence/swamp_sources_repository.ts";
 import {
   checkGithubPvrEnabled,
@@ -169,6 +172,7 @@ export async function resolveExtensionTarget(
     };
   }
 
+  await ensureManagedConfigBase(repoDir, marker);
   const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
   const extensionVersion =
     (await readInstalledExtensionVersion(lockfilePath, extensionName)) ??

--- a/src/cli/commands/extension_rm.ts
+++ b/src/cli/commands/extension_rm.ts
@@ -24,8 +24,11 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireRepoMarker } from "../repo_context.ts";
-import { resolveManagedConfigPaths } from "../repo_context.ts";
+import {
+  ensureManagedConfigBase,
+  requireRepoMarker,
+  resolveManagedConfigPaths,
+} from "../repo_context.ts";
 import { resolvePrimaryTool } from "../../domain/repo/primary_tool.ts";
 import { resolveSkillsDir } from "../../domain/repo/skill_dirs.ts";
 import {
@@ -110,6 +113,7 @@ export const extensionRemoveCommand = withRemoteOptions(
     resolveRepoDir(options.repoDir),
   );
 
+  await ensureManagedConfigBase(repoDir, marker);
   const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
 
   const tool = resolvePrimaryTool(marker);

--- a/src/cli/commands/extension_search.ts
+++ b/src/cli/commands/extension_search.ts
@@ -24,8 +24,11 @@ import {
   type GlobalOptions,
   interactiveOutputMode,
 } from "../context.ts";
-import { requireRepoMarker } from "../repo_context.ts";
-import { resolveManagedConfigPaths } from "../repo_context.ts";
+import {
+  ensureManagedConfigBase,
+  requireRepoMarker,
+  resolveManagedConfigPaths,
+} from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { ReleaseChannel } from "../../domain/extensions/release_channel.ts";
 import {
@@ -257,6 +260,7 @@ export const extensionSearchCommand = withRemoteOptions(
     // Extension install writes to local files only (pulled-extensions/,
     // lockfile) — no datastore needed; see #445.
     const { repoDir, marker } = await requireRepoMarker(".");
+    await ensureManagedConfigBase(repoDir, marker);
     const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
 
     const tools = marker?.tools?.length ? marker.tools : ["claude"];

--- a/src/cli/commands/extension_update.ts
+++ b/src/cli/commands/extension_update.ts
@@ -24,8 +24,11 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireRepoMarker } from "../repo_context.ts";
-import { resolveManagedConfigPaths } from "../repo_context.ts";
+import {
+  ensureManagedConfigBase,
+  requireRepoMarker,
+  resolveManagedConfigPaths,
+} from "../repo_context.ts";
 import { createInstallContext, parseExtensionRef } from "./extension_pull.ts";
 import {
   consumeStream,
@@ -121,6 +124,7 @@ export const extensionUpdateCommand = withRemoteOptions(
   const { repoDir, marker } = await requireRepoMarker(
     resolveRepoDir(options.repoDir),
   );
+  await ensureManagedConfigBase(repoDir, marker);
   const { lockfilePath } = resolveManagedConfigPaths(repoDir, marker);
 
   // Per-extension models/workflows/vaults/datastores/reports

--- a/src/cli/create_extension_install_deps.ts
+++ b/src/cli/create_extension_install_deps.ts
@@ -29,7 +29,10 @@ import {
   LockfileRepository,
   resolveServerUrl,
 } from "../libswamp/mod.ts";
-import { resolveManagedConfigPaths } from "./repo_context.ts";
+import {
+  ensureManagedConfigBase,
+  resolveManagedConfigPaths,
+} from "./repo_context.ts";
 
 /**
  * Wires `ExtensionInstallDeps` from a repo directory and a logger.
@@ -52,6 +55,7 @@ export async function createExtensionInstallDeps(
   const repoPath = RepoPath.create(absoluteRepoDir);
   const markerRepo = new RepoMarkerRepository();
   const marker = await markerRepo.read(repoPath);
+  await ensureManagedConfigBase(absoluteRepoDir, marker);
   const { lockfilePath } = resolveManagedConfigPaths(absoluteRepoDir, marker);
   const tools = marker?.tools?.length ? marker.tools : ["claude"];
   const absoluteSkillsDirs = resolveUniqueLocalSkillsDirs(

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -194,7 +194,10 @@ import "../domain/models/models.ts";
 // separate files to avoid circular imports through mod.ts.
 import { resolveModelsDir } from "./resolve_models_dir.ts";
 export { resolveModelsDir };
-import { resolveManagedConfigPaths } from "./repo_context.ts";
+import {
+  ensureManagedConfigBase,
+  resolveManagedConfigPaths,
+} from "./repo_context.ts";
 import { resolveWorkflowsDir } from "./resolve_workflows_dir.ts";
 export { resolveWorkflowsDir };
 import { resolveVaultsDir } from "./resolve_vaults_dir.ts";
@@ -1379,6 +1382,7 @@ export async function runCli(args: string[]): Promise<void> {
     const loaderSpan = getTracer().startSpan(
       "swamp.cli.configure_extension_loaders",
     );
+    await ensureManagedConfigBase(repoDir, marker);
     const { lockfilePath: managedLockfilePath } = resolveManagedConfigPaths(
       repoDir,
       marker,
@@ -1481,6 +1485,9 @@ export async function runCli(args: string[]): Promise<void> {
   if (!hookMode) {
     const autoResolverIdentity = await loadIdentity();
     setAuthenticated(Boolean(autoResolverIdentity.bearerToken));
+    if (!commandNeedsLoaderSetup(args) || marker === null) {
+      await ensureManagedConfigBase(repoDir, marker);
+    }
     const { lockfilePath: autoResolverLockfilePath } =
       resolveManagedConfigPaths(repoDir, marker);
     configureExtensionAutoResolver(

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -62,6 +62,7 @@ import {
 import { summarizeSyncError } from "../infrastructure/persistence/sync_error_diagnostic.ts";
 import { FileLock } from "../infrastructure/persistence/file_lock.ts";
 import {
+  getManagedConfigBase,
   registerManagedConfig,
   swampPath,
 } from "../infrastructure/persistence/paths.ts";
@@ -238,10 +239,68 @@ export interface RequireRepoOptions {
 }
 
 /**
+ * Pre-populates the module-level managed config registry by resolving the
+ * datastore config. Call this before {@link resolveManagedConfigPaths} in
+ * commands that use {@link requireRepoMarker} (lightweight, no datastore
+ * resolution) so the registry-based fallback in resolveManagedConfigPaths
+ * returns the correct cache-relative paths for custom datastores (S3, GCS).
+ *
+ * Commands that go through {@link requireInitializedRepo} /
+ * {@link requireInitializedRepoReadOnly} / {@link requireInitializedRepoUnlocked}
+ * already pass `configBasePath` to resolveManagedConfigPaths and do NOT need
+ * this call.
+ *
+ * @param resolverOverride Test seam — inject a mock resolver to avoid loading
+ *   real datastore extensions in tests.
+ */
+export async function ensureManagedConfigBase(
+  repoDir: string,
+  marker: RepoMarkerData | null,
+  resolverOverride?: DatastorePathResolver,
+): Promise<void> {
+  if (marker?.datastore?.managedConfig !== true) return;
+
+  try {
+    if (resolverOverride) {
+      const configBase = resolverOverride.resolvePath("config");
+      registerManagedConfig(repoDir, true, configBase);
+      return;
+    }
+    const datastoreConfig = await resolveDatastoreConfig(
+      marker,
+      undefined,
+      repoDir,
+    );
+    const resolver = new DefaultDatastorePathResolver(
+      repoDir,
+      datastoreConfig,
+    );
+    const configBase = resolver.resolvePath("config");
+    registerManagedConfig(repoDir, true, configBase);
+  } catch (error) {
+    const logger = getSwampLogger(["cli", "managed-config"]);
+    logger.debug`Failed to resolve datastore for managedConfig base: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+    // Datastore extension not loadable — fall back to sentinel-based
+    // detection in resolveManagedConfigPaths. This can happen when
+    // pulling the datastore extension itself, but managedConfig is
+    // only true after config migrate which requires a working
+    // datastore, so this is an edge case.
+  }
+}
+
+/**
  * Resolves the pulled-extensions root and lockfile path based on
  * whether managed config is enabled. When managedConfig is true,
  * these paths point into .swamp/config/ (the datastore interface
  * layer). When false, they use the traditional locations.
+ *
+ * When the sentinel check fails but managedConfig is set in the marker,
+ * checks the module-level registry for a base path populated by a prior
+ * {@link ensureManagedConfigBase} call. This handles custom datastores
+ * (S3, GCS) where the sentinel lives at the cache path, not the
+ * repo-local `.swamp/config/`.
  */
 export function resolveManagedConfigPaths(
   repoDir: string,
@@ -250,7 +309,7 @@ export function resolveManagedConfigPaths(
   options?: { skipSentinelCheck?: boolean },
 ): { pulledExtensionsRoot: string; lockfilePath: string; active: boolean } {
   const managedConfig = marker?.datastore?.managedConfig === true;
-  const effectiveBase = configBasePath ?? swampPath(repoDir, "config");
+  let effectiveBase = configBasePath ?? swampPath(repoDir, "config");
 
   let active = false;
   if (managedConfig) {
@@ -261,7 +320,18 @@ export function resolveManagedConfigPaths(
         Deno.statSync(join(effectiveBase, "managed-config-migrated.json"));
         active = true;
       } catch {
-        // Sentinel not found — migration hasn't run yet, fall back
+        // Sentinel not found at the default path — check the registry
+        // for a base path populated by ensureManagedConfigBase (which
+        // resolves the datastore to find the cache-relative path).
+        // Only fall back to the registry when no explicit configBasePath
+        // was provided — an explicit argument takes precedence.
+        if (!configBasePath) {
+          const registeredBase = getManagedConfigBase(repoDir);
+          if (registeredBase) {
+            effectiveBase = registeredBase;
+            active = true;
+          }
+        }
       }
     }
   }

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -31,6 +31,7 @@ import {
   createLockProgressWriter,
   createModelLock,
   datastoreGlobalLockOptions,
+  ensureManagedConfigBase,
   flushSinglePhasePush,
   flushTwoPhasePush,
   type LockProgressWriter,
@@ -2373,6 +2374,137 @@ Deno.test("resolveManagedConfigPaths: custom modelsDir is used when managedConfi
     lockfilePath,
     join(repo, "custom", "models", "upstream_extensions.json"),
   );
+});
+
+// ── ensureManagedConfigBase Tests ────────────────────────────────────────────
+
+Deno.test("ensureManagedConfigBase: no-ops when managedConfig is false", async () => {
+  const repo = resolve("/repo-no-managed");
+  const marker: RepoMarkerData = {
+    swampVersion: "1.0.0",
+    initializedAt: "2026-01-01T00:00:00.000Z",
+  };
+  await ensureManagedConfigBase(repo, marker);
+  const { pulledExtensionsRoot } = resolveManagedConfigPaths(repo, marker);
+  assertPathEquals(
+    pulledExtensionsRoot,
+    join(repo, ".swamp", "pulled-extensions"),
+  );
+});
+
+Deno.test("ensureManagedConfigBase: registers cache-based config path via resolver override", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const cachePath = join(tmpDir, "cache");
+    await Deno.mkdir(cachePath, { recursive: true });
+    const marker: RepoMarkerData = {
+      swampVersion: "1.0.0",
+      initializedAt: "2026-01-01T00:00:00.000Z",
+      datastore: { type: "@swamp/s3-datastore", managedConfig: true },
+    };
+    const mockResolver = {
+      resolvePath: (subdir: string) => join(cachePath, subdir),
+      localPath: () => "",
+      datastorePath: () => "",
+      isDatastoreSubdir: () => false,
+      isExcluded: () => false,
+      config: () => ({ type: "filesystem", path: tmpDir }) as DatastoreConfig,
+    };
+    await ensureManagedConfigBase(tmpDir, marker, mockResolver);
+    const { pulledExtensionsRoot, lockfilePath, active } =
+      resolveManagedConfigPaths(tmpDir, marker);
+    assertEquals(active, true);
+    assertPathEquals(
+      pulledExtensionsRoot,
+      join(cachePath, "config", "pulled-extensions"),
+    );
+    assertPathEquals(
+      lockfilePath,
+      join(cachePath, "config", "upstream_extensions.json"),
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("resolveManagedConfigPaths: picks up registry-populated base when sentinel missing", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const cachePath = join(tmpDir, "remote-cache");
+    await Deno.mkdir(cachePath, { recursive: true });
+    const marker: RepoMarkerData = {
+      swampVersion: "1.0.0",
+      initializedAt: "2026-01-01T00:00:00.000Z",
+      datastore: { type: "@swamp/s3-datastore", managedConfig: true },
+    };
+    const mockResolver = {
+      resolvePath: (subdir: string) => join(cachePath, subdir),
+      localPath: () => "",
+      datastorePath: () => "",
+      isDatastoreSubdir: () => false,
+      isExcluded: () => false,
+      config: () => ({ type: "filesystem", path: tmpDir }) as DatastoreConfig,
+    };
+    await ensureManagedConfigBase(tmpDir, marker, mockResolver);
+    const { pulledExtensionsRoot, lockfilePath, active } =
+      resolveManagedConfigPaths(tmpDir, marker);
+    assertEquals(active, true);
+    assertPathEquals(
+      pulledExtensionsRoot,
+      join(cachePath, "config", "pulled-extensions"),
+    );
+    assertPathEquals(
+      lockfilePath,
+      join(cachePath, "config", "upstream_extensions.json"),
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("ensureManagedConfigBase: explicit configBasePath still takes precedence", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    const explicitBase = join(tmpDir, "explicit-config");
+    await Deno.mkdir(
+      join(explicitBase, "managed-config-migrated.json").replace(
+        "managed-config-migrated.json",
+        "",
+      ),
+      { recursive: true },
+    );
+    await Deno.writeTextFile(
+      join(explicitBase, "managed-config-migrated.json"),
+      "{}",
+    );
+    const cachePath = join(tmpDir, "cache");
+    await Deno.mkdir(cachePath, { recursive: true });
+    const marker: RepoMarkerData = {
+      swampVersion: "1.0.0",
+      initializedAt: "2026-01-01T00:00:00.000Z",
+      datastore: { type: "@swamp/s3-datastore", managedConfig: true },
+    };
+    const mockResolver = {
+      resolvePath: (subdir: string) => join(cachePath, subdir),
+      localPath: () => "",
+      datastorePath: () => "",
+      isDatastoreSubdir: () => false,
+      isExcluded: () => false,
+      config: () => ({ type: "filesystem", path: tmpDir }) as DatastoreConfig,
+    };
+    await ensureManagedConfigBase(tmpDir, marker, mockResolver);
+    const { lockfilePath } = resolveManagedConfigPaths(
+      tmpDir,
+      marker,
+      explicitBase,
+    );
+    assertPathEquals(
+      lockfilePath,
+      join(explicitBase, "upstream_extensions.json"),
+    );
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
 });
 
 // ── flushSinglePhasePush: catalog export ordering ──────────────────────────

--- a/src/libswamp/extensions/pull.ts
+++ b/src/libswamp/extensions/pull.ts
@@ -300,6 +300,13 @@ export interface ExtensionPullDeps {
    */
   denoRuntime?: DenoRuntime;
   repository?: ExtensionRepository;
+  /**
+   * Root directory for pulled extension sources. When provided, passed
+   * through to {@link InstallContext.pulledExtensionsRoot}. With
+   * managedConfig, callers pass the datastore-resolved
+   * `config/pulled-extensions` path.
+   */
+  pulledExtensionsRoot?: string;
 }
 
 /**
@@ -1290,6 +1297,7 @@ export async function* extensionPull(
         alreadyPulled: deps.alreadyPulled,
         depth: deps.depth,
         channel: input.channel,
+        pulledExtensionsRoot: deps.pulledExtensionsRoot,
       };
 
       // Let ConflictError propagate — CLI catches it for the two-phase prompt
@@ -1388,6 +1396,7 @@ export async function createExtensionPullDeps(
     denoRuntime?: DenoRuntime;
     repository?: ExtensionRepository;
     identity?: ClientIdentity;
+    pulledExtensionsRoot?: string;
   },
 ): Promise<ExtensionPullDeps> {
   const client = new ExtensionApiClient(serverUrl, args?.identity);
@@ -1410,6 +1419,7 @@ export async function createExtensionPullDeps(
     depth: 0,
     denoRuntime: args?.denoRuntime,
     repository: args?.repository,
+    pulledExtensionsRoot: args?.pulledExtensionsRoot,
   };
 }
 

--- a/src/serve/extension_reload.ts
+++ b/src/serve/extension_reload.ts
@@ -223,15 +223,21 @@ export async function reloadTrustedCollectives(
 
 export async function resolveLockfilePath(
   repoDir: string,
+  datastoreResolver?:
+    import("../domain/datastore/datastore_path_resolver.ts").DatastorePathResolver,
 ): Promise<string> {
   let marker: RepoMarkerData | null = null;
   try {
     const markerRepo = new RepoMarkerRepository();
     marker = await markerRepo.read(RepoPath.create(repoDir));
   } catch {
-    // Not in a swamp repo or marker unreadable — resolveManagedConfigPaths uses default paths
+    // Not in a swamp repo or marker unreadable — use default paths
   }
   if (marker?.datastore?.managedConfig) {
+    if (datastoreResolver) {
+      const configBase = datastoreResolver.resolvePath("config");
+      return join(configBase, "upstream_extensions.json");
+    }
     return managedConfigLockfilePath(repoDir);
   }
   const modelsDir = resolveModelsDir(marker);

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -106,7 +106,6 @@ import {
 } from "../../infrastructure/persistence/namespace_manifest.ts";
 import { createExtensionInstallDeps } from "../../cli/create_extension_install_deps.ts";
 import { loadIdentity } from "../../cli/load_identity.ts";
-import { managedConfigLockfilePath } from "../../infrastructure/persistence/paths.ts";
 import { resolveModelsDir } from "../../cli/resolve_models_dir.ts";
 import type {
   AuditTimelinePayload,
@@ -158,6 +157,34 @@ import {
   resolveLockfilePath,
 } from "../extension_reload.ts";
 import { isReservedVaultName } from "./vault_handlers.ts";
+
+/**
+ * Derives managed-config paths from the connection context's datastore resolver.
+ * When managedConfig is true, the lockfile and pulled-extensions root live at
+ * the datastore-resolved config path (cache path for S3, local for filesystem).
+ */
+function resolveManagedPathsFromContext(
+  ctx: ConnectionContext,
+  marker:
+    | import("../../infrastructure/persistence/repo_marker_repository.ts").RepoMarkerData
+    | null,
+): { lockfilePath: string; pulledExtensionsRoot: string | undefined } {
+  if (marker?.datastore?.managedConfig) {
+    const configBase = ctx.datastoreResolver.resolvePath("config");
+    return {
+      lockfilePath: join(configBase, "upstream_extensions.json"),
+      pulledExtensionsRoot: join(configBase, "pulled-extensions"),
+    };
+  }
+  const modelsDir = resolveModelsDir(marker);
+  return {
+    lockfilePath: join(
+      isAbsolute(modelsDir) ? modelsDir : resolve(ctx.repoDir, modelsDir),
+      "upstream_extensions.json",
+    ),
+    pulledExtensionsRoot: undefined,
+  };
+}
 
 export async function handleWorkerList(
   socket: WebSocket,
@@ -683,14 +710,8 @@ export async function handleExtensionPull(
 
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(RepoPath.create(repoDir));
-    const lockfilePath = marker?.datastore?.managedConfig
-      ? managedConfigLockfilePath(repoDir)
-      : join(
-        isAbsolute(resolveModelsDir(marker))
-          ? resolveModelsDir(marker)
-          : resolve(repoDir, resolveModelsDir(marker)),
-        "upstream_extensions.json",
-      );
+    const { lockfilePath, pulledExtensionsRoot } =
+      resolveManagedPathsFromContext(ctx, marker);
 
     const tools = marker?.tools?.length ? marker.tools : ["claude"];
     const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
@@ -707,7 +728,7 @@ export async function handleExtensionPull(
       lockfilePath,
       skillsDirs,
       repoDir,
-      { identity },
+      { identity, pulledExtensionsRoot },
     );
     const repository = new ExtensionRepository({
       catalog,
@@ -816,14 +837,7 @@ export async function handleExtensionRm(
     const repoDir = ctx.repoDir;
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(RepoPath.create(repoDir));
-    const lockfilePath = marker?.datastore?.managedConfig
-      ? managedConfigLockfilePath(repoDir)
-      : join(
-        isAbsolute(resolveModelsDir(marker))
-          ? resolveModelsDir(marker)
-          : resolve(repoDir, resolveModelsDir(marker)),
-        "upstream_extensions.json",
-      );
+    const { lockfilePath } = resolveManagedPathsFromContext(ctx, marker);
 
     deps = await createExtensionRmDeps(repoDir, lockfilePath);
     const libCtx = createLibSwampContext();
@@ -896,14 +910,7 @@ export async function handleExtensionOutdated(
     const repoDir = ctx.repoDir;
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(RepoPath.create(repoDir));
-    const lockfilePath = marker?.datastore?.managedConfig
-      ? managedConfigLockfilePath(repoDir)
-      : join(
-        isAbsolute(resolveModelsDir(marker))
-          ? resolveModelsDir(marker)
-          : resolve(repoDir, resolveModelsDir(marker)),
-        "upstream_extensions.json",
-      );
+    const { lockfilePath } = resolveManagedPathsFromContext(ctx, marker);
 
     const identity = await loadIdentity();
     const deps = await createExtensionUpdateDeps({
@@ -973,14 +980,7 @@ export async function handleExtensionUpdate(
     const repoDir = ctx.repoDir;
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(RepoPath.create(repoDir));
-    const lockfilePath = marker?.datastore?.managedConfig
-      ? managedConfigLockfilePath(repoDir)
-      : join(
-        isAbsolute(resolveModelsDir(marker))
-          ? resolveModelsDir(marker)
-          : resolve(repoDir, resolveModelsDir(marker)),
-        "upstream_extensions.json",
-      );
+    const { lockfilePath } = resolveManagedPathsFromContext(ctx, marker);
 
     const tools = marker?.tools?.length ? marker.tools : ["claude"];
     const skillsDirs = resolveUniqueLocalSkillsDirs(repoDir, tools);
@@ -1523,14 +1523,7 @@ export async function handleDoctorExtensions(
     const repoPath = RepoPath.create(repoDir);
     const markerRepo = new RepoMarkerRepository();
     const marker = await markerRepo.read(repoPath);
-    const lockfilePath = marker?.datastore?.managedConfig
-      ? managedConfigLockfilePath(repoDir)
-      : join(
-        isAbsolute(resolveModelsDir(marker))
-          ? resolveModelsDir(marker)
-          : resolve(repoDir, resolveModelsDir(marker)),
-        "upstream_extensions.json",
-      );
+    const { lockfilePath } = resolveManagedPathsFromContext(ctx, marker);
 
     const catalogDbPath = swampPath(repoDir, "_extension_catalog.db");
     sharedCatalog = new ExtensionCatalogStore(catalogDbPath);
@@ -1850,7 +1843,10 @@ export async function handleServeReload(
   logger.info`Extension reload requested by ${who}`;
 
   try {
-    const lockfilePath = await resolveLockfilePath(ctx.repoDir);
+    const lockfilePath = await resolveLockfilePath(
+      ctx.repoDir,
+      ctx.datastoreResolver,
+    );
     const reloadOptions = ctx.scheduledExecution
       ? {
         triggerOverrideUpdater: (


### PR DESCRIPTION
## Summary

- `swamp extension pull` and other extension commands wrote to `.swamp/pulled-extensions/` instead of `config/pulled-extensions/` when `managedConfig: true` and the datastore was a custom type (S3, GCS)
- Root cause: `resolveManagedConfigPaths` checked for the migration sentinel at the repo-local `.swamp/config/` path, but for custom datastores the sentinel lives at the cache path (e.g. `~/.swamp/repos/<id>/config/`)
- Added `ensureManagedConfigBase` — resolves the datastore config and registers the correct cache-relative base path in the module-level managed config registry; all 12 extension CLI commands now call it before `resolveManagedConfigPaths`
- Modified `resolveManagedConfigPaths` to check the registry when the sentinel check fails
- Fixed all 6 serve handler ad-hoc `managedConfigLockfilePath` calls with resolver-derived paths
- Threaded `pulledExtensionsRoot` through `ExtensionPullDeps` → `InstallContext` as defense-in-depth

## Test plan

- [x] 4 new unit tests for `ensureManagedConfigBase` and registry fallback
- [x] All 10 existing `resolveManagedConfigPaths` tests pass (no regressions)
- [x] All 31 extension pull tests pass
- [x] Full verification: lint, type-check, tests, compile, code review, adversarial review, UX review

Co-authored-by: Blake Irvin <blakeirvin@me.com>

Closes swamp-club#2048

🤖 Generated with [Claude Code](https://claude.com/claude-code)