### PR TITLE
fix(editor): announce blocking launches

### DIFF
--- a/src/cli/commands/issue_bug.ts
+++ b/src/cli/commands/issue_bug.ts
@@ -200,7 +200,14 @@ export const issueBugCommand = new Command()
         const template = buildBugTemplate();
         await Deno.writeTextFile(tempFile, template);
         ctx.logger.debug`Opening editor for bug report`;
-        await editorService.openFile(tempFile, { wait: true });
+        const launch = await editorService.prepareOpenFile(tempFile, {
+          wait: true,
+        });
+        ctx.logger.info(
+          "Opening {editor} and waiting for it to close. To submit without an editor, use --title and --body.",
+          { editor: launch.editor },
+        );
+        await launch.open();
 
         const content = await Deno.readTextFile(tempFile);
         const parsed = parseBugContent(content, template);

--- a/src/cli/commands/issue_edit.ts
+++ b/src/cli/commands/issue_edit.ts
@@ -199,7 +199,14 @@ export const issueEditCommand = new Command()
           buildEditTemplate(current.title, current.body, current.type),
         );
         ctx.logger.debug`Opening editor to edit issue #${issueNumber}`;
-        await new EditorService().openFile(tempFile, { wait: true });
+        const launch = await new EditorService().prepareOpenFile(tempFile, {
+          wait: true,
+        });
+        ctx.logger.info(
+          "Opening {editor} and waiting for it to close. To edit without an editor, use --title, --body, or --type.",
+          { editor: launch.editor },
+        );
+        await launch.open();
 
         const content = await Deno.readTextFile(tempFile);
         const parsed = parseEditContent(content);

