### PR TITLE
feat(model): expose configured method arguments

### DIFF
--- a/src/libswamp/models/get.ts
+++ b/src/libswamp/models/get.ts
@@ -49,6 +49,10 @@ export interface ModelGetData {
   typeVersion?: string;
   globalArgumentsSchema?: object;
   methods?: MethodDescribeData[];
+  configuredMethods?: Record<
+    string,
+    { arguments: Record<string, unknown> }
+  >;
 }
 
 export type ModelGetEvent =
@@ -130,6 +134,20 @@ export async function* modelGet(
         )
         : definition.globalArguments;
 
+      const configuredMethods: Record<
+        string,
+        { arguments: Record<string, unknown> }
+      > = {};
+      for (const [name, methodData] of Object.entries(definition.methodData)) {
+        if (methodData.arguments === undefined) continue;
+        const schema = modelDef?.methods[name]?.arguments;
+        configuredMethods[name] = {
+          arguments: schema
+            ? redactSensitiveValues(schema, methodData.arguments)
+            : methodData.arguments,
+        };
+      }
+
       const data: ModelGetData = {
         id: definition.id,
         name: definition.name,
@@ -147,6 +165,9 @@ export async function* modelGet(
           ? Object.entries(modelDef.methods).map(
             ([name, method]) => toMethodDescribeData(name, method),
           )
+          : undefined,
+        configuredMethods: Object.keys(configuredMethods).length > 0
+          ? configuredMethods
           : undefined,
       };
 

--- a/src/libswamp/models/get_test.ts
+++ b/src/libswamp/models/get_test.ts
@@ -55,6 +55,7 @@ const testDefinition = {
   version: 3,
   tags: { env: "prod" },
   globalArguments: { region: "us-east-1" },
+  methodData: {},
 };
 
 const testModelType = {
@@ -87,6 +88,7 @@ Deno.test("modelGet yields resolving -> completed with model data on success", a
         typeVersion: undefined,
         globalArgumentsSchema: undefined,
         methods: undefined,
+        configuredMethods: undefined,
       },
     },
   ]);
@@ -134,6 +136,7 @@ Deno.test("modelGet redacts sensitive global arguments when the schema is known"
         version: 1,
         tags: {},
         globalArguments: { apiKey: "SUPERSECRET123", region: "us-east-1" },
+        methodData: {},
       },
       type: { normalized: "acme/widget" },
     },
@@ -157,6 +160,53 @@ Deno.test("modelGet redacts sensitive global arguments when the schema is known"
   });
 });
 
