### PR TITLE
fix(verification): add src/cli/ to adversarial review guard (swamp-club#2052)

### DIFF
--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -57,7 +57,7 @@ Reviews are guarded by file path — they skip when no relevant files changed:
 | Review | Guard (run when any match) | Model |
 | --- | --- | --- |
 | code-review | always | claude-opus-4-6 |
-| adversarial-review | `src/domain/`, `src/infrastructure/`, `src/libswamp/`, `src/serve/`, `src/worker/` | claude-opus-4-6 |
+| adversarial-review | `src/cli/`, `src/domain/`, `src/infrastructure/`, `src/libswamp/`, `src/serve/`, `src/worker/` | claude-opus-4-6 |
 | ux-review | `src/cli/commands/`, `src/presentation/`, `src/domain/errors.ts`, `src/libswamp/` | claude-sonnet-4-6 |
 | ci-security-review | `.github/workflows/` | claude-opus-4-6 |
 

--- a/verification/workflow-verify-reviews.yaml
+++ b/verification/workflow-verify-reviews.yaml
@@ -112,7 +112,7 @@ jobs:
             workingDir: "/tmp/swamp-verify-reviews-${{ run.id }}"
 
       - name: adversarial-review
-        guard: "${{ data.latest('repo', 'diff').attributes.files.filter(f, f.startsWith('src/domain/') || f.startsWith('src/infrastructure/') || f.startsWith('src/libswamp/') || f.startsWith('src/serve/') || f.startsWith('src/worker/')).size() == 0 }}"
+        guard: "${{ data.latest('repo', 'diff').attributes.files.filter(f, f.startsWith('src/cli/') || f.startsWith('src/domain/') || f.startsWith('src/infrastructure/') || f.startsWith('src/libswamp/') || f.startsWith('src/serve/') || f.startsWith('src/worker/')).size() == 0 }}"
         task:
           type: model_method
           modelType: "command/shell"


### PR DESCRIPTION
## Summary

- Add `f.startsWith('src/cli/')` to the adversarial review guard in `verification/workflow-verify-reviews.yaml` so CLI infrastructure files (auth_context.ts, auto_resolver_adapters.ts, control_plane_vault.ts, load_identity.ts, repo_context.ts, resolve_datastore.ts) receive adversarial review coverage
- Update the guard table in `agent-constraints/verification-conventions.md` to match

## Context

The adversarial review guard only matched `src/domain/`, `src/infrastructure/`, `src/libswamp/`, `src/serve/`, `src/worker/`. Files in `src/cli/` outside `src/cli/commands/` — which contain security-relevant infrastructure code — skipped adversarial review entirely. This was an original omission when the guard was introduced in commit 66f1a629.

Discovered during #2050 verification where the adversarial review caught real bugs in earlier rounds but was skipped by guard on the final commit.

Closes swamp-club#2052

## Test plan

- [x] Verification passed: lint, fmt, type-check, tests (11356 passed), vuln-scan, compile, binary-check, code review (VERDICT: pass)
- [x] Adversarial, UX, CI security, and skill reviews correctly skipped by guard (no matching file changes)
- [x] Attestation posted to swamp-club

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>