### PR TITLE
fix(tests): add CEL type keywords to property test exclusion set (swamp-club#2054)

### DIFF
--- a/src/infrastructure/cel/cel_evaluator_property_test.ts
+++ b/src/infrastructure/cel/cel_evaluator_property_test.ts
@@ -75,6 +75,14 @@ const CEL_RESERVED = new Set([
   "matches",
   "size",
   "type",
+  // cel-js type keywords resolve as type references, not variable lookups
+  "bool",
+  "bytes",
+  "double",
+  "int",
+  "list",
+  "string",
+  "uint",
 ]);
 
 const arbIdent = fc


### PR DESCRIPTION
## Summary

- Add 7 missing CEL type keywords (`bool`, `bytes`, `double`, `int`, `list`, `string`, `uint`) to the `CEL_RESERVED` exclusion set in `cel_evaluator_property_test.ts`
- cel-js resolves bare type keywords as type references (returning `{}`) rather than context variable lookups, causing non-deterministic property test failures when fast-check's seed generates one of these as an identifier

## Test plan

- [x] Property test `CelEvaluator.evaluate: embedded interpolation yields the literal text with values substituted, stably` passes consistently
- [x] All 7 property tests in `cel_evaluator_property_test.ts` pass
- [x] Full verification suite green (lint, fmt, type-check, tests, compile, code review, adversarial review)

Closes swamp-club#2054

🤖 Generated with [Claude Code](https://claude.com/claude-code)