+Deno.test("modelGet: exposes configured method arguments and redacts sensitive values", async () => {
+  const deps = makeDeps({
+    lookupResult: {
+      definition: {
+        ...testDefinition,
+        methodData: {
+          import: {
+            arguments: {
+              chunkSize: 1000,
+              credentials: { token: "SUPERSECRET123", account: "primary" },
+            },
+          },
+        },
+      },
+      type: testModelType,
+    },
+    modelDef: {
+      version: "2026.05.28.1",
+      globalArguments: z.object({}),
+      methods: {
+        import: {
+          arguments: z.object({
+            chunkSize: z.number(),
+            credentials: z.object({
+              token: z.string().meta({ sensitive: true }),
+              account: z.string(),
+            }),
+          }),
+        },
+      },
+    },
+  });
+
+  const events = await collect<ModelGetEvent>(
+    modelGet(createLibSwampContext(), deps, "my-model"),
+  );
+
+  assertEquals(completedData(events).configuredMethods, {
+    import: {
+      arguments: {
+        chunkSize: 1000,
+        credentials: { token: "***", account: "primary" },
+      },
+    },
+  });
+});
+
 Deno.test("modelGet passes global arguments through unredacted when the model type is unavailable", async () => {
   const deps = makeDeps({
     lookupResult: {
@@ -166,6 +216,7 @@ Deno.test("modelGet passes global arguments through unredacted when the model ty
         version: 1,
         tags: {},
         globalArguments: { apiKey: "SUPERSECRET123" },
+        methodData: {},
       },
       type: { normalized: "acme/widget" },
     },
@@ -178,6 +229,29 @@ Deno.test("modelGet passes global arguments through unredacted when the model ty
 
   assertEquals(completedData(events).globalArguments, {
     apiKey: "SUPERSECRET123",
+  });
+});
+
+Deno.test("modelGet: exposes configured method arguments when the model type is unavailable", async () => {
+  const deps = makeDeps({
+    lookupResult: {
+      definition: {
+        ...testDefinition,
+        methodData: {
+          import: { arguments: { apiKey: "SUPERSECRET123" } },
+        },
+      },
+      type: testModelType,
+    },
+    modelDef: undefined,
+  });
+
+  const events = await collect<ModelGetEvent>(
+    modelGet(createLibSwampContext(), deps, "my-model"),
+  );
+
+  assertEquals(completedData(events).configuredMethods, {
+    import: { arguments: { apiKey: "SUPERSECRET123" } },
   });
 });
 

--- a/src/presentation/output/model_get_output_test.ts
+++ b/src/presentation/output/model_get_output_test.ts
@@ -42,7 +42,12 @@ const testDataWithDescription: ModelGetData = {
 const testDataWithConfiguredMethods: ModelGetData = {
   ...testData,
   configuredMethods: {
-    execute: { arguments: { timeout: 5000 } },
+    execute: {
+      arguments: {
+        timeout: 5000,
+        credentials: { token: "***", account: "primary" },
+      },
+    },
   },
 };
 
@@ -187,6 +192,8 @@ Deno.test("renderModelGet log mode shows configured method arguments", () => {
     assertStringIncludes(combined, "execute:");
     assertStringIncludes(combined, "timeout:");
     assertStringIncludes(combined, "5000");
+    assertStringIncludes(combined, '"token":"***"');
+    assertEquals(combined.includes("[object Object]"), false);
   } finally {
     console.log = originalLog;
   }

--- a/src/presentation/output/model_get_output_test.ts
+++ b/src/presentation/output/model_get_output_test.ts
@@ -39,6 +39,13 @@ const testDataWithDescription: ModelGetData = {
   description: "An echo model for testing",
 };
 
+const testDataWithConfiguredMethods: ModelGetData = {
+  ...testData,
+  configuredMethods: {
+    execute: { arguments: { timeout: 5000 } },
+  },
+};
+
 Deno.test("renderModelGet with json mode outputs valid JSON", () => {
   const logs: string[] = [];
   const originalLog = console.log;
@@ -68,6 +75,20 @@ Deno.test("renderModelGet JSON includes tags and attributes", () => {
     assertEquals(parsed.tags.env, "test");
     assertEquals(parsed.tags.project, "demo");
     assertEquals(parsed.globalArguments.message, "Hello World");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelGet JSON includes configured method arguments", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelGet(testDataWithConfiguredMethods, "json");
+    const parsed = JSON.parse(logs[0]);
+    assertEquals(parsed.configuredMethods.execute.arguments.timeout, 5000);
   } finally {
     console.log = originalLog;
   }
@@ -149,6 +170,23 @@ Deno.test("renderModelGet log mode shows model details", () => {
     assertStringIncludes(combined, "env:");
     assertStringIncludes(combined, "Global Arguments:");
     assertStringIncludes(combined, "message:");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+Deno.test("renderModelGet log mode shows configured method arguments", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (msg: string) => logs.push(msg);
+
+  try {
+    renderModelGet(testDataWithConfiguredMethods, "log");
+    const combined = stripAnsiCode(logs.join("\n"));
+    assertStringIncludes(combined, "Configured Method Arguments:");
+    assertStringIncludes(combined, "execute:");
+    assertStringIncludes(combined, "timeout:");
+    assertStringIncludes(combined, "5000");
   } finally {
     console.log = originalLog;
   }

--- a/src/presentation/renderers/model_get.ts
+++ b/src/presentation/renderers/model_get.ts
@@ -177,6 +177,15 @@ class LogModelGetRenderer implements Renderer<ModelGetEvent> {
           lines.push(...formatMethodLines(data.methods));
         }
 
+        if (data.configuredMethods) {
+          lines.push("");
+          lines.push(bold(cyan("Configured Method Arguments:")));
+          for (const [name, method] of Object.entries(data.configuredMethods)) {
+            lines.push(`  ${bold(cyan(name))}:`);
+            lines.push(...formatRecord(method.arguments, "    "));
+          }
+        }
+
         writeOutput(lines.join("\n"));
       },
       error: (e) => {

--- a/src/presentation/renderers/model_get.ts
+++ b/src/presentation/renderers/model_get.ts
@@ -113,7 +113,13 @@ function formatRecord(
   indent: string,
 ): string[] {
   return Object.entries(record).map(([key, value]) =>
-    `${indent}${key}: ${dim(String(value))}`
+    `${indent}${key}: ${
+      dim(
+        value !== null && typeof value === "object"
+          ? JSON.stringify(value)
+          : String(value),
+      )
+    }`
   );
 }
 


### PR DESCRIPTION
## Summary

- expose definition-configured method arguments in `swamp model get --json`
- redact configured sensitive values using each method schema
- render configured method arguments in log mode, including nested values

## Test Plan

- verification workflows passed: build, reviews, and skills
- posted swamp-club attestation `289fc713-9883-48cd-9445-943b005da523` for `f9b0593d9af8e0467e48f10ab4c6ff18fade613b`