--- a/src/cli/commands/issue_feature.ts
+++ b/src/cli/commands/issue_feature.ts
@@ -193,7 +193,14 @@ export const issueFeatureCommand = new Command()
       try {
         await Deno.writeTextFile(tempFile, FEATURE_TEMPLATE);
         ctx.logger.debug`Opening editor for feature request`;
-        await editorService.openFile(tempFile, { wait: true });
+        const launch = await editorService.prepareOpenFile(tempFile, {
+          wait: true,
+        });
+        ctx.logger.info(
+          "Opening {editor} and waiting for it to close. To submit without an editor, use --title and --body.",
+          { editor: launch.editor },
+        );
+        await launch.open();
 
         const content = await Deno.readTextFile(tempFile);
         const parsed = parseFeatureContent(content);

--- a/src/cli/commands/issue_ripple.ts
+++ b/src/cli/commands/issue_ripple.ts
@@ -124,7 +124,14 @@ export const issueRippleCommand = new Command()
       try {
         await Deno.writeTextFile(tempFile, RIPPLE_TEMPLATE);
         ctx.logger.debug`Opening editor for ripple on issue #${issueNumber}`;
-        await new EditorService().openFile(tempFile, { wait: true });
+        const launch = await new EditorService().prepareOpenFile(tempFile, {
+          wait: true,
+        });
+        ctx.logger.info(
+          "Opening {editor} and waiting for it to close. To post without an editor, use --body.",
+          { editor: launch.editor },
+        );
+        await launch.open();
 
         const content = await Deno.readTextFile(tempFile);
         const parsed = parseRippleContent(content);

--- a/src/cli/commands/issue_security.ts
+++ b/src/cli/commands/issue_security.ts
@@ -199,7 +199,14 @@ export const issueSecurityCommand = new Command()
       try {
         await Deno.writeTextFile(tempFile, SECURITY_TEMPLATE);
         ctx.logger.debug`Opening editor for security report`;
-        await editorService.openFile(tempFile, { wait: true });
+        const launch = await editorService.prepareOpenFile(tempFile, {
+          wait: true,
+        });
+        ctx.logger.info(
+          "Opening {editor} and waiting for it to close. To submit without an editor, use --title and --body.",
+          { editor: launch.editor },
+        );
+        await launch.open();
 
         const content = await Deno.readTextFile(tempFile);
         const parsed = parseSecurityContent(content);

--- a/src/infrastructure/editor/editor_service.ts
+++ b/src/infrastructure/editor/editor_service.ts
@@ -28,6 +28,15 @@ export interface EditorResult {
 }
 
 /**
+ * A resolved editor process that can be announced before it is started.
+ */
+export interface EditorLaunch {
+  editor: string;
+  waitsForExit: boolean;
+  open: () => Promise<EditorResult>;
+}
+
+/**
  * Options for opening a file in an editor.
  */
 export interface OpenFileOptions {
@@ -109,32 +118,48 @@ export class EditorService {
     filePath: string,
     options: OpenFileOptions = {},
   ): Promise<EditorResult> {
+    const launch = await this.prepareOpenFile(filePath, options);
+    return await launch.open();
+  }
+
+  /**
+   * Resolves an editor launch without starting its process.
+   */
+  async prepareOpenFile(
+    filePath: string,
+    options: OpenFileOptions = {},
+  ): Promise<EditorLaunch> {
     const editor = await this.findEditor();
 
     // Determine whether to wait: use explicit option, or auto-detect based on editor type
     const shouldWait = options.wait ?? this.isTerminalEditor(editor);
 
     const args = this.buildEditorArgs(editor, filePath, { wait: shouldWait });
-
-    const command = new Deno.Command(args[0], {
-      args: args.slice(1),
-      stdin: "inherit",
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-
-    if (shouldWait) {
-      // Wait for the editor to close (terminal editors)
-      const process = command.spawn();
-      await process.status;
-    } else {
-      // Spawn and return immediately (GUI editors)
-      command.spawn();
-    }
-
     return {
       editor: this.getEditorDisplayName(editor),
-      path: filePath,
+      waitsForExit: shouldWait,
+      open: async () => {
+        const command = new Deno.Command(args[0], {
+          args: args.slice(1),
+          stdin: "inherit",
+          stdout: "inherit",
+          stderr: "inherit",
+        });
+
+        if (shouldWait) {
+          // Wait for the editor to close (terminal editors)
+          const process = command.spawn();
+          await process.status;
+        } else {
+          // Spawn and return immediately (GUI editors)
+          command.spawn();
+        }
+
+        return {
+          editor: this.getEditorDisplayName(editor),
+          path: filePath,
+        };
+      },
     };
   }
 

--- a/src/infrastructure/editor/editor_service_test.ts
+++ b/src/infrastructure/editor/editor_service_test.ts
@@ -55,6 +55,19 @@ Deno.test("EditorService.findEditor handles $EDITOR with arguments", async () =>
   }
 });
 
+Deno.test("EditorService.prepareOpenFile exposes wait state before launching", async () => {
+  const service = new class extends EditorService {
+    override findEditor(): Promise<string> {
+      return Promise.resolve("code --reuse-window");
+    }
+  }();
+  const launch = await service.prepareOpenFile("/tmp/definition.yaml", {
+    wait: true,
+  });
+  assertEquals(launch.editor, "VS Code");
+  assertEquals(launch.waitsForExit, true);
+});
+
 Deno.test("EditorService.findEditor falls back when $EDITOR is not available", async () => {
   const originalEditor = Deno.env.get("EDITOR");
   try {

--- a/src/libswamp/models/edit.ts
+++ b/src/libswamp/models/edit.ts
@@ -28,7 +28,10 @@ import {
 import type { ModelType } from "../../domain/models/model_type.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import { YamlDefinitionRepository } from "../../infrastructure/persistence/yaml_definition_repository.ts";
-import { EditorService } from "../../infrastructure/editor/editor_service.ts";
+import {
+  type EditorLaunch,
+  EditorService,
+} from "../../infrastructure/editor/editor_service.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
@@ -48,6 +51,10 @@ export interface ModelEditData {
 
 export type ModelEditEvent =
   | { kind: "resolving" }
+  | {
+    kind: "launching";
+    data: { editor: string; path: string; waitsForExit: boolean };
+  }
   | { kind: "completed"; data: ModelEditData }
   | { kind: "error"; error: SwampError };
 
@@ -64,7 +71,7 @@ export interface ModelEditDeps {
   ) => Promise<{ definition: Definition; type: ModelType } | null>;
   resolveSymlink: (name: string) => Promise<string | null>;
   getDefinitionPath: (type: ModelType, id: DefinitionId) => string;
-  openEditor: (path: string) => Promise<{ editor: string }>;
+  prepareEditor: (path: string) => Promise<EditorLaunch>;
   updateFromStdin: (
     definition: Definition,
     type: ModelType,
@@ -88,10 +95,7 @@ export function createModelEditDeps(repoDir: string): ModelEditDeps {
       }
     },
     getDefinitionPath: (type, id) => definitionRepo.getPath(type, id),
-    openEditor: async (path) => {
-      const result = await editorService.openFile(path);
-      return { editor: result.editor };
-    },
+    prepareEditor: (path) => editorService.prepareOpenFile(path),
     updateFromStdin: async (definition, type, content) => {
       const yamlData = parseYaml(content) as DefinitionData;
       yamlData.id = definition.id;
@@ -195,7 +199,16 @@ export async function* modelEdit(
 
       // Editor mode
       ctx.logger.debug`Opening file: ${filePath}`;
-      const result = await deps.openEditor(filePath);
+      const launch = await deps.prepareEditor(filePath);
+      yield {
+        kind: "launching",
+        data: {
+          editor: launch.editor,
+          path: filePath,
+          waitsForExit: launch.waitsForExit,
+        },
+      };
+      const result = await launch.open();
 
       yield {
         kind: "completed",

--- a/src/libswamp/models/edit_test.ts
+++ b/src/libswamp/models/edit_test.ts
@@ -22,12 +22,21 @@ import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import { modelEdit, type ModelEditDeps, type ModelEditEvent } from "./edit.ts";
 
+function prepareEditor(editor: string) {
+  return (path: string) =>
+    Promise.resolve({
+      editor,
+      waitsForExit: false,
+      open: () => Promise.resolve({ editor, path }),
+    });
+}
+
 function makeDeps(overrides: Partial<ModelEditDeps> = {}): ModelEditDeps {
   return {
     lookupDefinition: () => Promise.resolve(null),
     resolveSymlink: () => Promise.resolve(null),
     getDefinitionPath: () => "/fake/path/definition.yaml",
-    openEditor: () => Promise.resolve({ editor: "VS Code" }),
+    prepareEditor: prepareEditor("VS Code"),
     updateFromStdin: () =>
       Promise.resolve(
         {
@@ -74,7 +83,7 @@ Deno.test("modelEdit: opens editor when model found", async () => {
         type: testModelType,
       }),
     getDefinitionPath: () => "/repo/models/my-model/definition.yaml",
-    openEditor: () => Promise.resolve({ editor: "Neovim" }),
+    prepareEditor: prepareEditor("Neovim"),
   });
 
   const events = await collect<ModelEditEvent>(
@@ -85,6 +94,14 @@ Deno.test("modelEdit: opens editor when model found", async () => {
 
   assertEquals(events, [
     { kind: "resolving" },
+    {
+      kind: "launching",
+      data: {
+        editor: "Neovim",
+        path: "/repo/models/my-model/definition.yaml",
+        waitsForExit: false,
+      },
+    },
     {
       kind: "completed",
       data: {
@@ -99,6 +116,43 @@ Deno.test("modelEdit: opens editor when model found", async () => {
   ]);
 });
 
+Deno.test("modelEdit: announces editor launch before opening", async () => {
+  let opened = false;
+  const deps = makeDeps({
+    lookupDefinition: () =>
+      Promise.resolve({ definition: testDefinition, type: testModelType }),
+    getDefinitionPath: () => "/repo/models/my-model/definition.yaml",
+    prepareEditor: (path) =>
+      Promise.resolve({
+        editor: "VS Code",
+        waitsForExit: true,
+        open: () => {
+          opened = true;
+          return Promise.resolve({ editor: "VS Code", path });
+        },
+      }),
+  });
+
+  const iterator = modelEdit(createLibSwampContext(), deps, {
+    modelIdOrName: "my-model",
+  })[Symbol.asyncIterator]();
+
+  await iterator.next();
+  const launch = await iterator.next();
+  assertEquals(launch.value, {
+    kind: "launching",
+    data: {
+      editor: "VS Code",
+      path: "/repo/models/my-model/definition.yaml",
+      waitsForExit: true,
+    },
+  });
+  assertEquals(opened, false);
+
+  await iterator.next();
+  assertEquals(opened, true);
+});
+
 Deno.test("modelEdit: falls back to symlink when lookup fails", async () => {
   const deps = makeDeps({
     lookupDefinition: () => {
@@ -106,7 +160,7 @@ Deno.test("modelEdit: falls back to symlink when lookup fails", async () => {
     },
     resolveSymlink: () =>
       Promise.resolve("/repo/extensions/models/broken/definition.yaml"),
-    openEditor: () => Promise.resolve({ editor: "VS Code" }),
+    prepareEditor: prepareEditor("VS Code"),
   });
 
   const events = await collect<ModelEditEvent>(
@@ -117,6 +171,14 @@ Deno.test("modelEdit: falls back to symlink when lookup fails", async () => {
 
   assertEquals(events, [
     { kind: "resolving" },
+    {
+      kind: "launching",
+      data: {
+        editor: "VS Code",
+        path: "/repo/extensions/models/broken/definition.yaml",
+        waitsForExit: false,
+      },
+    },
     {
       kind: "completed",
       data: {

--- a/src/libswamp/vaults/edit.ts
+++ b/src/libswamp/vaults/edit.ts
@@ -19,7 +19,10 @@
 
 import { YamlVaultConfigRepository } from "../../infrastructure/persistence/yaml_vault_config_repository.ts";
 import { join } from "@std/path";
-import { EditorService } from "../../infrastructure/editor/editor_service.ts";
+import {
+  type EditorLaunch,
+  EditorService,
+} from "../../infrastructure/editor/editor_service.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
@@ -45,6 +48,10 @@ export interface VaultEditData {
 
 export type VaultEditEvent =
   | { kind: "resolving" }
+  | {
+    kind: "launching";
+    data: { editor: string; path: string; waitsForExit: boolean };
+  }
   | { kind: "completed"; data: VaultEditData }
   | { kind: "error"; error: SwampError };
 
@@ -61,7 +68,7 @@ export interface VaultEditDeps {
   findAll: () => Promise<VaultEditConfigInfo[]>;
   getVaultPath: (config: VaultEditConfigInfo) => string;
   fileExists: (path: string) => Promise<boolean>;
-  openEditor: (path: string) => Promise<{ editor: string }>;
+  prepareEditor: (path: string) => Promise<EditorLaunch>;
 }
 
 /** Wires real infrastructure into VaultEditDeps. */
@@ -83,10 +90,7 @@ export function createVaultEditDeps(repoDir: string): VaultEditDeps {
         throw error;
       }
     },
-    openEditor: async (path) => {
-      const result = await editorService.openFile(path);
-      return { editor: result.editor };
-    },
+    prepareEditor: (path) => editorService.prepareOpenFile(path),
   };
 }
 
@@ -158,7 +162,16 @@ export async function* vaultEdit(
       }
 
       ctx.logger.debug`Opening file: ${filePath}`;
-      const result = await deps.openEditor(filePath);
+      const launch = await deps.prepareEditor(filePath);
+      yield {
+        kind: "launching",
+        data: {
+          editor: launch.editor,
+          path: filePath,
+          waitsForExit: launch.waitsForExit,
+        },
+      };
+      const result = await launch.open();
 
       yield {
         kind: "completed",

--- a/src/libswamp/vaults/edit_test.ts
+++ b/src/libswamp/vaults/edit_test.ts
@@ -22,6 +22,15 @@ import { collect } from "../testing.ts";
 import { createLibSwampContext } from "../context.ts";
 import { vaultEdit, type VaultEditDeps, type VaultEditEvent } from "./edit.ts";
 
+function prepareEditor(editor: string) {
+  return (path: string) =>
+    Promise.resolve({
+      editor,
+      waitsForExit: false,
+      open: () => Promise.resolve({ editor, path }),
+    });
+}
+
 function makeDeps(overrides: Partial<VaultEditDeps> = {}): VaultEditDeps {
   return {
     findByName: () => Promise.resolve(null),
@@ -29,7 +38,7 @@ function makeDeps(overrides: Partial<VaultEditDeps> = {}): VaultEditDeps {
     findAll: () => Promise.resolve([]),
     getVaultPath: () => "/fake/path/vault.yaml",
     fileExists: () => Promise.resolve(true),
-    openEditor: () => Promise.resolve({ editor: "VS Code" }),
+    prepareEditor: prepareEditor("VS Code"),
     ...overrides,
   };
 }
@@ -60,7 +69,7 @@ Deno.test("vaultEdit: opens editor when vault found by name", async () => {
   const deps = makeDeps({
     findByName: () => Promise.resolve(testVaultConfig),
     getVaultPath: () => "/repo/vaults/env/vault-1.yaml",
-    openEditor: () => Promise.resolve({ editor: "Neovim" }),
+    prepareEditor: prepareEditor("Neovim"),
   });
 
   const events = await collect<VaultEditEvent>(
@@ -71,6 +80,14 @@ Deno.test("vaultEdit: opens editor when vault found by name", async () => {
 
   assertEquals(events, [
     { kind: "resolving" },
+    {
+      kind: "launching",
+      data: {
+        editor: "Neovim",
+        path: "/repo/vaults/env/vault-1.yaml",
+        waitsForExit: false,
+      },
+    },
     {
       kind: "completed",
       data: {
@@ -84,12 +101,48 @@ Deno.test("vaultEdit: opens editor when vault found by name", async () => {
   ]);
 });
 
+Deno.test("vaultEdit: announces editor launch before opening", async () => {
+  let opened = false;
+  const deps = makeDeps({
+    findByName: () => Promise.resolve(testVaultConfig),
+    getVaultPath: () => "/repo/vaults/env/vault-1.yaml",
+    prepareEditor: (path) =>
+      Promise.resolve({
+        editor: "VS Code",
+        waitsForExit: true,
+        open: () => {
+          opened = true;
+          return Promise.resolve({ editor: "VS Code", path });
+        },
+      }),
+  });
+
+  const iterator = vaultEdit(createLibSwampContext(), deps, {
+    vaultNameOrId: "my-vault",
+  })[Symbol.asyncIterator]();
+
+  await iterator.next();
+  const launch = await iterator.next();
+  assertEquals(launch.value, {
+    kind: "launching",
+    data: {
+      editor: "VS Code",
+      path: "/repo/vaults/env/vault-1.yaml",
+      waitsForExit: true,
+    },
+  });
+  assertEquals(opened, false);
+
+  await iterator.next();
+  assertEquals(opened, true);
+});
+
 Deno.test("vaultEdit: finds vault by ID when name lookup fails", async () => {
   const deps = makeDeps({
     findByName: () => Promise.resolve(null),
     findAll: () => Promise.resolve([testVaultConfig]),
     getVaultPath: () => "/repo/vaults/env/vault-1.yaml",
-    openEditor: () => Promise.resolve({ editor: "VS Code" }),
+    prepareEditor: prepareEditor("VS Code"),
   });
 
   const events = await collect<VaultEditEvent>(
@@ -98,7 +151,7 @@ Deno.test("vaultEdit: finds vault by ID when name lookup fails", async () => {
     }),
   );
 
-  const completed = events[1] as Extract<
+  const completed = events[2] as Extract<
     VaultEditEvent,
     { kind: "completed" }
   >;
@@ -115,7 +168,7 @@ Deno.test("vaultEdit: finds vault by ID with type hint", async () => {
       return Promise.resolve(null);
     },
     getVaultPath: () => "/repo/vaults/env/vault-1.yaml",
-    openEditor: () => Promise.resolve({ editor: "VS Code" }),
+    prepareEditor: prepareEditor("VS Code"),
   });
 
   const events = await collect<VaultEditEvent>(
@@ -125,7 +178,7 @@ Deno.test("vaultEdit: finds vault by ID with type hint", async () => {
     }),
   );
 
-  const completed = events[1] as Extract<
+  const completed = events[2] as Extract<
     VaultEditEvent,
     { kind: "completed" }
   >;

--- a/src/libswamp/workflows/edit.ts
+++ b/src/libswamp/workflows/edit.ts
@@ -28,7 +28,10 @@ import {
   type WorkflowId,
 } from "../../domain/workflows/workflow_id.ts";
 import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
-import { EditorService } from "../../infrastructure/editor/editor_service.ts";
+import {
+  type EditorLaunch,
+  EditorService,
+} from "../../infrastructure/editor/editor_service.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
 import { notFound, validationFailed } from "../errors.ts";
@@ -62,6 +65,10 @@ export interface WorkflowEditData {
 
 export type WorkflowEditEvent =
   | { kind: "resolving" }
+  | {
+    kind: "launching";
+    data: { editor: string; path: string; waitsForExit: boolean };
+  }
   | { kind: "completed"; data: WorkflowEditData }
   | { kind: "error"; error: SwampError };
 
@@ -79,7 +86,7 @@ export interface WorkflowEditDeps {
   getPath: (id: WorkflowId) => string;
   resolveSymlink: (name: string) => Promise<string | null>;
   fileExists: (path: string) => Promise<boolean>;
-  openEditor: (path: string) => Promise<{ editor: string }>;
+  prepareEditor: (path: string) => Promise<EditorLaunch>;
   updateFromStdin: (
     workflow: Workflow,
     content: string,
@@ -116,10 +123,7 @@ export function createWorkflowEditDeps(
         throw error;
       }
     },
-    openEditor: async (path) => {
-      const result = await editorService.openFile(path);
-      return { editor: result.editor };
-    },
+    prepareEditor: (path) => editorService.prepareOpenFile(path),
     updateFromStdin: async (workflow, content) => {
       const yamlData = parseYaml(content) as WorkflowData;
       yamlData.id = workflow.id;
@@ -262,7 +266,16 @@ export async function* workflowEdit(
 
       // Editor mode
       ctx.logger.debug`Opening file: ${filePath}`;
-      const result = await deps.openEditor(filePath);
+      const launch = await deps.prepareEditor(filePath);
+      yield {
+        kind: "launching",
+        data: {
+          editor: launch.editor,
+          path: filePath,
+          waitsForExit: launch.waitsForExit,
+        },
+      };
+      const result = await launch.open();
 
       yield {
         kind: "completed",

--- a/src/libswamp/workflows/edit_test.ts
+++ b/src/libswamp/workflows/edit_test.ts
@@ -27,6 +27,15 @@ import {
 } from "./edit.ts";
 import type { Workflow } from "../../domain/workflows/workflow.ts";
 
+function prepareEditor(editor: string) {
+  return (path: string) =>
+    Promise.resolve({
+      editor,
+      waitsForExit: false,
+      open: () => Promise.resolve({ editor, path }),
+    });
+}
+
 function makeDeps(
   overrides: Partial<WorkflowEditDeps> = {},
 ): WorkflowEditDeps {
@@ -37,7 +46,7 @@ function makeDeps(
     getPath: () => "/fake/path/workflow.yaml",
     resolveSymlink: () => Promise.resolve(null),
     fileExists: () => Promise.resolve(true),
-    openEditor: () => Promise.resolve({ editor: "VS Code" }),
+    prepareEditor: prepareEditor("VS Code"),
     updateFromStdin: () =>
       Promise.resolve(
         {
@@ -92,7 +101,7 @@ Deno.test("workflowEdit: opens editor when workflow found by name", async () => 
   const deps = makeDeps({
     findByName: () => Promise.resolve(testWorkflow),
     getPath: () => "/repo/workflows/deploy-workflow/workflow.yaml",
-    openEditor: () => Promise.resolve({ editor: "Neovim" }),
+    prepareEditor: prepareEditor("Neovim"),
   });
 
   const events = await collect<WorkflowEditEvent>(
@@ -103,6 +112,14 @@ Deno.test("workflowEdit: opens editor when workflow found by name", async () => 
 
   assertEquals(events, [
     { kind: "resolving" },
+    {
+      kind: "launching",
+      data: {
+        editor: "Neovim",
+        path: "/repo/workflows/deploy-workflow/workflow.yaml",
+        waitsForExit: false,
+      },
+    },
     {
       kind: "completed",
       data: {
@@ -116,6 +133,42 @@ Deno.test("workflowEdit: opens editor when workflow found by name", async () => 
   ]);
 });
 
+Deno.test("workflowEdit: announces editor launch before opening", async () => {
+  let opened = false;
+  const deps = makeDeps({
+    findByName: () => Promise.resolve(testWorkflow),
+    getPath: () => "/repo/workflows/deploy-workflow/workflow.yaml",
+    prepareEditor: (path) =>
+      Promise.resolve({
+        editor: "VS Code",
+        waitsForExit: true,
+        open: () => {
+          opened = true;
+          return Promise.resolve({ editor: "VS Code", path });
+        },
+      }),
+  });
+
+  const iterator = workflowEdit(createLibSwampContext(), deps, {
+    workflowIdOrName: "deploy-workflow",
+  })[Symbol.asyncIterator]();
+
+  await iterator.next();
+  const launch = await iterator.next();
+  assertEquals(launch.value, {
+    kind: "launching",
+    data: {
+      editor: "VS Code",
+      path: "/repo/workflows/deploy-workflow/workflow.yaml",
+      waitsForExit: true,
+    },
+  });
+  assertEquals(opened, false);
+
+  await iterator.next();
+  assertEquals(opened, true);
+});
+
 Deno.test("workflowEdit: falls back to symlink when name lookup fails", async () => {
   const deps = makeDeps({
     findByName: () => {
@@ -123,7 +176,7 @@ Deno.test("workflowEdit: falls back to symlink when name lookup fails", async ()
     },
     resolveSymlink: () =>
       Promise.resolve("/repo/extensions/workflows/broken/workflow.yaml"),
-    openEditor: () => Promise.resolve({ editor: "VS Code" }),
+    prepareEditor: prepareEditor("VS Code"),
   });
 
   const events = await collect<WorkflowEditEvent>(
@@ -134,6 +187,14 @@ Deno.test("workflowEdit: falls back to symlink when name lookup fails", async ()
 
   assertEquals(events, [
     { kind: "resolving" },
+    {
+      kind: "launching",
+      data: {
+        editor: "VS Code",
+        path: "/repo/extensions/workflows/broken/workflow.yaml",
+        waitsForExit: false,
+      },
+    },
     {
       kind: "completed",
       data: {
@@ -156,7 +217,7 @@ Deno.test("workflowEdit: resolves symlink for extension workflows when file miss
       Promise.resolve(
         "/repo/extensions/workflows/deploy-workflow/workflow.yaml",
       ),
-    openEditor: () => Promise.resolve({ editor: "VS Code" }),
+    prepareEditor: prepareEditor("VS Code"),
   });
 
   const events = await collect<WorkflowEditEvent>(
@@ -165,7 +226,7 @@ Deno.test("workflowEdit: resolves symlink for extension workflows when file miss
     }),
   );
 
-  const completed = events[1] as Extract<
+  const completed = events[2] as Extract<
     WorkflowEditEvent,
     { kind: "completed" }
   >;
@@ -208,7 +269,7 @@ Deno.test("workflowEdit: opens broken workflow by name via findBrokenWorkflow fa
         id: "abc",
         error: "Unknown key 'ependssss'",
       }),
-    openEditor: () => Promise.resolve({ editor: "Neovim" }),
+    prepareEditor: prepareEditor("Neovim"),
   });
 
   const events = await collect<WorkflowEditEvent>(
@@ -219,6 +280,14 @@ Deno.test("workflowEdit: opens broken workflow by name via findBrokenWorkflow fa
 
   assertEquals(events, [
     { kind: "resolving" },
+    {
+      kind: "launching",
+      data: {
+        editor: "Neovim",
+        path: "/repo/workflows/workflow-abc.yaml",
+        waitsForExit: false,
+      },
+    },
     {
       kind: "completed",
       data: {
@@ -245,7 +314,7 @@ Deno.test("workflowEdit: opens broken workflow by UUID via findBrokenWorkflow fa
         id: brokenId,
         error: "Unknown key 'ependssss'",
       }),
-    openEditor: () => Promise.resolve({ editor: "Neovim" }),
+    prepareEditor: prepareEditor("Neovim"),
   });
 
   const events = await collect<WorkflowEditEvent>(
@@ -256,6 +325,14 @@ Deno.test("workflowEdit: opens broken workflow by UUID via findBrokenWorkflow fa
 
   assertEquals(events, [
     { kind: "resolving" },
+    {
+      kind: "launching",
+      data: {
+        editor: "Neovim",
+        path: `/repo/workflows/workflow-${brokenId}.yaml`,
+        waitsForExit: false,
+      },
+    },
     {
       kind: "completed",
       data: {

--- a/src/presentation/renderers/edit_renderers_test.ts
+++ b/src/presentation/renderers/edit_renderers_test.ts
@@ -1,0 +1,55 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { initializeLogging } from "../../infrastructure/logging/logger.ts";
+import { createModelEditRenderer } from "./model_edit.ts";
+import { createVaultEditRenderer } from "./vault_edit.ts";
+import { createWorkflowEditRenderer } from "./workflow_edit.ts";
+
+await initializeLogging({});
+
+const launch = {
+  kind: "launching" as const,
+  data: {
+    editor: "VS Code",
+    path: "/repo/definition.yaml",
+    waitsForExit: true,
+  },
+};
+
+Deno.test("edit renderers: log mode handles launch events", () => {
+  createModelEditRenderer("log").handlers().launching(launch);
+  createWorkflowEditRenderer("log").handlers().launching(launch);
+  createVaultEditRenderer("log").handlers().launching(launch);
+});
+
+Deno.test("edit renderers: json mode omits launch events", () => {
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (message: string) => logs.push(message);
+  try {
+    createModelEditRenderer("json").handlers().launching(launch);
+    createWorkflowEditRenderer("json").handlers().launching(launch);
+    createVaultEditRenderer("json").handlers().launching(launch);
+    assertEquals(logs, []);
+  } finally {
+    console.log = originalLog;
+  }
+});

--- a/src/presentation/renderers/model_edit.ts
+++ b/src/presentation/renderers/model_edit.ts
@@ -28,6 +28,19 @@ class LogModelEditRenderer implements Renderer<ModelEditEvent> {
     const logger = getSwampLogger(["model", "edit"]);
     return {
       resolving: () => {},
+      launching: (e) => {
+        if (e.data.waitsForExit) {
+          logger.info(
+            "Launching {editor} for {path}; waiting for it to close",
+            { editor: e.data.editor, path: e.data.path },
+          );
+          return;
+        }
+        logger.info("Launching {editor} for {path}", {
+          editor: e.data.editor,
+          path: e.data.path,
+        });
+      },
       completed: (e) => {
         const data = e.data;
         if (data.status === "opened") {
@@ -64,6 +77,7 @@ class JsonModelEditRenderer implements Renderer<ModelEditEvent> {
   handlers(): EventHandlers<ModelEditEvent> {
     return {
       resolving: () => {},
+      launching: () => {},
       completed: (e) => {
         console.log(JSON.stringify(e.data, null, 2));
       },

--- a/src/presentation/renderers/vault_edit.ts
+++ b/src/presentation/renderers/vault_edit.ts
@@ -28,6 +28,19 @@ class LogVaultEditRenderer implements Renderer<VaultEditEvent> {
     const logger = getSwampLogger(["vault", "edit"]);
     return {
       resolving: () => {},
+      launching: (e) => {
+        if (e.data.waitsForExit) {
+          logger.info(
+            "Launching {editor} for {path}; waiting for it to close",
+            { editor: e.data.editor, path: e.data.path },
+          );
+          return;
+        }
+        logger.info("Launching {editor} for {path}", {
+          editor: e.data.editor,
+          path: e.data.path,
+        });
+      },
       completed: (e) => {
         const data = e.data;
         logger
@@ -44,6 +57,7 @@ class JsonVaultEditRenderer implements Renderer<VaultEditEvent> {
   handlers(): EventHandlers<VaultEditEvent> {
     return {
       resolving: () => {},
+      launching: () => {},
       completed: (e) => {
         console.log(JSON.stringify(e.data, null, 2));
       },

--- a/src/presentation/renderers/workflow_edit.ts
+++ b/src/presentation/renderers/workflow_edit.ts
@@ -28,6 +28,19 @@ class LogWorkflowEditRenderer implements Renderer<WorkflowEditEvent> {
     const logger = getSwampLogger(["workflow", "edit"]);
     return {
       resolving: () => {},
+      launching: (e) => {
+        if (e.data.waitsForExit) {
+          logger.info(
+            "Launching {editor} for {path}; waiting for it to close",
+            { editor: e.data.editor, path: e.data.path },
+          );
+          return;
+        }
+        logger.info("Launching {editor} for {path}", {
+          editor: e.data.editor,
+          path: e.data.path,
+        });
+      },
       completed: (e) => {
         const data = e.data;
         if (data.status === "opened") {
@@ -53,6 +66,7 @@ class JsonWorkflowEditRenderer implements Renderer<WorkflowEditEvent> {
   handlers(): EventHandlers<WorkflowEditEvent> {
     return {
       resolving: () => {},
+      launching: () => {},
       completed: (e) => {
         console.log(JSON.stringify(e.data, null, 2));
       },

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -1618,6 +1618,7 @@ export async function handleModelEdit(
       }),
       {
         resolving: () => {},
+        launching: () => {},
         completed: (e) => {
           result = e.data as unknown as Record<string, unknown>;
         },

--- a/src/serve/handlers/vault_handlers.ts
+++ b/src/serve/handlers/vault_handlers.ts
@@ -783,6 +783,7 @@ export async function handleVaultEdit(
       }),
       {
         resolving: () => {},
+        launching: () => {},
         completed: (e) => {
           result = e.data as unknown as Record<string, unknown>;
         },

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -1662,6 +1662,7 @@ export async function handleWorkflowEdit(
       }),
       {
         resolving: () => {},
+        launching: () => {},
         completed: (e) => {
           result = e.data as unknown as Record<string, unknown>;
         },


### PR DESCRIPTION
## Summary
- Announce the resolved editor before blocking interactive issue flows.
- Emit pre-launch events for model, workflow, and vault edits while preserving JSON output.
- Cover launch ordering and renderer behavior.

## Verification
- verify-build: passed
- verify-reviews: passed
- verify-skills: passed (guard-skipped checks)

Closes #1724