### PR TITLE
fix(tests): avoid reentrant SIGINT delivery

### DIFF
--- a/src/infrastructure/process/shutdown_handlers_test.ts
+++ b/src/infrastructure/process/shutdown_handlers_test.ts
@@ -55,8 +55,10 @@ Deno.test({
             },
             includePosixSignals: false,
           });
-          // Re-raise SIGINT to exercise the new handler.
-          Deno.kill(Deno.pid, "SIGINT");
+          // Re-raise after this callback returns. Delivering a signal while
+          // Deno is still dispatching the original one can fall through to
+          // the default SIGINT handler during listener teardown.
+          setTimeout(() => Deno.kill(Deno.pid, "SIGINT"), 0);
         },
       });
 


### PR DESCRIPTION
## Summary

- Defer the replacement SIGINT until the initial handler callback returns.
- Preserve the POSIX shutdown-handler disposal and re-registration coverage.

## Test Plan

- `deno run test src/infrastructure/process/shutdown_handlers_test.ts` (30 consecutive runs)
- Preserved scratch reproduction (100 direct and 100 child-process runs)
- `verify-build`, `verify-reviews`, and `verify-skills` workflows