### PR TITLE
fix(extensions): auto-retry bundle-only conflicts with force in auto-resolver (swamp-club#2050)

### DIFF
--- a/src/cli/auto_resolver_adapters.ts
+++ b/src/cli/auto_resolver_adapters.ts
@@ -188,31 +188,9 @@ export function createAutoResolveInstallerAdapter(
     },
 
     async install(extensionName: string) {
-      // force: false so installExtension raises ConflictError rather than
-      // silently overwriting any existing files. The service's
-      // inspectInstallation check normally prevents reaching this point
-      // when the extension is already on disk (intact or truncated); the
-      // ConflictError catch below is defence-in-depth for races between
-      // inspect and install that the per-type re-entrancy guard in the
-      // resolver cannot cover (e.g. two types resolving the same
-      // extension concurrently).
-      try {
-        // Construct a fresh LockfileRepository per install to capture a
-        // current snapshot — the InstallContext is single-use per its
-        // JSDoc.
-        const lockfileRepository = await LockfileRepository.create(
-          lockfilePath,
-        );
-        // Honor the committed lockfile pin (swamp-club#465): when an entry
-        // already exists for this extension, install the recorded version and
-        // verify the download against the recorded checksum — the same
-        // integrity-anchored restore path `swamp extension install` uses —
-        // rather than silently fetching latest. This stops a fresh checkout
-        // (where .swamp/pulled-extensions is gitignored but the lockfile is
-        // committed) from pulling an unreviewed newer version. First-ever
-        // installs have no entry and fall back to latest (version: null),
-        // which then becomes the pin for next time.
-        const pinnedEntry = lockfileRepository.getEntry(extensionName);
+      async function runInstall(force: boolean) {
+        const lockfileRepo = await LockfileRepository.create(lockfilePath);
+        const pinnedEntry = lockfileRepo.getEntry(extensionName);
         const ref = {
           name: extensionName,
           version: pinnedEntry?.version ?? null,
@@ -222,32 +200,49 @@ export function createAutoResolveInstallerAdapter(
           downloadArchive,
           getChecksum,
           logger,
-          lockfileRepository,
+          lockfileRepository: lockfileRepo,
           skillsDirs: [swampPath(repoDir, SWAMP_SUBDIRS.pulledSkills)],
           repoDir,
-          force: false,
+          force,
           alreadyPulled: new Set<string>(),
           depth: 0,
           ...(pinnedEntry?.checksum
             ? { expectedChecksum: pinnedEntry.checksum }
             : {}),
         };
-        // W2 (commit 3): route through InstallExtensionService when an
-        // ExtensionRepository is available so phase 8 fires (catalog
-        // populated synchronously, I-Repo-1 fires on `(kind, type)`
-        // collision). When the repository isn't wired (e.g. headless
-        // bootstrap paths), fall back to the pre-W2 free function — the
-        // catalog gets populated lazily on next loader pass.
-        const result = repository !== undefined
+        return repository !== undefined
           ? await new InstallExtensionService({ denoRuntime, repository })
             .execute(ref, installCtx)
           : await installExtension(ref, installCtx);
+      }
+
+      // force: false so installExtension raises ConflictError rather than
+      // silently overwriting any existing files. The service's
+      // inspectInstallation check normally prevents reaching this point
+      // when the extension is already on disk (intact or truncated); the
+      // ConflictError catch below is defence-in-depth for races between
+      // inspect and install that the per-type re-entrancy guard in the
+      // resolver cannot cover (e.g. two types resolving the same
+      // extension concurrently).
+      try {
+        const result = await runInstall(false);
         if (!result) return null;
         return { version: result.version };
       } catch (error) {
         if (error instanceof ConflictError) {
+          const allBundles = error.conflicts.length > 0 &&
+            error.conflicts.every((p) =>
+              isBundleArtifactPath(p.replaceAll("\\", "/"))
+            );
+          if (allBundles) {
+            logger
+              .warn`Auto-install of ${extensionName}: overwriting stale bundle cache (${error.conflicts.length} file(s))`;
+            const retryResult = await runInstall(true);
+            if (!retryResult) return null;
+            return { version: retryResult.version };
+          }
           logger
-            .warn`Auto-install of ${extensionName} failed: bundle files already exist on disk and the type was not registered. To resolve: swamp extension pull ${extensionName} --force`;
+            .warn`Auto-install of ${extensionName} failed: files already exist on disk and the type was not registered. To resolve: swamp extension pull ${extensionName} --force`;
           return null;
         }
         throw error;

--- a/src/cli/auto_resolver_adapters_test.ts
+++ b/src/cli/auto_resolver_adapters_test.ts
@@ -20,7 +20,10 @@
 import { assertEquals } from "@std/assert";
 import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
-import { createAutoResolveInstallerAdapter } from "./auto_resolver_adapters.ts";
+import {
+  createAutoResolveInstallerAdapter,
+  isBundleArtifactPath,
+} from "./auto_resolver_adapters.ts";
 import type { DenoRuntime } from "../domain/runtime/deno_runtime.ts";
 import { ExtensionCatalogStore } from "../infrastructure/persistence/extension_catalog_store.ts";
 import { ExtensionRepository } from "../infrastructure/persistence/extension_repository.ts";
@@ -659,6 +662,58 @@ Deno.test("auto_resolver_adapters: hotLoadModels catalog walk skips types whose 
   } finally {
     await Deno.remove(tmpDir, { recursive: true });
   }
+});
+
+// swamp-club#2050: isBundleArtifactPath must recognise all four bundle
+// stores so the auto-resolver can distinguish bundle-only ConflictErrors
+// (safe to force-overwrite) from source-file conflicts (user WIP).
+
+Deno.test("isBundleArtifactPath: recognises all four bundle stores", () => {
+  assertEquals(isBundleArtifactPath(".swamp/bundles/abc123/x.js"), true);
+  assertEquals(isBundleArtifactPath(".swamp/vault-bundles/abc123/v.js"), true);
+  assertEquals(
+    isBundleArtifactPath(".swamp/datastore-bundles/abc123/ds.js"),
+    true,
+  );
+  assertEquals(
+    isBundleArtifactPath(".swamp/report-bundles/abc123/r.js"),
+    true,
+  );
+});
+
+Deno.test("isBundleArtifactPath: rejects non-bundle paths", () => {
+  assertEquals(
+    isBundleArtifactPath(
+      ".swamp/pulled-extensions/@fake/ext/models/foo.ts",
+    ),
+    false,
+  );
+  assertEquals(
+    isBundleArtifactPath(
+      ".swamp/pulled-extensions/@fake/ext/datastores/bar.ts",
+    ),
+    false,
+  );
+  assertEquals(isBundleArtifactPath(".swamp/definitions/my-model.yaml"), false);
+  assertEquals(isBundleArtifactPath("models/foo.ts"), false);
+});
+
+Deno.test("isBundleArtifactPath: bundle-only conflict set is detected as all-bundles", () => {
+  const conflicts = [
+    ".swamp/bundles/abc123/model.js",
+    ".swamp/vault-bundles/def456/vault.js",
+    ".swamp/datastore-bundles/789ghi/s3.js",
+    ".swamp/report-bundles/jkl012/report.js",
+  ];
+  assertEquals(conflicts.every(isBundleArtifactPath), true);
+});
+
+Deno.test("isBundleArtifactPath: mixed conflict set is not all-bundles", () => {
+  const conflicts = [
+    ".swamp/datastore-bundles/abc123/s3.js",
+    ".swamp/pulled-extensions/@swamp/s3-datastore/datastores/s3.ts",
+  ];
+  assertEquals(conflicts.every(isBundleArtifactPath), false);
 });
 
 Deno.test("auto_resolver_adapters: hotLoadModels catalog walk attempts attach when base is fully loaded", async () => {


### PR DESCRIPTION
## Summary

- When the auto-resolver's `install()` hits a `ConflictError` where **every** conflict path is a regenerable bundle artifact (any of `.swamp/bundles/`, `.swamp/vault-bundles/`, `.swamp/datastore-bundles/`, `.swamp/report-bundles/`), retry with `force: true` instead of failing
- Extracted a `runInstall(force)` helper inside the install adapter to eliminate duplicated install-context construction
- Conflict paths are normalized to forward slashes before the bundle check for Windows compatibility
- Guarded against vacuous truth on empty conflict arrays (`length > 0 &&`)

## Context

The #2037 fix (PR #2388) upgraded the `ConflictError` log from `debug` to `warn` but still failed the install uniformly. Bundle files are regenerable cache — the managedConfig deployment scenario where an init container writes bundles to the default path, then serve re-downloads hitting stale bundles, should succeed rather than requiring manual `--force` intervention.

## Test plan

- [x] 4 new unit tests for `isBundleArtifactPath` covering all four bundle stores, non-bundle paths, bundle-only conflict sets, and mixed conflict sets
- [x] All 22 tests in `auto_resolver_adapters_test.ts` pass
- [x] Full build verification: 9/9 steps passed (lint, fmt, type-check, 11,336 tests, compile, deps audit, binary check)
- [x] Code review: VERDICT: pass
- [x] Adversarial review ran in prior verification rounds (caught Windows backslash bug + code duplication — both fixed); skipped by guard on final commit (filed #2052 for the guard gap)

Fixes swamp-club#2050

🤖 Generated with [Claude Code](https://claude.com/claude-code)