### PR TITLE
fix(datastore): optimize writeCatalogExport with compact JSON, page-buffered writes, and atomic rename (swamp-club#2026)

### DIFF
--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -152,10 +152,13 @@ export function createCatalogStore(
  * flat JSON array. Extensions upload this file to the remote datastore
  * via {@link DatastoreSyncService.exportCatalog}.
  *
- * Uses cooperative yielding: iterates the catalog page by page, writing
- * each row's JSON incrementally, and yields the event loop between pages
- * so concurrent async work (HTTP handlers, WebSocket messages, workflow
- * steps) is not starved by the synchronous SQLite reads.
+ * Writes to a temp file first, then atomically renames to the final path
+ * so a crash mid-write never corrupts the previous valid export.
+ *
+ * Uses page-buffered writes (one write per {@link ITERATE_PAGE_SIZE}
+ * batch) and compact JSON to minimize I/O syscalls and output size.
+ * Yields the event loop between pages so concurrent async work is not
+ * starved by the synchronous SQLite reads.
  */
 export async function writeCatalogExport(
   catalogStore: CatalogStore,
@@ -163,31 +166,46 @@ export async function writeCatalogExport(
   namespace: string,
 ): Promise<number> {
   const exportPath = join(cachePath, namespace, ".catalog-export.json");
+  const tmpPath = join(
+    cachePath,
+    namespace,
+    `.${crypto.randomUUID()}.tmp`,
+  );
   const encoder = new TextEncoder();
-  const file = await Deno.open(exportPath, {
+  const file = await Deno.open(tmpPath, {
     write: true,
     create: true,
     truncate: true,
   });
   try {
     let rowCount = 0;
-    let first = true;
-    await file.write(encoder.encode("[\n"));
+    const pageBuffer: string[] = [];
+    await file.write(encoder.encode("["));
     for (const row of catalogStore.iterateNamespace(namespace)) {
-      if (!first) {
-        await file.write(encoder.encode(",\n"));
-      }
-      first = false;
-      await file.write(encoder.encode(JSON.stringify(row, null, 2)));
+      if (rowCount > 0) pageBuffer.push(",");
+      pageBuffer.push(JSON.stringify(row));
       rowCount++;
       if (rowCount % ITERATE_PAGE_SIZE === 0) {
+        await file.write(encoder.encode(pageBuffer.join("")));
+        pageBuffer.length = 0;
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
       }
     }
-    await file.write(encoder.encode("\n]\n"));
-    return rowCount;
-  } finally {
+    if (pageBuffer.length > 0) {
+      await file.write(encoder.encode(pageBuffer.join("")));
+    }
+    await file.write(encoder.encode("]\n"));
     file.close();
+    await Deno.rename(tmpPath, exportPath);
+    return rowCount;
+  } catch (error) {
+    try {
+      file.close();
+    } catch { /* already closed or I/O error */ }
+    try {
+      await Deno.remove(tmpPath);
+    } catch { /* best-effort cleanup */ }
+    throw error;
   }
 }
 

--- a/src/infrastructure/persistence/repository_factory_test.ts
+++ b/src/infrastructure/persistence/repository_factory_test.ts
@@ -332,3 +332,100 @@ Deno.test("writeCatalogExport: yields event loop between pages", async () => {
     cleanup();
   }
 });
+
+Deno.test("writeCatalogExport: no temp files left after successful write", async () => {
+  const { store, cachePath, cleanup } = setupCatalogExportFixture();
+  try {
+    store.upsert(makeRow());
+    await writeCatalogExport(store, cachePath, "test-ns");
+    const nsDir = join(cachePath, "test-ns");
+    const files: string[] = [];
+    for await (const entry of Deno.readDir(nsDir)) {
+      files.push(entry.name);
+    }
+    const tmpFiles = files.filter((f) => f.endsWith(".tmp"));
+    assertEquals(tmpFiles, [], "temp files should be cleaned up after export");
+    assert(
+      files.includes(".catalog-export.json"),
+      "export file should exist",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("writeCatalogExport: old export survives when write fails mid-iteration", async () => {
+  const { store, cachePath, cleanup } = setupCatalogExportFixture();
+  try {
+    store.upsert(makeRow());
+    await writeCatalogExport(store, cachePath, "test-ns");
+    const originalContent = await Deno.readTextFile(
+      join(cachePath, "test-ns", ".catalog-export.json"),
+    );
+
+    const failingStore = {
+      iterateNamespace(_ns: string) {
+        return (function* () {
+          yield makeRow({ data_name: "will-fail", id: "fail-uuid" });
+          throw new Error("simulated mid-iteration failure");
+        })();
+      },
+    } as unknown as CatalogStore;
+
+    let threw = false;
+    try {
+      await writeCatalogExport(failingStore, cachePath, "test-ns");
+    } catch {
+      threw = true;
+    }
+    assert(threw, "writeCatalogExport should have thrown");
+
+    const survivingContent = await Deno.readTextFile(
+      join(cachePath, "test-ns", ".catalog-export.json"),
+    );
+    assertEquals(
+      survivingContent,
+      originalContent,
+      "original export should be intact after failed write",
+    );
+
+    const nsDir = join(cachePath, "test-ns");
+    for await (const entry of Deno.readDir(nsDir)) {
+      assert(
+        !entry.name.endsWith(".tmp"),
+        `temp file ${entry.name} should have been cleaned up`,
+      );
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+Deno.test("writeCatalogExport: 100k rows benchmark", async () => {
+  const { store, cachePath, cleanup } = setupCatalogExportFixture();
+  try {
+    const totalRows = 100_000;
+    for (let i = 0; i < totalRows; i++) {
+      store.upsert(makeRow({
+        data_name: `data-${i}`,
+        version: 1,
+        id: `uuid-${i}`,
+        size: i * 10,
+        tags: `{"type":"resource","specName":"result","index":"${i}"}`,
+      }));
+    }
+    const start = performance.now();
+    const count = await writeCatalogExport(store, cachePath, "test-ns");
+    const elapsed = performance.now() - start;
+    assertEquals(count, totalRows);
+    console.log(`  writeCatalogExport 100k rows: ${elapsed.toFixed(0)}ms`);
+
+    const content = await Deno.readTextFile(
+      join(cachePath, "test-ns", ".catalog-export.json"),
+    );
+    const parsed = JSON.parse(content) as CatalogRow[];
+    assertEquals(parsed.length, totalRows);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- Rewrites `writeCatalogExport` (`repository_factory.ts`) to fix 55s+ per-step
  catalog export overhead at 102k rows (reported in swamp-club#2026)
- Switches from pretty-printed JSON (`JSON.stringify(row, null, 2)`) to compact
  JSON, reducing output size ~3x
- Replaces per-row `file.write` calls (~204k async ops) with page-buffered writes
  (~102 writes of 1000-row batches), with memory bounded to ~500KB/page — safe
  under concurrent serve workloads
- Writes to a temp file with atomic `Deno.rename`, closing a pre-existing
  crash-safety gap where `truncate: true` destroyed the old valid export before
  the new one was fully written
- Benchmark: 100k rows in ~2.2s (down from 55s reported)

## Test Plan

- All 5 existing `writeCatalogExport` tests pass (use `JSON.parse`, no format assertions)
- New: no temp files left after successful write
- New: old export survives when iteration fails mid-write (crash safety)
- New: 100k row benchmark — asserts correctness, logs timing for human inspection
- `repo_context_test.ts` flush-ordering integration test passes
- Full verification workflow passed (lint, fmt, type-check, tests, compile,
  code review, adversarial review, UX review)

Closes swamp-club#2026

Co-authored-by: magistr <magistr@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)