### PR TITLE
fix(cli): honor .swamp.yaml serverAddress in all serve-aware commands

### DIFF
--- a/design/surfaces/repo.md
+++ b/design/surfaces/repo.md
@@ -133,10 +133,9 @@ options are:
   synced datastore the deletions ride along with the same post-run push.
   `swamp data gc` remains available for repo-wide manual GC.
 - `serverAddress`: Default `swamp serve` URL for this repository. When set,
-  `model method run` and `workflow run` route through this serve instance
-  without requiring `SWAMP_SERVE_URL` or `--server`. Other serve-aware
-  commands will gain support in follow-up work. Precedence: `--server`
-  flag > `SWAMP_SERVE_URL` env > `SWAMP_SERVER_URL` env > `.swamp.yaml
+  all serve-aware commands route through this serve instance without
+  requiring `SWAMP_SERVE_URL` or `--server`. Precedence: `--server` flag >
+  `SWAMP_SERVE_URL` env > `SWAMP_SERVER_URL` env > `.swamp.yaml
   serverAddress`. Set during init with `swamp repo init --server <url>` or
   by editing `.swamp.yaml` directly.
 

--- a/src/cli/commands/auth_whoami.ts
+++ b/src/cli/commands/auth_whoami.ts
@@ -27,6 +27,7 @@ import {
 } from "../../libswamp/mod.ts";
 import { createAuthWhoamiRenderer } from "../../presentation/renderers/auth_whoami.ts";
 import { loadIdentity } from "../load_identity.ts";
+import { resolveServeUrl } from "../remote_run.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnyOptions = any;
@@ -48,7 +49,10 @@ export const authWhoamiCommand = new Command()
       identity,
     });
 
-    const renderer = createAuthWhoamiRenderer(cliCtx.outputMode);
+    const effectiveServeUrl = resolveServeUrl(undefined);
+    const renderer = createAuthWhoamiRenderer(cliCtx.outputMode, {
+      effectiveServeUrl,
+    });
     await consumeStream(whoami(ctx, deps), renderer.handlers());
 
     cliCtx.logger.debug("Auth whoami command completed");

--- a/src/cli/commands/model_method_run.ts
+++ b/src/cli/commands/model_method_run.ts
@@ -244,19 +244,8 @@ Exit codes: 0 = success, 1 = general error, 75 = lock contention (temporary — 
         : modelOrType;
       const definitionName = isDirectExecution ? definitionNameArg : undefined;
 
-      let markerServerAddress: string | undefined;
-      try {
-        const markerRepo = new RepoMarkerRepository();
-        const repoDir = resolveRepoDir(options.repoDir);
-        const m = await markerRepo.read(RepoPath.create(repoDir));
-        markerServerAddress = m?.serverAddress;
-      } catch {
-        // Not in a repo — serverAddress fallback unavailable
-      }
-
       const server = resolveServeUrl(
         options.server as string | undefined,
-        markerServerAddress,
       );
       if (server) {
         await runMethodViaServer(

--- a/src/cli/commands/workflow_run.ts
+++ b/src/cli/commands/workflow_run.ts
@@ -35,8 +35,6 @@ import {
   requireInitializedRepoUnlocked,
 } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
-import { RepoMarkerRepository } from "../../infrastructure/persistence/repo_marker_repository.ts";
-import { RepoPath } from "../../domain/repo/repo_path.ts";
 import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import {
@@ -250,19 +248,8 @@ export const workflowRunCommand = new Command()
       );
     }
 
-    let markerServerAddress: string | undefined;
-    try {
-      const markerRepo = new RepoMarkerRepository();
-      const repoDir = resolveRepoDir(options.repoDir);
-      const m = await markerRepo.read(RepoPath.create(repoDir));
-      markerServerAddress = m?.serverAddress;
-    } catch {
-      // Not in a repo — serverAddress fallback unavailable
-    }
-
     const server = resolveServeUrl(
       options.server as string | undefined,
-      markerServerAddress,
     );
     if (server) {
       if (failOnSeverity) {

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -69,6 +69,7 @@ import {
   WorkflowNameType,
 } from "./completion_types.ts";
 import { isTransientError } from "../infrastructure/persistence/io_errors.ts";
+import { setMarkerServerAddress } from "./remote_run.ts";
 import { ExtensionCatalogStore } from "../infrastructure/persistence/extension_catalog_store.ts";
 import { ExtensionRepository } from "../infrastructure/persistence/extension_repository.ts";
 import { readLocalManifestIdentity } from "../infrastructure/persistence/local_manifest_reader.ts";
@@ -1335,8 +1336,9 @@ export async function runCli(args: string[]): Promise<void> {
     setActiveTelemetryContext(telemetryCtx);
   }
 
-  // Read marker once for log level, extension loading, and auto-resolver.
-  // Hook commands skip this — null marker gives default "info" log level.
+  // Read marker once for log level, extension loading, auto-resolver,
+  // and serverAddress cache. Hook commands skip this — null marker gives
+  // default "info" log level and no serverAddress fallback.
   let marker: RepoMarkerData | null = null;
   if (!hookMode) {
     try {
@@ -1347,6 +1349,7 @@ export async function runCli(args: string[]): Promise<void> {
       // Not in a swamp repo - marker stays null
     }
   }
+  setMarkerServerAddress(marker?.serverAddress);
 
   // Read extension sources (additional extension directories from
   // .swamp-sources.yaml). Resolved once and shared across all loaders.

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -50,9 +50,19 @@ import {
   STATUS_COLORS,
 } from "../presentation/output/console_writer.ts";
 
+let _cachedMarkerServerAddress: string | undefined;
+
+/** Called once from the CLI entry point after the marker is read. */
+export function setMarkerServerAddress(value: string | undefined): void {
+  _cachedMarkerServerAddress = value;
+}
+
+/** Test-only: resets the cached marker server address between test cases. */
+export function resetMarkerServerAddress(): void {
+  _cachedMarkerServerAddress = undefined;
+}
+
 /**
- * Resolves the server URL from the `--server` flag with env var and
- * repo-marker fallbacks.
  * Precedence: flag > SWAMP_SERVE_URL > SWAMP_SERVER_URL > .swamp.yaml serverAddress.
  */
 export function resolveServeUrl(
@@ -60,7 +70,8 @@ export function resolveServeUrl(
   markerValue?: string,
 ): string | undefined {
   return flagValue ?? Deno.env.get("SWAMP_SERVE_URL") ??
-    Deno.env.get("SWAMP_SERVER_URL") ?? markerValue;
+    Deno.env.get("SWAMP_SERVER_URL") ?? markerValue ??
+    _cachedMarkerServerAddress;
 }
 
 export function writeRemoteIndicator(serverUrl: string): void {

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -29,10 +29,12 @@ import {
   normalizeServerUrl,
   probeServerHealth,
   requestServerResponse,
+  resetMarkerServerAddress,
   resolveServerToken,
   resolveServeUrl,
   runModelMethodOverServer,
   runWorkflowOverServer,
+  setMarkerServerAddress,
   warnServerReloadNeeded,
   writeRemoteIndicator,
 } from "./remote_run.ts";
@@ -205,6 +207,88 @@ Deno.test("resolveServeUrl: returns undefined when no flag, env var, or markerVa
     Deno.env.delete("SWAMP_SERVE_URL");
     Deno.env.delete("SWAMP_SERVER_URL");
     assertEquals(resolveServeUrl(undefined, undefined), undefined);
+  } finally {
+    if (prevServe !== undefined) Deno.env.set("SWAMP_SERVE_URL", prevServe);
+    if (prevServer !== undefined) Deno.env.set("SWAMP_SERVER_URL", prevServer);
+  }
+});
+
+// ── cached marker serverAddress tests ─────────────────────────────────
+
+Deno.test("resolveServeUrl: falls back to cached marker serverAddress", () => {
+  const prevServe = Deno.env.get("SWAMP_SERVE_URL");
+  const prevServer = Deno.env.get("SWAMP_SERVER_URL");
+  try {
+    Deno.env.delete("SWAMP_SERVE_URL");
+    Deno.env.delete("SWAMP_SERVER_URL");
+    setMarkerServerAddress("wss://cached.example.com");
+    assertEquals(resolveServeUrl(undefined), "wss://cached.example.com");
+  } finally {
+    resetMarkerServerAddress();
+    if (prevServe !== undefined) Deno.env.set("SWAMP_SERVE_URL", prevServe);
+    if (prevServer !== undefined) Deno.env.set("SWAMP_SERVER_URL", prevServer);
+  }
+});
+
+Deno.test("resolveServeUrl: explicit markerValue takes precedence over cached value", () => {
+  const prevServe = Deno.env.get("SWAMP_SERVE_URL");
+  const prevServer = Deno.env.get("SWAMP_SERVER_URL");
+  try {
+    Deno.env.delete("SWAMP_SERVE_URL");
+    Deno.env.delete("SWAMP_SERVER_URL");
+    setMarkerServerAddress("wss://cached.example.com");
+    assertEquals(
+      resolveServeUrl(undefined, "wss://explicit.example.com"),
+      "wss://explicit.example.com",
+    );
+  } finally {
+    resetMarkerServerAddress();
+    if (prevServe !== undefined) Deno.env.set("SWAMP_SERVE_URL", prevServe);
+    if (prevServer !== undefined) Deno.env.set("SWAMP_SERVER_URL", prevServer);
+  }
+});
+
+Deno.test("resolveServeUrl: env var takes precedence over cached marker value", () => {
+  const prevServe = Deno.env.get("SWAMP_SERVE_URL");
+  const prevServer = Deno.env.get("SWAMP_SERVER_URL");
+  try {
+    Deno.env.set("SWAMP_SERVE_URL", "wss://env.example.com");
+    Deno.env.delete("SWAMP_SERVER_URL");
+    setMarkerServerAddress("wss://cached.example.com");
+    assertEquals(resolveServeUrl(undefined), "wss://env.example.com");
+  } finally {
+    resetMarkerServerAddress();
+    if (prevServe !== undefined) Deno.env.set("SWAMP_SERVE_URL", prevServe);
+    else Deno.env.delete("SWAMP_SERVE_URL");
+    if (prevServer !== undefined) Deno.env.set("SWAMP_SERVER_URL", prevServer);
+    else Deno.env.delete("SWAMP_SERVER_URL");
+  }
+});
+
+Deno.test("resolveServeUrl: returns undefined when cache is not set and no other source", () => {
+  const prevServe = Deno.env.get("SWAMP_SERVE_URL");
+  const prevServer = Deno.env.get("SWAMP_SERVER_URL");
+  try {
+    Deno.env.delete("SWAMP_SERVE_URL");
+    Deno.env.delete("SWAMP_SERVER_URL");
+    resetMarkerServerAddress();
+    assertEquals(resolveServeUrl(undefined), undefined);
+  } finally {
+    if (prevServe !== undefined) Deno.env.set("SWAMP_SERVE_URL", prevServe);
+    if (prevServer !== undefined) Deno.env.set("SWAMP_SERVER_URL", prevServer);
+  }
+});
+
+Deno.test("resetMarkerServerAddress: clears the cached value", () => {
+  const prevServe = Deno.env.get("SWAMP_SERVE_URL");
+  const prevServer = Deno.env.get("SWAMP_SERVER_URL");
+  try {
+    Deno.env.delete("SWAMP_SERVE_URL");
+    Deno.env.delete("SWAMP_SERVER_URL");
+    setMarkerServerAddress("wss://cached.example.com");
+    assertEquals(resolveServeUrl(undefined), "wss://cached.example.com");
+    resetMarkerServerAddress();
+    assertEquals(resolveServeUrl(undefined), undefined);
   } finally {
     if (prevServe !== undefined) Deno.env.set("SWAMP_SERVE_URL", prevServe);
     if (prevServer !== undefined) Deno.env.set("SWAMP_SERVER_URL", prevServer);

--- a/src/presentation/renderers/auth_whoami.ts
+++ b/src/presentation/renderers/auth_whoami.ts
@@ -86,7 +86,13 @@ function collectiveLines(
   });
 }
 
+export interface AuthWhoamiRendererOptions {
+  effectiveServeUrl?: string;
+}
+
 class LogAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
+  constructor(private readonly options: AuthWhoamiRendererOptions) {}
+
   handlers(): EventHandlers<AuthWhoamiEvent> {
     return {
       loading_credentials: () => {},
@@ -103,6 +109,10 @@ class LogAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
           writeOutput(
             `${e.identity.username} (${e.identity.email}) on ${e.identity.serverUrl}`,
           );
+        }
+
+        if (this.options.effectiveServeUrl) {
+          writeOutput(`Serve: ${this.options.effectiveServeUrl}`);
         }
 
         const entitlements = e.identity.collectiveEntitlements;
@@ -131,6 +141,8 @@ class LogAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
 }
 
 class JsonAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
+  constructor(private readonly options: AuthWhoamiRendererOptions) {}
+
   handlers(): EventHandlers<AuthWhoamiEvent> {
     return {
       loading_credentials: () => {},
@@ -140,6 +152,9 @@ class JsonAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
           {
             authenticated: true,
             serverUrl: e.identity.serverUrl,
+            ...(this.options.effectiveServeUrl
+              ? { effectiveServeUrl: this.options.effectiveServeUrl }
+              : {}),
             ...(e.identity.collectiveToken
               ? {
                 collectiveToken: true,
@@ -176,11 +191,12 @@ class JsonAuthWhoamiRenderer implements Renderer<AuthWhoamiEvent> {
 
 export function createAuthWhoamiRenderer(
   mode: OutputMode,
+  options: AuthWhoamiRendererOptions = {},
 ): Renderer<AuthWhoamiEvent> {
   switch (mode) {
     case "json":
-      return new JsonAuthWhoamiRenderer();
+      return new JsonAuthWhoamiRenderer(options);
     case "log":
-      return new LogAuthWhoamiRenderer();
+      return new LogAuthWhoamiRenderer(options);
   }
 }

--- a/src/presentation/renderers/auth_whoami_test.ts
+++ b/src/presentation/renderers/auth_whoami_test.ts
@@ -253,12 +253,16 @@ function makeEntitledIdentity(
   };
 }
 
-function captureLog(identity: WhoamiIdentity, mode: OutputMode): string {
+function captureLog(
+  identity: WhoamiIdentity,
+  mode: OutputMode,
+  options?: { effectiveServeUrl?: string },
+): string {
   const logs: string[] = [];
   const originalLog = console.log;
   console.log = (msg: string) => logs.push(msg);
   try {
-    const renderer = createAuthWhoamiRenderer(mode);
+    const renderer = createAuthWhoamiRenderer(mode, options);
     renderer.handlers().completed({ kind: "completed", identity });
   } finally {
     console.log = originalLog;
@@ -425,4 +429,36 @@ Deno.test("JsonAuthWhoamiRenderer - omits entitlement keys when the server sent 
   assertEquals("plan" in parsed, false);
   assertEquals("collectiveEntitlements" in parsed, false);
   assertEquals(parsed.collectives, ["org-a"]);
+});
+
+// --- effectiveServeUrl rendering ---
+
+Deno.test("LogAuthWhoamiRenderer - shows effective serve URL when set", () => {
+  const output = captureLog(
+    makeIdentity(),
+    "log",
+    { effectiveServeUrl: "wss://serve.example.com" },
+  );
+  assertStringIncludes(output, "Serve: wss://serve.example.com");
+});
+
+Deno.test("LogAuthWhoamiRenderer - omits serve line when no effective serve URL", () => {
+  const output = captureLog(makeIdentity(), "log");
+  assertEquals(output.includes("Serve:"), false);
+});
+
+Deno.test("JsonAuthWhoamiRenderer - includes effectiveServeUrl when set", () => {
+  const output = captureLog(
+    makeIdentity(),
+    "json",
+    { effectiveServeUrl: "wss://serve.example.com" },
+  );
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.effectiveServeUrl, "wss://serve.example.com");
+});
+
+Deno.test("JsonAuthWhoamiRenderer - omits effectiveServeUrl when not set", () => {
+  const output = captureLog(makeIdentity(), "json");
+  const parsed = JSON.parse(output);
+  assertEquals("effectiveServeUrl" in parsed, false);
 });


### PR DESCRIPTION
## Summary

- Wire `.swamp.yaml` `serverAddress` into all ~100 serve-aware CLI commands by
  adding a module-level cache in `resolveServeUrl` that `mod.ts` populates from
  the repo marker at CLI startup — zero changes needed to the 110 existing call
  sites
- Remove the now-redundant inline marker reads from `model_method_run.ts` and
  `workflow_run.ts` (the only two commands that previously handled it)
- Add `effectiveServeUrl` to `auth whoami` output (both log and JSON modes) so
  operators can see which serve their next call targets
- Update `design/surfaces/repo.md` to remove the "will gain support in
  follow-up work" caveat

Closes swamp-club#2046

Co-authored-by: Blake Irvin <bixu@users.noreply.github.com>

## Test plan

- [x] 5 new unit tests for cached marker serverAddress precedence in
  `remote_run_test.ts`
- [x] 4 new renderer tests for `effectiveServeUrl` in
  `auth_whoami_test.ts` (log present, log absent, JSON present, JSON absent)
- [x] All 11,325 tests pass
- [x] Lint, fmt, type-check, deps-audit, compile all pass
- [x] Code review: pass
- [x] UX review: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)