### PR TITLE
fix(paths): fall back to USERPROFILE for config directory

### DIFF
--- a/src/infrastructure/persistence/paths.ts
+++ b/src/infrastructure/persistence/paths.ts
@@ -344,10 +344,10 @@ export function getSwampDataDir(): string {
  * Resolution order:
  * 1. `SWAMP_HOME` — if set, returns `$SWAMP_HOME/config`.
  * 2. `XDG_CONFIG_HOME` — returns `$XDG_CONFIG_HOME/swamp/`.
- * 3. `HOME` — falls back to `~/.config/swamp/`.
+ * 3. `HOME` / `USERPROFILE` — falls back to `~/.config/swamp/`.
  *
  * @returns The absolute path to the swamp config directory
- * @throws Error if neither SWAMP_HOME nor HOME is set
+ * @throws Error if neither SWAMP_HOME, HOME, nor USERPROFILE is set
  */
 export function getSwampConfigDir(): string {
   const swampHome = Deno.env.get("SWAMP_HOME");
@@ -360,9 +360,11 @@ export function getSwampConfigDir(): string {
     return join(xdgConfigHome, "swamp");
   }
 
-  const home = Deno.env.get("HOME");
+  const home = Deno.env.get("HOME") ?? Deno.env.get("USERPROFILE");
   if (!home) {
-    throw new Error("HOME environment variable is not set");
+    throw new Error(
+      "Cannot determine config directory: neither HOME nor USERPROFILE is set",
+    );
   }
   return join(home, ".config", "swamp");
 }
@@ -376,7 +378,7 @@ export function getSwampConfigDir(): string {
  *
  * @returns The absolute path to `<config>/telemetry` (XDG-aware via
  *   {@link getSwampConfigDir})
- * @throws Error if HOME environment variable is not set
+ * @throws Error if no user home environment variable is set
  */
 export function globalTelemetryDir(): string {
   return join(getSwampConfigDir(), SWAMP_SUBDIRS.telemetry);

--- a/src/infrastructure/persistence/paths_test.ts
+++ b/src/infrastructure/persistence/paths_test.ts
@@ -198,24 +198,59 @@ Deno.test("getSwampConfigDir falls back to HOME/.config/swamp", () => {
   }
 });
 
-Deno.test("getSwampConfigDir throws when neither SWAMP_HOME nor HOME is set", () => {
+Deno.test("getSwampConfigDir falls back to USERPROFILE/.config/swamp", () => {
+  const saved = {
+    swampHome: Deno.env.get("SWAMP_HOME"),
+    xdg: Deno.env.get("XDG_CONFIG_HOME"),
+    home: Deno.env.get("HOME"),
+    profile: Deno.env.get("USERPROFILE"),
+  };
+  try {
+    Deno.env.delete("SWAMP_HOME");
+    Deno.env.delete("XDG_CONFIG_HOME");
+    Deno.env.delete("HOME");
+    Deno.env.set("USERPROFILE", "C:\\Users\\testuser");
+    assertPathEquals(
+      getSwampConfigDir(),
+      "C:\\Users\\testuser/.config/swamp",
+    );
+  } finally {
+    if (saved.swampHome !== undefined) {
+      Deno.env.set("SWAMP_HOME", saved.swampHome);
+    } else Deno.env.delete("SWAMP_HOME");
+    if (saved.xdg !== undefined) Deno.env.set("XDG_CONFIG_HOME", saved.xdg);
+    else Deno.env.delete("XDG_CONFIG_HOME");
+    if (saved.home !== undefined) Deno.env.set("HOME", saved.home);
+    else Deno.env.delete("HOME");
+    if (saved.profile !== undefined) {
+      Deno.env.set("USERPROFILE", saved.profile);
+    } else Deno.env.delete("USERPROFILE");
+  }
+});
+
+Deno.test("getSwampConfigDir throws when no home environment variable is set", () => {
   const originalXdg = Deno.env.get("XDG_CONFIG_HOME");
   const originalHome = Deno.env.get("HOME");
+  const originalProfile = Deno.env.get("USERPROFILE");
   const originalSwampHome = Deno.env.get("SWAMP_HOME");
   try {
     Deno.env.delete("SWAMP_HOME");
     Deno.env.delete("XDG_CONFIG_HOME");
     Deno.env.delete("HOME");
+    Deno.env.delete("USERPROFILE");
     assertThrows(
       () => getSwampConfigDir(),
       Error,
-      "HOME environment variable is not set",
+      "Cannot determine config directory: neither HOME nor USERPROFILE is set",
     );
   } finally {
     if (originalXdg !== undefined) Deno.env.set("XDG_CONFIG_HOME", originalXdg);
     else Deno.env.delete("XDG_CONFIG_HOME");
     if (originalHome !== undefined) Deno.env.set("HOME", originalHome);
     else Deno.env.delete("HOME");
+    if (originalProfile !== undefined) {
+      Deno.env.set("USERPROFILE", originalProfile);
+    } else Deno.env.delete("USERPROFILE");
     if (originalSwampHome !== undefined) {
       Deno.env.set("SWAMP_HOME", originalSwampHome);
     } else Deno.env.delete("SWAMP_HOME");


### PR DESCRIPTION
## Summary

- resolve the Swamp config directory from `USERPROFILE` when `HOME` is unavailable
- preserve existing `SWAMP_HOME` and `XDG_CONFIG_HOME` precedence
- add cross-platform path-resolution coverage

Fixes swamp-club#2053.

## Test Plan

- `deno run test src/infrastructure/persistence/paths_test.ts`
- locally compiled CLI reproduction with `HOME` unset and `USERPROFILE` set
- `verify-build`, `verify-reviews`, and `verify-skills` workflows