### PR TITLE
feat(audit): Phase 3 — real-time WebSocket streaming and dashboard Activity page

### DIFF
--- a/design/enablers/serve-audit.md
+++ b/design/enablers/serve-audit.md
@@ -1,6 +1,6 @@
 ---
 audience: everyone
-last-verified: 2026-09-05 @ HEAD
+last-verified: 2026-09-08 @ HEAD
 ---
 
 # Serve Audit
@@ -108,35 +108,62 @@ a warning at startup — production deployments should use a dedicated store.
 - `swamp audit log` — query the audit log with filters (`--since`, `--until`,
   `--principal`, `--category`, `--action`, `--outcome`, `--limit`)
 - `swamp audit verify` — check chain integrity for a time range
+- `swamp audit log --follow` — stream new audit events in real-time after the
+  initial query (Ctrl+C to stop)
+
+## Real-time streaming
+
+`audit.subscribe` starts a live stream of audit events over the existing
+WebSocket connection. The server sends `audit.event` messages as they occur,
+filtered by the subscription parameters. Subscriptions stay active until the
+connection closes or the client sends `audit.unsubscribe`.
+
+Filter shape matches `audit.query`: categories, principals, actions, outcomes,
+resourceKind. Per-connection subscription cap: 2. Subscriptions are
+re-authorized every 60 seconds — revoked grants terminate the stream.
+
+No durability guarantee — this is live streaming, not a replay mechanism. Missed
+events are queryable via `audit.query`.
+
+## System events
+
+The `system` audit category captures infrastructure lifecycle events with
+`principalKind: "system"`:
+
+- `instance.start` — emitted when the serve instance starts (with version)
+- `instance.stop` — emitted on graceful shutdown
+
+System events are always at `metadata` audit level (management tier).
 
 ## Domain model
 
-| Type              | DDD Building Block | Location                          |
-| ----------------- | ------------------ | --------------------------------- |
-| AuditEvent        | Entity             | `src/domain/serve_audit/`         |
-| ChainedAuditEvent | Type Alias         | `src/domain/serve_audit/`         |
-| AuditDecision     | Value Object       | `src/domain/serve_audit/`         |
-| AuditCategory     | Value Object       | `src/domain/serve_audit/`         |
-| AuditStage        | Value Object       | `src/domain/serve_audit/`         |
-| AuditOutcome      | Value Object       | `src/domain/serve_audit/`         |
-| AuditLevel        | Value Object       | `src/domain/serve_audit/`         |
-| AuditPolicyRule   | Value Object       | `src/domain/serve_audit/`         |
-| AuditChainState   | Domain Service     | `src/domain/serve_audit/`         |
-| RingBuffer        | Data Structure     | `src/domain/serve_audit/`         |
-| AuditEmitter      | Domain Service     | `src/domain/serve_audit/`         |
-| AuditPolicy       | Value Object       | `src/domain/serve_audit/`         |
-| AuditWal          | Domain Service     | `src/domain/serve_audit/`         |
-| AuditQueryService | Domain Service     | `src/domain/serve_audit/`         |
-| AuditSink         | Port Interface     | `src/domain/serve_audit/`         |
-| AuditStore        | Port Interface     | `src/domain/serve_audit/`         |
-| AuditEventBuilder | Factory            | `src/domain/serve_audit/`         |
-| RemoteAuditStore  | Adapter            | `src/infrastructure/persistence/` |
-| StoreSink         | Adapter            | `src/serve/audit_sinks/`          |
-| WalSink           | Adapter            | `src/serve/audit_sinks/`          |
+| Type                    | DDD Building Block | Location                          |
+| ----------------------- | ------------------ | --------------------------------- |
+| AuditEvent              | Entity             | `src/domain/serve_audit/`         |
+| ChainedAuditEvent       | Type Alias         | `src/domain/serve_audit/`         |
+| AuditDecision           | Value Object       | `src/domain/serve_audit/`         |
+| AuditCategory           | Value Object       | `src/domain/serve_audit/`         |
+| AuditStage              | Value Object       | `src/domain/serve_audit/`         |
+| AuditOutcome            | Value Object       | `src/domain/serve_audit/`         |
+| AuditLevel              | Value Object       | `src/domain/serve_audit/`         |
+| AuditPolicyRule         | Value Object       | `src/domain/serve_audit/`         |
+| AuditSubscriptionFilter | Value Object       | `src/serve/audit_sinks/`          |
+| AuditChainState         | Domain Service     | `src/domain/serve_audit/`         |
+| RingBuffer              | Data Structure     | `src/domain/serve_audit/`         |
+| AuditEmitter            | Domain Service     | `src/domain/serve_audit/`         |
+| AuditPolicy             | Value Object       | `src/domain/serve_audit/`         |
+| AuditWal                | Domain Service     | `src/domain/serve_audit/`         |
+| AuditQueryService       | Domain Service     | `src/domain/serve_audit/`         |
+| AuditSink               | Port Interface     | `src/domain/serve_audit/`         |
+| AuditStore              | Port Interface     | `src/domain/serve_audit/`         |
+| AuditEventBuilder       | Factory            | `src/domain/serve_audit/`         |
+| RemoteAuditStore        | Adapter            | `src/infrastructure/persistence/` |
+| StoreSink               | Adapter            | `src/serve/audit_sinks/`          |
+| WalSink                 | Adapter            | `src/serve/audit_sinks/`          |
+| WebSocketSink           | Adapter            | `src/serve/audit_sinks/`          |
 
 ## Future phases
 
-- **Phase 3**: Real-time WebSocket streaming (`audit.subscribe`), `--follow`
-  for `swamp audit log`
-- **Phase 4**: Webhook and syslog sinks, bulk export, HMAC
+- **Phase 4**: Webhook and syslog sinks, bulk export, HMAC, HA join/leave
+  system events, health state transition events
 - **Phase 5**: Extension sinks, alerting, compliance templates

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -19,6 +19,7 @@
 
 import { useEffect, useState } from "react";
 import { SwampProvider, useSwamp } from "./client/SwampProvider";
+import { useAuditStream } from "./client/useAuditStream";
 import { useHealthStream } from "./client/useHealthStream";
 import { useRequest } from "./client/useRequest";
 import { extractArray } from "./client/extract";
@@ -37,6 +38,7 @@ import { Approvals } from "./views/Approvals";
 import { Data } from "./views/Data";
 import { Vaults } from "./views/Vaults";
 import { Extensions } from "./views/Extensions";
+import { Activity } from "./views/Activity";
 import { RunDetail } from "./views/RunDetail";
 
 export function App() {
@@ -75,6 +77,7 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
   const [view, setView] = useState<View>("overview");
   const [detail, setDetail] = useState<DetailView>(null);
   const health = useHealthStream();
+  const auditStream = useAuditStream();
 
   const { data: approvalsData } = useRequest("workflow.approvals");
   const approvalCount = extractArray(approvalsData).length;
@@ -155,6 +158,7 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
               {view === "schedules" && <Schedules health={health} />}
               {view === "webhooks" && <Webhooks health={health} />}
               {view === "approvals" && <Approvals />}
+              {view === "activity" && <Activity auditStream={auditStream} />}
               {view === "data" && <Data />}
               {view === "vaults" && <Vaults />}
               {view === "extensions" && <Extensions />}

--- a/packages/dashboard/src/client/useAuditStream.ts
+++ b/packages/dashboard/src/client/useAuditStream.ts
@@ -1,0 +1,199 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useSwamp } from "./SwampProvider";
+
+export interface AuditEvent {
+  id: string;
+  timestamp: string;
+  instanceId: string;
+  category: string;
+  stage: string;
+  outcome: string;
+  action: string;
+  resourceKind: string;
+  resourceName: string;
+  principalKind: string;
+  principalId: string;
+  initiatedBy: string;
+  sourceIp: string;
+  requestId: string;
+  methodName?: string;
+  detail?: string;
+  decision?: Record<string, unknown>;
+}
+
+const DEFAULT_MAX_EVENTS = 1000;
+
+export function useAuditStream(): {
+  events: AuditEvent[];
+  streaming: boolean;
+  liveEnabled: boolean;
+  error: string | null;
+  clearEvents: () => void;
+  setLiveEnabled: (enabled: boolean) => void;
+  maxEvents: number;
+  setMaxEvents: (n: number) => void;
+} {
+  const { connected, request, token } = useSwamp();
+  const [events, setEvents] = useState<AuditEvent[]>([]);
+  const [streaming, setStreaming] = useState(false);
+  const [liveEnabled, setLiveEnabled] = useState(true);
+  const [maxEvents, setMaxEvents] = useState(DEFAULT_MAX_EVENTS);
+  const [error, setError] = useState<string | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  const clearEvents = useCallback(() => setEvents([]), []);
+
+  useEffect(() => {
+    if (!connected) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const result = await request<{
+          events: AuditEvent[];
+          total?: number;
+        }>("audit.query", { limit: maxEvents });
+        if (!cancelled) {
+          setEvents(
+            (result.events ?? []).slice(-maxEvents) as AuditEvent[],
+          );
+        }
+      } catch {
+        // audit may not be configured
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [connected, request, maxEvents]);
+
+  useEffect(() => {
+    if (!connected || !liveEnabled) {
+      if (wsRef.current) {
+        wsRef.current.send(JSON.stringify({
+          type: "audit.unsubscribe",
+          id: crypto.randomUUID(),
+        }));
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+      setStreaming(false);
+      return;
+    }
+
+    let cancelled = false;
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    const wsUrl = `${proto}//${location.host}/`;
+    const protocols = token ? [`bearer.${token}`] : undefined;
+    const ws = new WebSocket(wsUrl, protocols);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      if (cancelled) {
+        ws.close();
+        return;
+      }
+      ws.send(JSON.stringify({
+        type: "audit.subscribe",
+        id: crypto.randomUUID(),
+      }));
+    };
+
+    ws.onmessage = (event) => {
+      let msg: {
+        type: string;
+        id: string;
+        payload?: Record<string, unknown>;
+      };
+      try {
+        msg = JSON.parse(event.data as string);
+      } catch {
+        return;
+      }
+
+      if (msg.type === "audit.subscribe" && msg.payload) {
+        if (!cancelled) {
+          setStreaming(true);
+          setError(null);
+        }
+        return;
+      }
+
+      if (msg.type === "error") {
+        const errPayload = msg as unknown as {
+          error?: { message: string };
+        };
+        if (!cancelled) {
+          setError(errPayload.error?.message ?? "Subscription failed");
+          setStreaming(false);
+        }
+        return;
+      }
+
+      if (msg.type === "audit.event" && msg.payload) {
+        const auditEvent = (msg.payload as { event: AuditEvent }).event;
+        if (!cancelled) {
+          setEvents((prev) => {
+            const next = [...prev, auditEvent];
+            return next.length > maxEvents ? next.slice(-maxEvents) : next;
+          });
+        }
+      }
+    };
+
+    ws.onclose = () => {
+      if (!cancelled) setStreaming(false);
+      wsRef.current = null;
+    };
+
+    ws.onerror = () => {
+      if (!cancelled) {
+        setError("WebSocket connection failed");
+        setStreaming(false);
+      }
+    };
+
+    return () => {
+      cancelled = true;
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({
+          type: "audit.unsubscribe",
+          id: crypto.randomUUID(),
+        }));
+        ws.close();
+      }
+      wsRef.current = null;
+    };
+  }, [connected, token, liveEnabled, maxEvents]);
+
+  return {
+    events,
+    streaming,
+    liveEnabled,
+    error,
+    clearEvents,
+    setLiveEnabled,
+    maxEvents,
+    setMaxEvents,
+  };
+}

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -29,6 +29,7 @@ export type View =
   | "schedules"
   | "webhooks"
   | "approvals"
+  | "activity"
   | "data"
   | "vaults"
   | "extensions"
@@ -51,6 +52,7 @@ const ICONS: Record<string, string> = {
     '<rect x="2" y="2" width="14" height="14" rx="2"/><path d="M2 6h14M6 6v10"/>',
   vaults:
     '<rect x="4" y="2" width="10" height="14" rx="2"/><circle cx="9" cy="9" r="2"/><path d="M9 2v5M9 11v5M4 9h3M11 9h3"/>',
+  activity: '<path d="M2 9h4l2-5 3 10 2-5h3"/><circle cx="15" cy="9" r="1.5"/>',
   extensions: '<path d="M3 5h12M3 9h12M3 13h8"/>',
   system:
     '<path d="M9 2a7 7 0 110 14A7 7 0 019 2z"/><path d="M12 9a3 3 0 01-6 0 3 3 0 016 0z"/><path d="M9 1v2M9 15v2M1 9h2M15 9h2M3.3 3.3l1.4 1.4M13.3 13.3l1.4 1.4M3.3 14.7l1.4-1.4M13.3 4.7l1.4-1.4"/>',
@@ -229,6 +231,12 @@ export function Sidebar({
           active={activeView === "approvals"}
           onClick={onNavigate}
           badge={approvalCount > 0 ? approvalCount : undefined}
+        />
+        <NavItem
+          label="Activity"
+          view="activity"
+          active={activeView === "activity"}
+          onClick={onNavigate}
         />
       </div>
 

--- a/packages/dashboard/src/views/Activity.tsx
+++ b/packages/dashboard/src/views/Activity.tsx
@@ -1,0 +1,462 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { useState } from "react";
+import type { AuditEvent } from "../client/useAuditStream";
+
+const CATEGORY_COLORS: Record<string, string> = {
+  auth: "#6366f1",
+  access: "#f59e0b",
+  execution: "#22c55e",
+  secrets: "#ef4444",
+  admin: "#8b5cf6",
+  data: "#3b82f6",
+  system: "#64748b",
+};
+
+const OUTCOME_COLORS: Record<string, string> = {
+  success: "var(--success)",
+  failure: "var(--danger)",
+  denied: "var(--warning)",
+};
+
+function formatTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function CategoryBadge({ category }: { category: string }) {
+  const color = CATEGORY_COLORS[category] ?? "var(--text-3)";
+  return (
+    <span
+      style={{
+        fontFamily: "'JetBrains Mono', monospace",
+        fontSize: "0.65rem",
+        fontWeight: 500,
+        padding: "1px 6px",
+        borderRadius: 4,
+        background: `${color}20`,
+        color,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {category}
+    </span>
+  );
+}
+
+function OutcomeDot({ outcome }: { outcome: string }) {
+  const color = OUTCOME_COLORS[outcome] ?? "var(--text-3)";
+  return (
+    <span
+      style={{
+        width: 7,
+        height: 7,
+        borderRadius: "50%",
+        background: color,
+        display: "inline-block",
+        flexShrink: 0,
+      }}
+      title={outcome}
+    />
+  );
+}
+
+function EventRow({ event }: { event: AuditEvent }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div
+      style={{
+        borderBottom: "1px solid var(--border)",
+        cursor: "pointer",
+      }}
+      onClick={() => setExpanded(!expanded)}
+    >
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns:
+            "72px 18px 68px minmax(100px, 1.5fr) minmax(80px, 1fr) minmax(80px, 1fr)",
+          gap: 12,
+          alignItems: "center",
+          padding: "8px 16px",
+          fontSize: "0.8rem",
+        }}
+      >
+        <span
+          className="mono"
+          style={{ color: "var(--text-3)", fontSize: "0.72rem" }}
+        >
+          {formatTime(event.timestamp)}
+        </span>
+        <OutcomeDot outcome={event.outcome} />
+        <CategoryBadge category={event.category} />
+        <span
+          className="mono"
+          style={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {event.action}
+        </span>
+        <span
+          style={{
+            color: "var(--text-3)",
+            fontSize: "0.72rem",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {event.initiatedBy}
+        </span>
+        <span
+          className="mono"
+          style={{
+            color: "var(--text-3)",
+            fontSize: "0.68rem",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {event.resourceKind}:{event.resourceName}
+        </span>
+      </div>
+      {expanded && (
+        <div
+          style={{
+            padding: "8px 16px 12px",
+            background: "var(--card-bg)",
+            fontSize: "0.72rem",
+            fontFamily: "'JetBrains Mono', monospace",
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: "4px 24px",
+            color: "var(--text-2)",
+          }}
+        >
+          <div>
+            <strong>ID:</strong> {event.id}
+          </div>
+          <div>
+            <strong>Request:</strong> {event.requestId}
+          </div>
+          <div>
+            <strong>Instance:</strong> {event.instanceId}
+          </div>
+          <div>
+            <strong>Source IP:</strong> {event.sourceIp}
+          </div>
+          <div>
+            <strong>Initiated by:</strong> {event.initiatedBy}
+          </div>
+          <div>
+            <strong>Principal kind:</strong> {event.principalKind}
+          </div>
+          {event.methodName && (
+            <div>
+              <strong>Method name:</strong> {event.methodName}
+            </div>
+          )}
+          {event.detail && (
+            <div style={{ gridColumn: "1 / -1" }}>
+              <strong>Detail:</strong> {event.detail}
+            </div>
+          )}
+          {event.decision && (() => {
+            const d = event.decision as Record<string, string>;
+            return (
+              <div
+                style={{
+                  gridColumn: "1 / -1",
+                  marginTop: 4,
+                  padding: "6px 8px",
+                  borderRadius: 4,
+                  background: d.effect === "deny"
+                    ? "rgba(239, 68, 68, 0.1)"
+                    : "rgba(34, 197, 94, 0.1)",
+                }}
+              >
+                <strong>Decision:</strong> {d.effect} {d.action} on{" "}
+                {d.resourceKind}:{d.resourceName}
+                {d.grantId && (
+                  <span style={{ opacity: 0.7 }}>
+                    {` (grant: ${d.grantId})`}
+                  </span>
+                )}
+              </div>
+            );
+          })()}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const CATEGORIES = [
+  "auth",
+  "access",
+  "execution",
+  "secrets",
+  "admin",
+  "data",
+  "system",
+];
+const OUTCOMES = ["success", "failure", "denied"];
+
+interface ActivityProps {
+  auditStream: {
+    events: AuditEvent[];
+    streaming: boolean;
+    liveEnabled: boolean;
+    error: string | null;
+    clearEvents: () => void;
+    setLiveEnabled: (enabled: boolean) => void;
+    maxEvents: number;
+    setMaxEvents: (n: number) => void;
+  };
+}
+
+const EVENT_LIMITS = [100, 500, 1000];
+
+export function Activity({ auditStream }: ActivityProps) {
+  const {
+    events,
+    streaming,
+    liveEnabled,
+    error,
+    clearEvents,
+    setLiveEnabled,
+    maxEvents,
+    setMaxEvents,
+  } = auditStream;
+  const [categoryFilters, setCategoryFilters] = useState<Set<string>>(
+    new Set(),
+  );
+  const [outcomeFilters, setOutcomeFilters] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const toggleCategory = (c: string) => {
+    setCategoryFilters((prev) => {
+      const next = new Set(prev);
+      if (next.has(c)) next.delete(c);
+      else next.add(c);
+      return next;
+    });
+  };
+
+  const toggleOutcome = (o: string) => {
+    setOutcomeFilters((prev) => {
+      const next = new Set(prev);
+      if (next.has(o)) next.delete(o);
+      else next.add(o);
+      return next;
+    });
+  };
+
+  const filtered = events.filter((e) => {
+    if (categoryFilters.size > 0 && !categoryFilters.has(e.category)) {
+      return false;
+    }
+    if (outcomeFilters.size > 0 && !outcomeFilters.has(e.outcome)) return false;
+    return true;
+  });
+
+  const reversed = [...filtered].reverse();
+
+  return (
+    <>
+      <div className="page-header">
+        <h1>Activity</h1>
+        <div className="header-right">
+          <button
+            type="button"
+            onClick={() => setLiveEnabled(!liveEnabled)}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "4px 10px",
+              borderRadius: 5,
+              fontSize: "0.78rem",
+              fontWeight: 500,
+              fontFamily: "inherit",
+              cursor: "pointer",
+              border: streaming
+                ? "1px solid var(--success)"
+                : liveEnabled
+                ? "1px solid var(--warning)"
+                : "1px solid var(--text-3)",
+              background: streaming
+                ? "rgba(34, 197, 94, 0.15)"
+                : liveEnabled
+                ? "rgba(245, 158, 11, 0.1)"
+                : "transparent",
+              color: streaming
+                ? "var(--success)"
+                : liveEnabled
+                ? "var(--warning)"
+                : "var(--text-3)",
+            }}
+          >
+            <span
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: "50%",
+                background: streaming
+                  ? "var(--success)"
+                  : liveEnabled
+                  ? "var(--warning)"
+                  : "var(--text-3)",
+                animation: streaming ? "pulse 2s infinite" : "none",
+              }}
+            />
+            {streaming ? "Live" : liveEnabled ? "Connecting" : "Paused"}
+          </button>
+          <div className="time-range">
+            {EVENT_LIMITS.map((n) => (
+              <button
+                type="button"
+                key={n}
+                className={`time-btn${maxEvents === n ? " active" : ""}`}
+                onClick={() => setMaxEvents(n)}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+          {error && (
+            <span style={{ fontSize: "0.72rem", color: "var(--danger)" }}>
+              {error}
+            </span>
+          )}
+          <span
+            className="mono"
+            style={{ fontSize: "0.75rem", color: "var(--text-3)" }}
+          >
+            {filtered.length} events
+          </span>
+          <div className="time-range">
+            {CATEGORIES.map((c) => (
+              <button
+                type="button"
+                key={c}
+                className={`time-btn${categoryFilters.has(c) ? " active" : ""}`}
+                onClick={() => toggleCategory(c)}
+              >
+                {c}
+              </button>
+            ))}
+          </div>
+          <div className="time-range">
+            {OUTCOMES.map((o) => (
+              <button
+                type="button"
+                key={o}
+                className={`time-btn${outcomeFilters.has(o) ? " active" : ""}`}
+                onClick={() => toggleOutcome(o)}
+              >
+                {o}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            className="time-btn"
+            onClick={clearEvents}
+            style={{ marginLeft: 8 }}
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+
+      <div
+        className="card"
+        style={{ overflow: "hidden", padding: 0, flex: 1 }}
+      >
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns:
+              "72px 18px 68px minmax(100px, 1.5fr) minmax(80px, 1fr) minmax(80px, 1fr)",
+            gap: 12,
+            padding: "10px 16px",
+            fontSize: "0.68rem",
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+            color: "var(--text-3)",
+            borderBottom: "1px solid var(--border)",
+          }}
+        >
+          <span>Time</span>
+          <span></span>
+          <span>Category</span>
+          <span>Action</span>
+          <span>Initiated By</span>
+          <span>Resource</span>
+        </div>
+        <div style={{ overflowY: "auto", maxHeight: "calc(100vh - 200px)" }}>
+          {reversed.length === 0
+            ? (
+              <div
+                style={{
+                  padding: 32,
+                  textAlign: "center",
+                  color: "var(--text-3)",
+                  fontSize: "0.85rem",
+                }}
+              >
+                {streaming
+                  ? "Waiting for audit events..."
+                  : "No audit events — is audit enabled in serve.yaml?"}
+              </div>
+            )
+            : reversed.map((event, idx) => (
+              <EventRow key={`${event.id}-${idx}`} event={event} />
+            ))}
+        </div>
+      </div>
+
+      <style>
+        {`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}
+      </style>
+    </>
+  );
+}

--- a/src/cli/commands/audit_log.ts
+++ b/src/cli/commands/audit_log.ts
@@ -23,10 +23,15 @@ import {
   requestServerResponse,
   resolveServerToken,
   resolveServeUrl,
+  subscribeServerEvents,
   withRemoteOptions,
 } from "../remote_run.ts";
 import type { AuditQueryResponse } from "../../serve/protocol.ts";
-import { renderAuditLog } from "../../presentation/output/audit_log_output.ts";
+import {
+  renderAuditEvent,
+  renderAuditLog,
+  renderAuditLogHeader,
+} from "../../presentation/output/audit_log_output.ts";
 import { UserError } from "../../domain/errors.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -45,6 +50,10 @@ export const auditLogCommand = withRemoteOptions(
       "Filter by outcome",
       "swamp audit log --server http://localhost:7443 --outcome denied",
     )
+    .example(
+      "Follow live",
+      "swamp audit log --server http://localhost:7443 --follow",
+    )
     .option(
       "--since <date:string>",
       "Start time, e.g. 2026-09-01T00:00:00Z [default: 24 hours ago]",
@@ -56,7 +65,7 @@ export const auditLogCommand = withRemoteOptions(
     .option("--principal <id:string>", "Filter by principal ID")
     .option(
       "--category <cat:string>",
-      "Filter by audit category (auth, access, execution, secrets, admin, data)",
+      "Filter by audit category (auth, access, execution, secrets, admin, data, system)",
     )
     .option("--action <action:string>", "Filter by action")
     .option(
@@ -69,7 +78,11 @@ export const auditLogCommand = withRemoteOptions(
     )
     .option("--limit <count:integer>", "Max events to return [default: 100]", {
       default: 100,
-    }),
+    })
+    .option(
+      "--follow",
+      "Stream new audit events in real-time after the initial query",
+    ),
 ).action(async function (options: AnyOptions) {
   const ctx = createContext(options as GlobalOptions, ["audit", "log"]);
 
@@ -102,5 +115,39 @@ export const auditLogCommand = withRemoteOptions(
     },
   );
 
-  renderAuditLog(response, ctx.outputMode);
+  if (!options.follow) {
+    renderAuditLog(response, ctx.outputMode);
+    return;
+  }
+
+  renderAuditLogHeader(ctx.outputMode);
+  for (const event of response.events) {
+    renderAuditEvent(event as Record<string, string>, ctx.outputMode);
+  }
+
+  const ac = new AbortController();
+  const onSignal = () => ac.abort();
+  Deno.addSignalListener("SIGINT", onSignal);
+
+  try {
+    const filter: Record<string, unknown> = {};
+    if (options.category) filter.categories = [options.category];
+    if (options.principal) filter.principals = [options.principal];
+    if (options.action) filter.actions = [options.action];
+    if (options.outcome) filter.outcomes = [options.outcome];
+
+    const stream = subscribeServerEvents(
+      { server, token, signal: ac.signal },
+      {
+        type: "audit.subscribe",
+        payload: Object.keys(filter).length > 0 ? filter : undefined,
+      },
+    );
+
+    for await (const event of stream) {
+      renderAuditEvent(event as Record<string, string>, ctx.outputMode);
+    }
+  } finally {
+    Deno.removeSignalListener("SIGINT", onSignal);
+  }
 });

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -34,6 +34,7 @@ import {
 } from "../../serve/handlers/admin_handlers.ts";
 import {
   closeConnectionsForPrincipal,
+  emitSystemAuditEvent,
   removeConnection,
   setConnectionCollectives,
   setConnectionSourceIp,
@@ -122,6 +123,7 @@ import {
 } from "../../domain/serve_audit/mod.ts";
 import { StoreSink } from "../../serve/audit_sinks/store_sink.ts";
 import { WalSink } from "../../serve/audit_sinks/wal_sink.ts";
+import { WebSocketSink } from "../../serve/audit_sinks/websocket_sink.ts";
 import { RemoteAuditStore } from "../../infrastructure/persistence/remote_audit_store.ts";
 import { resolveDatastoreExpressions } from "../datastore_expression_resolver.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
@@ -2941,8 +2943,9 @@ export const serveCommand = new Command()
           }
         }
 
+        const webSocketSink = new WebSocketSink();
         connectionCtx.auditEmitter = new AuditEmitter({
-          sinks: [walSink],
+          sinks: [walSink, webSocketSink],
           policy,
           chainState,
         });
@@ -2950,10 +2953,17 @@ export const serveCommand = new Command()
         connectionCtx.auditPolicy = policy;
         connectionCtx.auditFailOpen = auditConfig.failOpen;
         connectionCtx.auditWal = wal;
+        connectionCtx.auditWebSocketSink = webSocketSink;
 
         logger.info(
           "Audit pipeline enabled with {count} store target(s), WAL at {walDir}",
           { count: auditStores.length, walDir },
+        );
+
+        emitSystemAuditEvent(
+          connectionCtx,
+          "instance.start",
+          `version=${VERSION}`,
         );
       }
     }
@@ -4316,6 +4326,7 @@ export const serveCommand = new Command()
         await telemetryFlushService.stop();
       }
       if (connectionCtx.auditEmitter) {
+        emitSystemAuditEvent(connectionCtx, "instance.stop");
         await connectionCtx.auditEmitter.close();
         if (connectionCtx.auditWal) {
           await connectionCtx.auditWal.saveChainState(

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -4327,6 +4327,7 @@ export const serveCommand = new Command()
       }
       if (connectionCtx.auditEmitter) {
         emitSystemAuditEvent(connectionCtx, "instance.stop");
+        await connectionCtx.auditEmitter.flush();
         await connectionCtx.auditEmitter.close();
         if (connectionCtx.auditWal) {
           await connectionCtx.auditWal.saveChainState(

--- a/src/cli/remote_run.ts
+++ b/src/cli/remote_run.ts
@@ -371,6 +371,133 @@ export function requestServerResponse<T>(
   });
 }
 
+export interface SubscribeServerOptions {
+  readonly server: string;
+  readonly token: string | undefined;
+  readonly signal?: AbortSignal;
+  readonly caCerts?: string[];
+  readonly headers?: Record<string, string>;
+}
+
+export async function* subscribeServerEvents(
+  options: SubscribeServerOptions,
+  request: { type: string; payload?: unknown },
+): AsyncGenerator<Record<string, unknown>> {
+  const baseUrl = normalizeServerUrl(options.server);
+  const extraHeaders = options.headers ?? resolveExtraHeaders();
+  const headers: Record<string, string> = { ...extraHeaders };
+  if (options.token) {
+    headers["Authorization"] = `Bearer ${options.token}`;
+  }
+  const requestId = crypto.randomUUID();
+  const socket = createSocket(baseUrl, headers, options.caCerts);
+
+  type QueueItem =
+    | { kind: "message"; data: Record<string, unknown> }
+    | { kind: "error"; error: Error }
+    | { kind: "close" };
+
+  const queue: QueueItem[] = [];
+  let resolve: (() => void) | null = null;
+  let subscriptionId: string | undefined;
+
+  function enqueue(item: QueueItem) {
+    queue.push(item);
+    if (resolve) {
+      resolve();
+      resolve = null;
+    }
+  }
+
+  function waitForItem(): Promise<void> {
+    if (queue.length > 0) return Promise.resolve();
+    return new Promise<void>((r) => {
+      resolve = r;
+    });
+  }
+
+  const onAbort = () => {
+    if (socket.readyState === WebSocket.OPEN && subscriptionId) {
+      socket.send(JSON.stringify({
+        type: "audit.unsubscribe",
+        id: crypto.randomUUID(),
+      }));
+    }
+    try {
+      socket.close();
+    } catch { /* already closed */ }
+    enqueue({ kind: "close" });
+  };
+
+  options.signal?.addEventListener("abort", onAbort, { once: true });
+
+  socket.onerror = (event) => {
+    const msg = event instanceof ErrorEvent ? event.message : "unknown";
+    enqueue({ kind: "error", error: new UserError(`WebSocket error: ${msg}`) });
+  };
+
+  socket.onclose = () => {
+    enqueue({ kind: "close" });
+  };
+
+  socket.onopen = () => {
+    socket.send(JSON.stringify({ ...request, id: requestId }));
+  };
+
+  socket.onmessage = (event) => {
+    if (typeof event.data !== "string") return;
+    try {
+      const message = JSON.parse(event.data) as Record<string, unknown>;
+      if (typeof message !== "object" || message === null) return;
+
+      if (message.type === "error" && message.id === requestId) {
+        enqueue({
+          kind: "error",
+          error: new UserError(
+            formatServerError(
+              message.error as { code: string; message: string },
+            ),
+          ),
+        });
+        return;
+      }
+
+      if (
+        message.type === "audit.subscribe" && message.id === requestId &&
+        message.payload
+      ) {
+        const payload = message.payload as { subscriptionId: string };
+        subscriptionId = payload.subscriptionId;
+        return;
+      }
+
+      if (message.type === "audit.event" && message.payload) {
+        enqueue({
+          kind: "message",
+          data: (message.payload as { event: Record<string, unknown> }).event,
+        });
+      }
+    } catch { /* not a protocol frame */ }
+  };
+
+  try {
+    while (true) {
+      await waitForItem();
+      while (queue.length > 0) {
+        const item = queue.shift()!;
+        if (item.kind === "close") return;
+        if (item.kind === "error") throw item.error;
+        yield item.data;
+      }
+    }
+  } finally {
+    options.signal?.removeEventListener("abort", onAbort);
+    try {
+      socket.close();
+    } catch { /* already closed */ }
+  }
+}
+
 // deno-lint-ignore no-explicit-any
 type AnyCommand = Command<any, any, any, any, any, any, any, any>;
 

--- a/src/cli/remote_run_test.ts
+++ b/src/cli/remote_run_test.ts
@@ -35,6 +35,7 @@ import {
   runModelMethodOverServer,
   runWorkflowOverServer,
   setMarkerServerAddress,
+  subscribeServerEvents,
   warnServerReloadNeeded,
   writeRemoteIndicator,
 } from "./remote_run.ts";
@@ -1549,4 +1550,105 @@ Deno.test({
       await server.shutdown();
     }
   },
+});
+
+// ── subscribeServerEvents tests ──────────────────────────────────────
+
+Deno.test("subscribeServerEvents: yields audit events from server", async () => {
+  const server = scriptedServer((request, reply) => {
+    if (request.type === "audit.subscribe") {
+      reply({
+        type: "audit.subscribe",
+        id: request.id,
+        payload: { subscriptionId: "sub-1" },
+      });
+      reply({
+        type: "audit.event",
+        id: "sub-1",
+        payload: { event: { action: "vault.get", outcome: "success" } },
+      });
+      reply({
+        type: "audit.event",
+        id: "sub-1",
+        payload: { event: { action: "model.run", outcome: "denied" } },
+      });
+    }
+  });
+  try {
+    const events: Record<string, unknown>[] = [];
+    const ac = new AbortController();
+    const stream = subscribeServerEvents(
+      { server: server.url, token: undefined, signal: ac.signal },
+      { type: "audit.subscribe" },
+    );
+    for await (const event of stream) {
+      events.push(event);
+      if (events.length >= 2) {
+        ac.abort();
+      }
+    }
+    assertEquals(events.length, 2);
+    assertEquals(events[0].action, "vault.get");
+    assertEquals(events[1].action, "model.run");
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("subscribeServerEvents: propagates server error", async () => {
+  const server = scriptedServer((request, reply) => {
+    reply({
+      type: "error",
+      id: request.id,
+      error: { code: "audit_not_configured", message: "Audit not enabled" },
+    });
+  });
+  try {
+    const stream = subscribeServerEvents(
+      { server: server.url, token: undefined },
+      { type: "audit.subscribe" },
+    );
+    await assertRejects(
+      async () => {
+        for await (const _ of stream) {
+          // should not yield
+        }
+      },
+      UserError,
+      "Audit not enabled",
+    );
+  } finally {
+    await server.shutdown();
+  }
+});
+
+Deno.test("subscribeServerEvents: terminates on socket close", async () => {
+  const server = scriptedServer((request, reply, socket) => {
+    if (request.type === "audit.subscribe") {
+      reply({
+        type: "audit.subscribe",
+        id: request.id,
+        payload: { subscriptionId: "sub-1" },
+      });
+      reply({
+        type: "audit.event",
+        id: "sub-1",
+        payload: { event: { action: "test" } },
+      });
+      setTimeout(() => socket.close(), 50);
+    }
+  });
+  try {
+    const events: Record<string, unknown>[] = [];
+    const stream = subscribeServerEvents(
+      { server: server.url, token: undefined },
+      { type: "audit.subscribe" },
+    );
+    for await (const event of stream) {
+      events.push(event);
+    }
+    assertEquals(events.length, 1);
+  } finally {
+    await server.shutdown();
+  }
 });

--- a/src/domain/serve_audit/audit_emitter.ts
+++ b/src/domain/serve_audit/audit_emitter.ts
@@ -65,11 +65,6 @@ export class AuditEmitter {
       this.#chainState = sinksOrOptions.chainState ?? new AuditChainState();
       this.#policy = sinksOrOptions.policy;
     }
-    if (this.#sinks.length > 1) {
-      throw new Error(
-        "AuditEmitter currently supports a single sink — multi-sink chain integrity requires per-sink chain state (planned for a future phase)",
-      );
-    }
     for (const sink of this.#sinks) {
       this.#cursors.set(sink.name, 0);
     }
@@ -140,7 +135,7 @@ export class AuditEmitter {
       chained.push(await this.#chainState.chain(event));
     }
 
-    let anyWriteSucceeded = false;
+    let anyDurableWriteSucceeded = false;
     for (const sink of this.#sinks) {
       const sinkCursor = this.#cursors.get(sink.name) ?? 0;
       const offset = sinkCursor - minCursor;
@@ -149,7 +144,7 @@ export class AuditEmitter {
       try {
         await sink.write(sinkEvents);
         this.#cursors.set(sink.name, throughSeq);
-        anyWriteSucceeded = true;
+        if (sink.durable) anyDurableWriteSucceeded = true;
       } catch (error: unknown) {
         logger.warn(
           "Audit sink {sink} failed, events dropped: {error}",
@@ -161,7 +156,7 @@ export class AuditEmitter {
       }
     }
 
-    if (!anyWriteSucceeded) {
+    if (!anyDurableWriteSucceeded) {
       this.#chainState.restore(chainSnapshot);
     }
   }

--- a/src/domain/serve_audit/audit_emitter_test.ts
+++ b/src/domain/serve_audit/audit_emitter_test.ts
@@ -43,13 +43,17 @@ function makeEvent(action: string): AuditEvent {
   });
 }
 
-function createMockSink(name: string): AuditSink & {
+function createMockSink(
+  name: string,
+  durable = true,
+): AuditSink & {
   written: AuditEvent[][];
   flushed: number;
   closed: boolean;
 } {
   const sink = {
     name,
+    durable,
     written: [] as AuditEvent[][],
     flushed: 0,
     closed: false,
@@ -97,19 +101,72 @@ Deno.test("AuditEmitter: batches multiple events in single drain", async () => {
   assertEquals(sink.written[0].length, 3);
 });
 
-Deno.test("AuditEmitter: rejects multiple sinks", () => {
+Deno.test("AuditEmitter: supports multiple sinks", async () => {
   const sinkA = createMockSink("a");
   const sinkB = createMockSink("b");
-  assertThrows(
-    () => new AuditEmitter([sinkA, sinkB]),
-    Error,
-    "single sink",
-  );
+  const emitter = new AuditEmitter([sinkA, sinkB]);
+
+  emitter.emit(makeEvent("test"));
+  await emitter.flush();
+
+  assertEquals(sinkA.written.length, 1);
+  assertEquals(sinkB.written.length, 1);
+});
+
+Deno.test("AuditEmitter: chain state preserved when non-durable sink fails but durable succeeds", async () => {
+  const durableSink = createMockSink("durable", true);
+  const nonDurableSink: AuditSink = {
+    name: "non-durable",
+    durable: false,
+    write(): Promise<void> {
+      return Promise.reject(new Error("non-durable failed"));
+    },
+    flush(): Promise<void> {
+      return Promise.resolve();
+    },
+    close(): Promise<void> {
+      return Promise.resolve();
+    },
+  };
+  const emitter = new AuditEmitter([durableSink, nonDurableSink]);
+  const initialSeq = emitter.chainState.sequence;
+
+  emitter.emit(makeEvent("test"));
+  await emitter.flush();
+
+  assertEquals(durableSink.written.length, 1);
+  assertEquals(emitter.chainState.sequence, initialSeq + 1);
+});
+
+Deno.test("AuditEmitter: chain state rolled back when only non-durable sink succeeds", async () => {
+  const failingDurable: AuditSink = {
+    name: "durable",
+    durable: true,
+    write(): Promise<void> {
+      return Promise.reject(new Error("durable failed"));
+    },
+    flush(): Promise<void> {
+      return Promise.resolve();
+    },
+    close(): Promise<void> {
+      return Promise.resolve();
+    },
+  };
+  const nonDurableSink = createMockSink("non-durable", false);
+  const emitter = new AuditEmitter([failingDurable, nonDurableSink]);
+  const initialSeq = emitter.chainState.sequence;
+
+  emitter.emit(makeEvent("test"));
+  await emitter.flush();
+
+  assertEquals(nonDurableSink.written.length, 1);
+  assertEquals(emitter.chainState.sequence, initialSeq);
 });
 
 Deno.test("AuditEmitter: sink error does not propagate to caller", async () => {
   const failingSink: AuditSink = {
     name: "failing",
+    durable: true,
     write(): Promise<void> {
       return Promise.reject(new Error("sink failure"));
     },

--- a/src/domain/serve_audit/audit_emitter_test.ts
+++ b/src/domain/serve_audit/audit_emitter_test.ts
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { initializeLogging } from "../../infrastructure/logging/logger.ts";
 import { AuditEmitter } from "./audit_emitter.ts";
 import type { AuditEvent } from "./audit_event.ts";

--- a/src/domain/serve_audit/audit_event.ts
+++ b/src/domain/serve_audit/audit_event.ts
@@ -23,7 +23,8 @@ export type AuditCategory =
   | "execution"
   | "secrets"
   | "admin"
-  | "data";
+  | "data"
+  | "system";
 
 export type AuditStage = "request" | "response";
 

--- a/src/domain/serve_audit/audit_policy.ts
+++ b/src/domain/serve_audit/audit_policy.ts
@@ -33,12 +33,21 @@ export interface AuditPolicyRule {
 const MANAGEMENT_ACTIONS = new Set([
   "audit.query",
   "audit.verify",
+  "audit.subscribe",
   "serve.reload",
   "serve.health",
 ]);
 
-export function classifyTier(action: string): AuditEventTier {
+const MANAGEMENT_CATEGORIES = new Set<string>(["system"]);
+
+export function classifyTier(
+  action: string,
+  category?: string,
+): AuditEventTier {
   if (MANAGEMENT_ACTIONS.has(action)) return "management";
+  if (category !== undefined && MANAGEMENT_CATEGORIES.has(category)) {
+    return "management";
+  }
   return "data";
 }
 
@@ -63,7 +72,7 @@ export class AuditPolicy {
   }
 
   evaluate(category: AuditCategory, action: string): AuditLevel {
-    const tier = classifyTier(action);
+    const tier = classifyTier(action, category);
     for (const rule of this.#rules) {
       if (rule.category !== undefined && rule.category !== category) continue;
       if (rule.action !== undefined && rule.action !== action) continue;

--- a/src/domain/serve_audit/audit_policy_test.ts
+++ b/src/domain/serve_audit/audit_policy_test.ts
@@ -27,8 +27,18 @@ import {
 Deno.test("classifyTier: management actions", () => {
   assertEquals(classifyTier("audit.query"), "management");
   assertEquals(classifyTier("audit.verify"), "management");
+  assertEquals(classifyTier("audit.subscribe"), "management");
   assertEquals(classifyTier("serve.reload"), "management");
   assertEquals(classifyTier("serve.health"), "management");
+});
+
+Deno.test("classifyTier: system category is management tier", () => {
+  assertEquals(classifyTier("instance.start", "system"), "management");
+  assertEquals(classifyTier("instance.stop", "system"), "management");
+});
+
+Deno.test("classifyTier: non-system category with data action is data tier", () => {
+  assertEquals(classifyTier("model.run", "execution"), "data");
 });
 
 Deno.test("classifyTier: data actions", () => {

--- a/src/domain/serve_audit/audit_sink.ts
+++ b/src/domain/serve_audit/audit_sink.ts
@@ -21,6 +21,7 @@ import type { AuditEvent } from "./audit_event.ts";
 
 export interface AuditSink {
   readonly name: string;
+  readonly durable: boolean;
   write(events: readonly AuditEvent[]): Promise<void>;
   flush(): Promise<void>;
   close(): Promise<void>;

--- a/src/presentation/output/audit_log_output.ts
+++ b/src/presentation/output/audit_log_output.ts
@@ -22,6 +22,16 @@ import { writeOutput } from "../../infrastructure/logging/logger.ts";
 import type { AuditQueryResponse } from "../../serve/protocol.ts";
 import type { OutputMode } from "./output.ts";
 
+const COL_WIDTHS = [16, 9, 12, 30, 20, 30];
+const HEADERS = [
+  "TIME",
+  "OUTCOME",
+  "CATEGORY",
+  "ACTION",
+  "PRINCIPAL",
+  "RESOURCE",
+];
+
 function formatTimestamp(iso: string): string {
   try {
     const date = new Date(iso);
@@ -49,6 +59,39 @@ function outcomeColor(outcome: string): string {
   }
 }
 
+function formatEventRow(e: Record<string, string>): string {
+  const time = formatTimestamp(e.timestamp ?? "");
+  const outcome = outcomeColor(e.outcome ?? "");
+  const category = e.category ?? "";
+  const action = e.action ?? "";
+  const principal = e.principalId ?? "";
+  const resource = `${e.resourceKind ?? ""}:${e.resourceName ?? ""}`;
+
+  return `${dim(time.padEnd(COL_WIDTHS[0]))}  ${
+    outcome.padEnd(COL_WIDTHS[1] + (outcome.length - (e.outcome ?? "").length))
+  }  ${category.padEnd(COL_WIDTHS[2])}  ${action.padEnd(COL_WIDTHS[3])}  ${
+    principal.padEnd(COL_WIDTHS[4])
+  }  ${resource}`;
+}
+
+export function renderAuditLogHeader(mode: OutputMode): void {
+  if (mode === "json") return;
+  writeOutput(bold(dim(
+    HEADERS.map((h, i) => h.padEnd(COL_WIDTHS[i])).join("  "),
+  )));
+}
+
+export function renderAuditEvent(
+  event: Record<string, string>,
+  mode: OutputMode,
+): void {
+  if (mode === "json") {
+    console.log(JSON.stringify(event));
+    return;
+  }
+  writeOutput(formatEventRow(event));
+}
+
 export function renderAuditLog(
   data: AuditQueryResponse,
   mode: OutputMode,
@@ -63,37 +106,10 @@ export function renderAuditLog(
     return;
   }
 
-  const headers = [
-    "TIME",
-    "OUTCOME",
-    "CATEGORY",
-    "ACTION",
-    "PRINCIPAL",
-    "RESOURCE",
-  ];
-  writeOutput(bold(dim(
-    headers.map((h, i) => {
-      const widths = [16, 9, 12, 30, 20, 30];
-      return h.padEnd(widths[i]);
-    }).join("  "),
-  )));
+  renderAuditLogHeader(mode);
 
   for (const event of data.events) {
-    const e = event as Record<string, string>;
-    const time = formatTimestamp(e.timestamp ?? "");
-    const outcome = outcomeColor(e.outcome ?? "");
-    const category = e.category ?? "";
-    const action = e.action ?? "";
-    const principal = e.principalId ?? "";
-    const resource = `${e.resourceKind ?? ""}:${e.resourceName ?? ""}`;
-
-    writeOutput(
-      `${dim(time.padEnd(16))}  ${
-        outcome.padEnd(9 + (outcome.length - (e.outcome ?? "").length))
-      }  ${category.padEnd(12)}  ${action.padEnd(30)}  ${
-        principal.padEnd(20)
-      }  ${resource}`,
-    );
+    renderAuditEvent(event as Record<string, string>, mode);
   }
 
   if (data.total !== undefined) {

--- a/src/presentation/output/audit_log_output_test.ts
+++ b/src/presentation/output/audit_log_output_test.ts
@@ -20,7 +20,11 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { stripAnsiCode } from "@std/fmt/colors";
 import type { AuditQueryResponse } from "../../serve/protocol.ts";
-import { renderAuditLog } from "./audit_log_output.ts";
+import {
+  renderAuditEvent,
+  renderAuditLog,
+  renderAuditLogHeader,
+} from "./audit_log_output.ts";
 
 function captureLogs(fn: () => void): string {
   const logs: string[] = [];
@@ -121,4 +125,47 @@ Deno.test("renderAuditLog: log mode includes date in timestamp", () => {
   // The formatter uses local time, so just check that it has MM-DD format
   // (two digits, dash, two digits pattern somewhere)
   assertEquals(output.match(/\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}/) !== null, true);
+});
+
+// ── renderAuditLogHeader tests ─────────────────────────────────────────
+
+Deno.test("renderAuditLogHeader: log mode prints column headers", () => {
+  const output = captureLogs(() => renderAuditLogHeader("log"));
+  assertStringIncludes(output, "TIME");
+  assertStringIncludes(output, "OUTCOME");
+  assertStringIncludes(output, "CATEGORY");
+  assertStringIncludes(output, "ACTION");
+});
+
+Deno.test("renderAuditLogHeader: json mode prints nothing", () => {
+  const output = captureLogs(() => renderAuditLogHeader("json"));
+  assertEquals(output, "");
+});
+
+// ── renderAuditEvent tests ────────────────────────────────────────────
+
+Deno.test("renderAuditEvent: log mode prints event row", () => {
+  const event = {
+    timestamp: "2026-09-06T12:00:00.000Z",
+    outcome: "success",
+    category: "execution",
+    action: "model.method.run",
+    principalId: "user:test",
+    resourceKind: "model",
+    resourceName: "hello",
+  };
+  const output = captureLogs(() => renderAuditEvent(event, "log"));
+  assertStringIncludes(output, "model.method.run");
+  assertStringIncludes(output, "user:test");
+});
+
+Deno.test("renderAuditEvent: json mode prints JSON", () => {
+  const event = {
+    action: "vault.get",
+    outcome: "denied",
+  };
+  const output = captureLogs(() => renderAuditEvent(event, "json"));
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.action, "vault.get");
+  assertEquals(parsed.outcome, "denied");
 });

--- a/src/serve/audit_sinks/store_sink.ts
+++ b/src/serve/audit_sinks/store_sink.ts
@@ -54,6 +54,7 @@ function unwrapStore(
 
 export class StoreSink implements AuditSink {
   readonly name = "store";
+  readonly durable = true;
   readonly #stores: readonly { store: AuditStore; retentionDays?: number }[];
   readonly #batchSize: number;
   readonly #flushIntervalMs: number;

--- a/src/serve/audit_sinks/wal_sink.ts
+++ b/src/serve/audit_sinks/wal_sink.ts
@@ -31,6 +31,7 @@ export interface WalSinkOptions {
 
 export class WalSink implements AuditSink {
   readonly name = "wal";
+  readonly durable = true;
   readonly #wal: AuditWal;
   readonly #downstream: AuditSink;
   readonly #delivered = new Set<string>();

--- a/src/serve/audit_sinks/wal_sink_test.ts
+++ b/src/serve/audit_sinks/wal_sink_test.ts
@@ -64,6 +64,7 @@ function createMockSink(): AuditSink & {
 } {
   const sink = {
     name: "mock-downstream",
+    durable: true,
     written: [] as AuditEvent[][],
     flushed: 0,
     closed: false,
@@ -86,6 +87,7 @@ function createMockSink(): AuditSink & {
 function createFailingSink(): AuditSink & { failWrites: boolean } {
   return {
     name: "failing-downstream",
+    durable: true,
     failWrites: true,
     write(): Promise<void> {
       if (this.failWrites) {
@@ -180,6 +182,7 @@ Deno.test(
     let writeCount = 0;
     const failOnSecond: AuditSink = {
       name: "fail-on-second",
+      durable: true,
       write(): Promise<void> {
         writeCount++;
         if (writeCount >= 2) {

--- a/src/serve/audit_sinks/websocket_sink.ts
+++ b/src/serve/audit_sinks/websocket_sink.ts
@@ -1,0 +1,149 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import type {
+  AuditCategory,
+  AuditEvent,
+  AuditOutcome,
+} from "../../domain/serve_audit/audit_event.ts";
+import type { AuditSink } from "../../domain/serve_audit/audit_sink.ts";
+
+const logger = getSwampLogger(["serve", "audit", "websocket-sink"]);
+
+export interface AuditSubscriptionFilter {
+  readonly categories?: readonly AuditCategory[];
+  readonly principals?: readonly string[];
+  readonly actions?: readonly string[];
+  readonly outcomes?: readonly AuditOutcome[];
+  readonly resourceKind?: string;
+}
+
+export interface AuditSubscription {
+  readonly id: string;
+  readonly socket: WebSocket;
+  readonly filter: AuditSubscriptionFilter;
+}
+
+function matchesFilter(
+  event: AuditEvent,
+  filter: AuditSubscriptionFilter,
+): boolean {
+  if (
+    filter.categories && filter.categories.length > 0 &&
+    !filter.categories.includes(event.category)
+  ) {
+    return false;
+  }
+  if (
+    filter.principals && filter.principals.length > 0 &&
+    !filter.principals.includes(event.principalId)
+  ) {
+    return false;
+  }
+  if (
+    filter.actions && filter.actions.length > 0 &&
+    !filter.actions.includes(event.action)
+  ) {
+    return false;
+  }
+  if (
+    filter.outcomes && filter.outcomes.length > 0 &&
+    !filter.outcomes.includes(event.outcome)
+  ) {
+    return false;
+  }
+  if (
+    filter.resourceKind !== undefined &&
+    event.resourceKind !== filter.resourceKind
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export class WebSocketSink implements AuditSink {
+  readonly name = "websocket";
+  readonly durable = false;
+  readonly #subscriptions = new Map<string, AuditSubscription>();
+
+  subscribe(subscription: AuditSubscription): void {
+    this.#subscriptions.set(subscription.id, subscription);
+    logger.info(
+      "Audit subscription {id} registered, {count} active",
+      { id: subscription.id, count: this.#subscriptions.size },
+    );
+  }
+
+  unsubscribe(id: string): void {
+    if (this.#subscriptions.delete(id)) {
+      logger.info(
+        "Audit subscription {id} removed, {count} active",
+        { id, count: this.#subscriptions.size },
+      );
+    }
+  }
+
+  get subscriptionCount(): number {
+    return this.#subscriptions.size;
+  }
+
+  subscriptionsForSocket(socket: WebSocket): string[] {
+    const ids: string[] = [];
+    for (const [id, sub] of this.#subscriptions) {
+      if (sub.socket === socket) ids.push(id);
+    }
+    return ids;
+  }
+
+  async write(events: readonly AuditEvent[]): Promise<void> {
+    if (this.#subscriptions.size === 0) return;
+
+    for (const [id, sub] of this.#subscriptions) {
+      if (sub.socket.readyState !== WebSocket.OPEN) {
+        this.#subscriptions.delete(id);
+        continue;
+      }
+
+      for (const event of events) {
+        if (!matchesFilter(event, sub.filter)) continue;
+        try {
+          sub.socket.send(JSON.stringify({
+            type: "audit.event",
+            id: sub.id,
+            payload: { event },
+          }));
+        } catch {
+          this.#subscriptions.delete(id);
+          break;
+        }
+      }
+    }
+    await Promise.resolve();
+  }
+
+  async flush(): Promise<void> {
+    await Promise.resolve();
+  }
+
+  async close(): Promise<void> {
+    this.#subscriptions.clear();
+    await Promise.resolve();
+  }
+}

--- a/src/serve/audit_sinks/websocket_sink_test.ts
+++ b/src/serve/audit_sinks/websocket_sink_test.ts
@@ -1,0 +1,260 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { createAuditEvent } from "../../domain/serve_audit/audit_event.ts";
+import type { AuditEvent } from "../../domain/serve_audit/audit_event.ts";
+import { WebSocketSink } from "./websocket_sink.ts";
+
+function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
+  return createAuditEvent({
+    instanceId: "test-instance",
+    category: "access",
+    stage: "response",
+    outcome: "success",
+    action: "model.run",
+    resourceKind: "model",
+    resourceName: "test-model",
+    principalKind: "user",
+    principalId: "user-1",
+    initiatedBy: "user:test",
+    sourceIp: "127.0.0.1",
+    requestId: crypto.randomUUID(),
+    ...overrides,
+  });
+}
+
+function mockSocket(
+  readyState = WebSocket.OPEN,
+): { socket: WebSocket; sent: string[] } {
+  const sent: string[] = [];
+  const socket = {
+    readyState,
+    send(data: string) {
+      sent.push(data);
+    },
+    close() {},
+  } as unknown as WebSocket;
+  return { socket, sent };
+}
+
+Deno.test("WebSocketSink: subscribe and receive events", async () => {
+  const sink = new WebSocketSink();
+  const { socket, sent } = mockSocket();
+
+  sink.subscribe({ id: "sub-1", socket, filter: {} });
+  assertEquals(sink.subscriptionCount, 1);
+
+  const event = makeEvent();
+  await sink.write([event]);
+
+  assertEquals(sent.length, 1);
+  const parsed = JSON.parse(sent[0]);
+  assertEquals(parsed.type, "audit.event");
+  assertEquals(parsed.id, "sub-1");
+  assertEquals(parsed.payload.event.id, event.id);
+});
+
+Deno.test("WebSocketSink: filter by category", async () => {
+  const sink = new WebSocketSink();
+  const { socket, sent } = mockSocket();
+
+  sink.subscribe({
+    id: "sub-1",
+    socket,
+    filter: { categories: ["secrets"] },
+  });
+
+  await sink.write([
+    makeEvent({ category: "access" }),
+    makeEvent({ category: "secrets" }),
+  ]);
+
+  assertEquals(sent.length, 1);
+  const parsed = JSON.parse(sent[0]);
+  assertEquals(parsed.payload.event.category, "secrets");
+});
+
+Deno.test("WebSocketSink: filter by principal", async () => {
+  const sink = new WebSocketSink();
+  const { socket, sent } = mockSocket();
+
+  sink.subscribe({
+    id: "sub-1",
+    socket,
+    filter: { principals: ["user-2"] },
+  });
+
+  await sink.write([
+    makeEvent({ principalId: "user-1" }),
+    makeEvent({ principalId: "user-2" }),
+  ]);
+
+  assertEquals(sent.length, 1);
+  const parsed = JSON.parse(sent[0]);
+  assertEquals(parsed.payload.event.principalId, "user-2");
+});
+
+Deno.test("WebSocketSink: filter by outcome", async () => {
+  const sink = new WebSocketSink();
+  const { socket, sent } = mockSocket();
+
+  sink.subscribe({
+    id: "sub-1",
+    socket,
+    filter: { outcomes: ["denied"] },
+  });
+
+  await sink.write([
+    makeEvent({ outcome: "success" }),
+    makeEvent({ outcome: "denied" }),
+  ]);
+
+  assertEquals(sent.length, 1);
+});
+
+Deno.test("WebSocketSink: filter by action", async () => {
+  const sink = new WebSocketSink();
+  const { socket, sent } = mockSocket();
+
+  sink.subscribe({
+    id: "sub-1",
+    socket,
+    filter: { actions: ["vault.get"] },
+  });
+
+  await sink.write([
+    makeEvent({ action: "model.run" }),
+    makeEvent({ action: "vault.get" }),
+  ]);
+
+  assertEquals(sent.length, 1);
+});
+
+Deno.test("WebSocketSink: filter by resourceKind", async () => {
+  const sink = new WebSocketSink();
+  const { socket, sent } = mockSocket();
+
+  sink.subscribe({
+    id: "sub-1",
+    socket,
+    filter: { resourceKind: "vault" },
+  });
+
+  await sink.write([
+    makeEvent({ resourceKind: "model" }),
+    makeEvent({ resourceKind: "vault" }),
+  ]);
+
+  assertEquals(sent.length, 1);
+});
+
+Deno.test("WebSocketSink: empty filter matches all events", async () => {
+  const sink = new WebSocketSink();
+  const { socket, sent } = mockSocket();
+
+  sink.subscribe({ id: "sub-1", socket, filter: {} });
+
+  await sink.write([makeEvent(), makeEvent(), makeEvent()]);
+
+  assertEquals(sent.length, 3);
+});
+
+Deno.test("WebSocketSink: unsubscribe removes subscription", async () => {
+  const sink = new WebSocketSink();
+  const { socket, sent } = mockSocket();
+
+  sink.subscribe({ id: "sub-1", socket, filter: {} });
+  sink.unsubscribe("sub-1");
+  assertEquals(sink.subscriptionCount, 0);
+
+  await sink.write([makeEvent()]);
+  assertEquals(sent.length, 0);
+});
+
+Deno.test("WebSocketSink: closed socket is auto-removed", async () => {
+  const sink = new WebSocketSink();
+  const { socket } = mockSocket(WebSocket.CLOSED);
+
+  sink.subscribe({ id: "sub-1", socket, filter: {} });
+  await sink.write([makeEvent()]);
+
+  assertEquals(sink.subscriptionCount, 0);
+});
+
+Deno.test("WebSocketSink: multiple subscribers receive independently", async () => {
+  const sink = new WebSocketSink();
+  const { socket: socket1, sent: sent1 } = mockSocket();
+  const { socket: socket2, sent: sent2 } = mockSocket();
+
+  sink.subscribe({
+    id: "sub-1",
+    socket: socket1,
+    filter: { categories: ["access"] },
+  });
+  sink.subscribe({
+    id: "sub-2",
+    socket: socket2,
+    filter: { categories: ["secrets"] },
+  });
+
+  await sink.write([
+    makeEvent({ category: "access" }),
+    makeEvent({ category: "secrets" }),
+  ]);
+
+  assertEquals(sent1.length, 1);
+  assertEquals(sent2.length, 1);
+});
+
+Deno.test("WebSocketSink: subscriptionsForSocket returns correct ids", () => {
+  const sink = new WebSocketSink();
+  const { socket: socket1 } = mockSocket();
+  const { socket: socket2 } = mockSocket();
+
+  sink.subscribe({ id: "sub-1", socket: socket1, filter: {} });
+  sink.subscribe({ id: "sub-2", socket: socket1, filter: {} });
+  sink.subscribe({ id: "sub-3", socket: socket2, filter: {} });
+
+  const ids = sink.subscriptionsForSocket(socket1);
+  assertEquals(ids.sort(), ["sub-1", "sub-2"]);
+});
+
+Deno.test("WebSocketSink: durable is false", () => {
+  const sink = new WebSocketSink();
+  assertEquals(sink.durable, false);
+});
+
+Deno.test("WebSocketSink: close clears all subscriptions", async () => {
+  const sink = new WebSocketSink();
+  const { socket } = mockSocket();
+
+  sink.subscribe({ id: "sub-1", socket, filter: {} });
+  sink.subscribe({ id: "sub-2", socket, filter: {} });
+
+  await sink.close();
+  assertEquals(sink.subscriptionCount, 0);
+});
+
+Deno.test("WebSocketSink: no-op when no subscriptions", async () => {
+  const sink = new WebSocketSink();
+  await sink.write([makeEvent()]);
+  await sink.flush();
+  await sink.close();
+});

--- a/src/serve/audited_test.ts
+++ b/src/serve/audited_test.ts
@@ -29,6 +29,7 @@ await initializeLogging({});
 function createCaptureSink(): AuditSink & { events: AuditEvent[] } {
   const sink = {
     name: "capture",
+    durable: true,
     events: [] as AuditEvent[],
     write(events: readonly AuditEvent[]): Promise<void> {
       sink.events.push(...events);

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -1602,7 +1602,7 @@ export function handleMessage(
         auditOpts(
           "execution",
           "workflow",
-          "*",
+          request.payload?.workflowIdOrName ?? "*",
         ),
       );
       break;
@@ -1718,7 +1718,7 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("data", "data", "*"),
+        auditOpts("data", "data", request.payload?.predicate ?? "*"),
       );
       break;
     case "data.list":
@@ -1744,7 +1744,11 @@ export function handleMessage(
           principal,
           request.payload,
         ),
-        auditOpts("data", "data", "*"),
+        auditOpts(
+          "data",
+          "data",
+          request.payload?.query ?? request.payload?.model ?? "*",
+        ),
       );
       break;
     case "data.versions":
@@ -1796,7 +1800,7 @@ export function handleMessage(
           principal,
           request.payload,
         ),
-        auditOpts("data", "model", "*"),
+        auditOpts("data", "model", request.payload?.query ?? "*"),
       );
       break;
     case "model.method.describe":
@@ -1822,7 +1826,7 @@ export function handleMessage(
           principal,
           request.payload,
         ),
-        auditOpts("data", "workflow", "*"),
+        auditOpts("data", "workflow", request.payload?.query ?? "*"),
       );
       break;
     case "workflow.approvals":
@@ -2189,7 +2193,11 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("data", "model", "*"),
+        auditOpts(
+          "data",
+          "model",
+          request.payload?.outputIdOrModelName ?? "*",
+        ),
       );
       break;
     case "model.output.data":
@@ -2202,7 +2210,7 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("data", "model", "*"),
+        auditOpts("data", "model", request.payload?.outputIdArg ?? "*"),
       );
       break;
     case "model.output.logs":
@@ -2215,7 +2223,7 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("data", "model", "*"),
+        auditOpts("data", "model", request.payload?.outputIdArg ?? "*"),
       );
       break;
     case "model.output.search":
@@ -2228,7 +2236,7 @@ export function handleMessage(
           principal,
           request.payload,
         ),
-        auditOpts("data", "model", "*"),
+        auditOpts("data", "model", request.payload?.query ?? "*"),
       );
       break;
     case "model.method.history.get":
@@ -2241,7 +2249,11 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("data", "model", "*"),
+        auditOpts(
+          "data",
+          "model",
+          request.payload?.outputIdOrModelName ?? "*",
+        ),
       );
       break;
     case "model.method.history.logs":
@@ -2254,7 +2266,11 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("data", "model", "*"),
+        auditOpts(
+          "data",
+          "model",
+          request.payload?.outputIdOrModelName ?? "*",
+        ),
       );
       break;
     case "model.method.history.search":
@@ -2267,7 +2283,7 @@ export function handleMessage(
           principal,
           request.payload,
         ),
-        auditOpts("data", "model", "*"),
+        auditOpts("data", "model", request.payload?.query ?? "*"),
       );
       break;
     case "model.validate":
@@ -2280,7 +2296,11 @@ export function handleMessage(
           principal,
           request.payload,
         ),
-        auditOpts("data", "model", "*"),
+        auditOpts(
+          "data",
+          "model",
+          request.payload?.modelIdOrName ?? "*",
+        ),
       );
       break;
     case "model.evaluate":
@@ -2293,7 +2313,11 @@ export function handleMessage(
           principal,
           request.payload,
         ),
-        auditOpts("execution", "model", "*"),
+        auditOpts(
+          "execution",
+          "model",
+          request.payload?.modelIdOrName ?? "*",
+        ),
       );
       break;
     case "workflow.get":
@@ -2306,7 +2330,11 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("data", "workflow", "*"),
+        auditOpts(
+          "data",
+          "workflow",
+          request.payload?.workflowIdOrName ?? "*",
+        ),
       );
       break;
     case "workflow.history.get":
@@ -2319,7 +2347,11 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("data", "workflow", "*"),
+        auditOpts(
+          "data",
+          "workflow",
+          request.payload?.workflowIdOrName ?? "*",
+        ),
       );
       break;
     case "workflow.history.logs":
@@ -2345,7 +2377,11 @@ export function handleMessage(
           principal,
           request.payload,
         ),
-        auditOpts("data", "workflow", "*"),
+        auditOpts(
+          "data",
+          "workflow",
+          request.payload?.query ?? request.payload?.workflow ?? "*",
+        ),
       );
       break;
     case "workflow.run.search":
@@ -2358,7 +2394,7 @@ export function handleMessage(
           principal,
           request.payload,
         ),
-        auditOpts("data", "workflow", "*"),
+        auditOpts("data", "workflow", request.payload?.query ?? "*"),
       );
       break;
     case "workflow.schema":
@@ -2371,7 +2407,11 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("data", "workflow", "*"),
+        auditOpts(
+          "data",
+          "workflow",
+          request.payload?.workflowIdOrName ?? "*",
+        ),
       );
       break;
     case "workflow.approve":
@@ -2826,7 +2866,7 @@ export function handleMessage(
           principal,
           request.payload,
         ),
-        auditOpts("data", "model", "*"),
+        auditOpts("data", "model", request.payload?.query ?? "*"),
       );
       break;
     case "workflow.create":
@@ -2855,7 +2895,7 @@ export function handleMessage(
         auditOpts(
           "admin",
           "workflow",
-          "*",
+          request.payload?.workflowIdOrName ?? "*",
         ),
       );
       break;
@@ -2872,7 +2912,7 @@ export function handleMessage(
         auditOpts(
           "admin",
           "workflow",
-          "*",
+          request.payload?.workflowIdOrName ?? "*",
         ),
       );
       break;
@@ -2886,7 +2926,11 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("data", "workflow", "*"),
+        auditOpts(
+          "data",
+          "workflow",
+          request.payload?.workflowIdOrName ?? "*",
+        ),
       );
       break;
     case "workflow.evaluate":
@@ -2899,7 +2943,11 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("execution", "workflow", "*"),
+        auditOpts(
+          "execution",
+          "workflow",
+          request.payload?.workflowIdOrName ?? "*",
+        ),
       );
       break;
     case "workflow.trigger.set":
@@ -2912,7 +2960,11 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("admin", "workflow", "*"),
+        auditOpts(
+          "admin",
+          "workflow",
+          request.payload?.workflowName ?? "*",
+        ),
       );
       break;
     case "workflow.trigger.get":
@@ -2925,7 +2977,7 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("data", "workflow", "*"),
+        auditOpts("data", "workflow", request.payload?.workflowName ?? "*"),
       );
       break;
     case "workflow.trigger.remove":
@@ -2938,7 +2990,11 @@ export function handleMessage(
           controller,
           principal,
         ),
-        auditOpts("admin", "workflow", "*"),
+        auditOpts(
+          "admin",
+          "workflow",
+          request.payload?.workflowName ?? "*",
+        ),
       );
       break;
     case "vault.create":

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -28,6 +28,7 @@ import { getSwampLogger } from "../infrastructure/logging/logger.ts";
 import type { Principal } from "../domain/access/principal.ts";
 import { audited, type AuditedOptions } from "./audited.ts";
 import { AuditQueryService } from "../domain/serve_audit/audit_query_service.ts";
+import type { AuditSubscriptionFilter } from "./audit_sinks/websocket_sink.ts";
 import {
   GIT_SHA as SERVER_GIT_SHA,
   VERSION as SERVER_VERSION,
@@ -467,6 +468,29 @@ const AuditVerifyRequestSchema = z.object({
     since: z.string().optional(),
     until: z.string().optional(),
   }),
+});
+
+const MAX_AUDIT_FILTER_ITEMS = 20;
+
+const AuditSubscribeRequestSchema = z.object({
+  type: z.literal("audit.subscribe"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    categories: z.array(z.string().max(64)).max(MAX_AUDIT_FILTER_ITEMS)
+      .optional(),
+    principals: z.array(z.string().max(256)).max(MAX_AUDIT_FILTER_ITEMS)
+      .optional(),
+    actions: z.array(z.string().max(256)).max(MAX_AUDIT_FILTER_ITEMS)
+      .optional(),
+    outcomes: z.array(z.string().max(64)).max(MAX_AUDIT_FILTER_ITEMS)
+      .optional(),
+    resourceKind: z.string().max(256).optional(),
+  }).optional(),
+});
+
+const AuditUnsubscribeRequestSchema = z.object({
+  type: z.literal("audit.unsubscribe"),
+  id: z.string().min(1).max(256),
 });
 
 const SummariseRequestSchema = z.object({
@@ -1204,6 +1228,8 @@ const ServerRequestSchema = z.discriminatedUnion("type", [
   AuditTimelineRequestSchema,
   AuditQueryRequestSchema,
   AuditVerifyRequestSchema,
+  AuditSubscribeRequestSchema,
+  AuditUnsubscribeRequestSchema,
   SummariseRequestSchema,
   ReportGetRequestSchema,
   ReportSearchRequestSchema,
@@ -1322,12 +1348,17 @@ export function extractRequestId(data: unknown): string {
 
 const logger = getSwampLogger(["serve", "connection"]);
 
+const MAX_SUBSCRIPTIONS_PER_CONNECTION = 2;
+const SUBSCRIPTION_REAUTH_INTERVAL_MS = 60_000;
+
 export function handleConnection(
   socket: WebSocket,
   ctx: ConnectionContext,
   principal: Principal | null,
 ): void {
   const activeRequests = new Map<string, AbortController>();
+  const activeSubscriptions = new Set<string>();
+  const subscriptionTimers = new Map<string, ReturnType<typeof setInterval>>();
   const workerAttachment = ctx.workerGateway?.attachTransport({
     send: (data) => {
       if (socket.readyState === WebSocket.OPEN) {
@@ -1364,7 +1395,15 @@ export function handleConnection(
     ) {
       return;
     }
-    handleMessage(socket, ctx, activeRequests, event, principal);
+    handleMessage(
+      socket,
+      ctx,
+      activeRequests,
+      event,
+      principal,
+      activeSubscriptions,
+      subscriptionTimers,
+    );
   };
 
   socket.onclose = () => {
@@ -1374,6 +1413,16 @@ export function handleConnection(
       controller.abort();
     }
     activeRequests.clear();
+    if (ctx.auditWebSocketSink) {
+      for (const subId of activeSubscriptions) {
+        ctx.auditWebSocketSink.unsubscribe(subId);
+      }
+    }
+    for (const timer of subscriptionTimers.values()) {
+      clearInterval(timer);
+    }
+    activeSubscriptions.clear();
+    subscriptionTimers.clear();
   };
 
   socket.onerror = (event) => {
@@ -1393,6 +1442,8 @@ export function handleMessage(
   activeRequests: Map<string, AbortController>,
   event: MessageEvent,
   principal: Principal | null = null,
+  activeSubscriptions: Set<string> = new Set(),
+  subscriptionTimers: Map<string, ReturnType<typeof setInterval>> = new Map(),
 ): void {
   let parsed: unknown;
   try {
@@ -1921,6 +1972,109 @@ export function handleMessage(
         auditOpts("admin", "access", "audit"),
       );
       break;
+    case "audit.subscribe":
+      if (
+        !authorizeOrReject(
+          socket,
+          request.id,
+          principal,
+          "admin",
+          { kind: "access", name: "audit", fields: {} },
+          ctx,
+        ).allowed
+      ) {
+        task = Promise.resolve();
+        activeRequests.delete(request.id);
+        break;
+      }
+      task = audited(
+        (() => {
+          if (!ctx.auditWebSocketSink) {
+            sendError(
+              socket,
+              request.id,
+              "audit_not_configured",
+              "Audit subsystem is not enabled",
+            );
+            return Promise.resolve();
+          }
+          if (activeSubscriptions.size >= MAX_SUBSCRIPTIONS_PER_CONNECTION) {
+            sendError(
+              socket,
+              request.id,
+              "subscription_limit",
+              `Maximum ${MAX_SUBSCRIPTIONS_PER_CONNECTION} audit subscriptions per connection`,
+            );
+            return Promise.resolve();
+          }
+          const filter: AuditSubscriptionFilter = request.payload
+            ? {
+              categories: request.payload.categories as
+                | AuditSubscriptionFilter["categories"]
+                | undefined,
+              principals: request.payload.principals,
+              actions: request.payload.actions,
+              outcomes: request.payload.outcomes as
+                | AuditSubscriptionFilter["outcomes"]
+                | undefined,
+              resourceKind: request.payload.resourceKind,
+            }
+            : {};
+          const subscriptionId = crypto.randomUUID();
+          ctx.auditWebSocketSink.subscribe({
+            id: subscriptionId,
+            socket,
+            filter,
+          });
+          activeSubscriptions.add(subscriptionId);
+
+          const reauthTimer = setInterval(() => {
+            const result = authorizeOrReject(
+              socket,
+              subscriptionId,
+              principal,
+              "admin",
+              { kind: "access", name: "audit", fields: {} },
+              ctx,
+            );
+            if (!result.allowed) {
+              ctx.auditWebSocketSink!.unsubscribe(subscriptionId);
+              activeSubscriptions.delete(subscriptionId);
+              clearInterval(reauthTimer);
+              subscriptionTimers.delete(subscriptionId);
+            }
+          }, SUBSCRIPTION_REAUTH_INTERVAL_MS);
+          Deno.unrefTimer(reauthTimer);
+          subscriptionTimers.set(subscriptionId, reauthTimer);
+
+          send(socket, {
+            type: "audit.subscribe",
+            id: request.id,
+            payload: { subscriptionId },
+          });
+          return Promise.resolve();
+        })(),
+        auditOpts("admin", "access", "audit"),
+      );
+      break;
+    case "audit.unsubscribe": {
+      const subIds = ctx.auditWebSocketSink
+        ? ctx.auditWebSocketSink.subscriptionsForSocket(socket)
+        : [];
+      for (const subId of subIds) {
+        ctx.auditWebSocketSink!.unsubscribe(subId);
+        activeSubscriptions.delete(subId);
+        const timer = subscriptionTimers.get(subId);
+        if (timer) {
+          clearInterval(timer);
+          subscriptionTimers.delete(subId);
+        }
+      }
+      send(socket, { type: "audit.unsubscribe", id: request.id });
+      task = Promise.resolve();
+      activeRequests.delete(request.id);
+      break;
+    }
     case "summarise":
       task = audited(
         handleSummarise(

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -52,7 +52,10 @@ import type { ScheduledExecutionService } from "../../libswamp/mod.ts";
 import type { MergedServeOptions } from "../serve_config.ts";
 import type { HealthCollector } from "../health_collector.ts";
 import type { AuditEmitter } from "../../domain/serve_audit/audit_emitter.ts";
-import type { AuditDecision } from "../../domain/serve_audit/audit_event.ts";
+import type {
+  AuditCategory,
+  AuditDecision,
+} from "../../domain/serve_audit/audit_event.ts";
 import { buildAuditEvent } from "../../domain/serve_audit/audit_event_builder.ts";
 import type { AuditStore } from "../../domain/serve_audit/audit_store.ts";
 import type { AuditPolicy } from "../../domain/serve_audit/audit_policy.ts";
@@ -182,6 +185,8 @@ export interface ConnectionContext {
   auditFailOpen?: boolean;
   /** WAL instance — used to check health for fail-secure mode. */
   auditWal?: AuditWal;
+  /** WebSocket audit sink — broadcasts events to subscribed connections. */
+  auditWebSocketSink?: import("../audit_sinks/websocket_sink.ts").WebSocketSink;
 }
 
 // SECURITY: Authorization must operate on canonical (normalized) model types,
@@ -716,4 +721,27 @@ export function subscribeUntilDetach(
       unsub();
     }, { once: true });
   });
+}
+
+export function emitSystemAuditEvent(
+  ctx: ConnectionContext,
+  action: string,
+  detail?: string,
+): void {
+  if (!ctx.auditEmitter) return;
+  ctx.auditEmitter.emit(buildAuditEvent({
+    instanceId: ctx.instanceId ?? "unknown",
+    category: "system" as AuditCategory,
+    stage: "response",
+    outcome: "success",
+    action,
+    resourceKind: "server",
+    resourceName: ctx.instanceId ?? "unknown",
+    principalKind: "system",
+    principalId: "system",
+    initiatedBy: "system",
+    sourceIp: "127.0.0.1",
+    requestId: crypto.randomUUID(),
+    detail,
+  }));
 }

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -52,10 +52,7 @@ import type { ScheduledExecutionService } from "../../libswamp/mod.ts";
 import type { MergedServeOptions } from "../serve_config.ts";
 import type { HealthCollector } from "../health_collector.ts";
 import type { AuditEmitter } from "../../domain/serve_audit/audit_emitter.ts";
-import type {
-  AuditCategory,
-  AuditDecision,
-} from "../../domain/serve_audit/audit_event.ts";
+import type { AuditDecision } from "../../domain/serve_audit/audit_event.ts";
 import { buildAuditEvent } from "../../domain/serve_audit/audit_event_builder.ts";
 import type { AuditStore } from "../../domain/serve_audit/audit_store.ts";
 import type { AuditPolicy } from "../../domain/serve_audit/audit_policy.ts";
@@ -731,7 +728,7 @@ export function emitSystemAuditEvent(
   if (!ctx.auditEmitter) return;
   ctx.auditEmitter.emit(buildAuditEvent({
     instanceId: ctx.instanceId ?? "unknown",
-    category: "system" as AuditCategory,
+    category: "system",
     stage: "response",
     outcome: "success",
     action,

--- a/src/serve/handlers/shared_test.ts
+++ b/src/serve/handlers/shared_test.ts
@@ -26,6 +26,7 @@ import type { Principal } from "../../domain/access/principal.ts";
 import {
   authorizeAnyOrReject,
   type ConnectionContext,
+  emitSystemAuditEvent,
   filterByAuthorization,
   setConnectionCollectives,
 } from "./shared.ts";
@@ -335,4 +336,34 @@ Deno.test("authorizeAnyOrReject: returns true for admin fallback", () => {
     ctx,
   );
   assertEquals(result, true);
+});
+
+// ── emitSystemAuditEvent tests ─────────────────────────────────────────
+
+Deno.test("emitSystemAuditEvent: emits event with system category", () => {
+  const emitted: unknown[] = [];
+  const ctx = {
+    auditEmitter: {
+      emit(event: unknown) {
+        emitted.push(event);
+      },
+    },
+    instanceId: "test-instance",
+  } as unknown as ConnectionContext;
+
+  emitSystemAuditEvent(ctx, "instance.start", "version=1.0");
+
+  assertEquals(emitted.length, 1);
+  const event = emitted[0] as Record<string, unknown>;
+  assertEquals(event.category, "system");
+  assertEquals(event.action, "instance.start");
+  assertEquals(event.principalKind, "system");
+  assertEquals(event.principalId, "system");
+  assertEquals(event.detail, "version=1.0");
+  assertEquals(event.resourceKind, "server");
+});
+
+Deno.test("emitSystemAuditEvent: no-op without emitter", () => {
+  const ctx = {} as unknown as ConnectionContext;
+  emitSystemAuditEvent(ctx, "instance.start");
 });

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -173,6 +173,22 @@ export interface AuditVerifyPayload {
   until?: string;
 }
 
+export interface AuditSubscribePayload {
+  categories?: string[];
+  principals?: string[];
+  actions?: string[];
+  outcomes?: string[];
+  resourceKind?: string;
+}
+
+export interface AuditEventPayload {
+  event: Record<string, unknown>;
+}
+
+export interface AuditSubscribeResponse {
+  subscriptionId: string;
+}
+
 export interface SummarisePayload {
   since?: string;
   limit?: number;
@@ -750,6 +766,8 @@ export type ServerRequest =
   | { type: "audit.timeline"; id: string; payload?: AuditTimelinePayload }
   | { type: "audit.query"; id: string; payload: AuditQueryPayload }
   | { type: "audit.verify"; id: string; payload: AuditVerifyPayload }
+  | { type: "audit.subscribe"; id: string; payload?: AuditSubscribePayload }
+  | { type: "audit.unsubscribe"; id: string }
   | { type: "summarise"; id: string; payload?: SummarisePayload }
   | { type: "report.get"; id: string; payload: ReportGetPayload }
   | { type: "report.search"; id: string; payload?: ReportSearchPayload }
@@ -1552,6 +1570,9 @@ export type ServerMessage =
   | { type: "audit.timeline"; id: string; payload: AuditTimelineResponse }
   | { type: "audit.query"; id: string; payload: AuditQueryResponse }
   | { type: "audit.verify"; id: string; payload: AuditVerifyResponse }
+  | { type: "audit.subscribe"; id: string; payload: AuditSubscribeResponse }
+  | { type: "audit.unsubscribe"; id: string }
+  | { type: "audit.event"; id: string; payload: AuditEventPayload }
   | { type: "summarise"; id: string; payload: SummariseResponse }
   | { type: "report.get"; id: string; payload: ReportGetResponse }
   | { type: "report.search"; id: string; payload: ReportSearchResponse }


### PR DESCRIPTION
## Summary

Phase 3 of the serve audit log (#2049). Adds real-time audit event streaming over WebSocket and a dashboard Activity page for live monitoring.

### Server-side
- **Multi-sink AuditEmitter** — removed single-sink restriction with durable/non-durable distinction for chain state rollback
- **WebSocketSink** — broadcasts audit events to subscribed WebSocket connections with per-subscriber filtering and backpressure
- **`audit.subscribe` / `audit.unsubscribe`** protocol types with Zod-validated filters (bounded arrays), per-connection cap of 2 subscriptions, periodic re-authorization (60s)
- **`system` audit category** — `instance.start` and `instance.stop` lifecycle events, classified as management tier
- **Wildcard resource fix** — ~30 handlers now record actual model/workflow names instead of `*` in audit events

### CLI
- **`--follow` flag** on `swamp audit log` — queries historical events then subscribes for live streaming via `subscribeServerEvents`
- **Streaming output** — `renderAuditEvent` / `renderAuditLogHeader` for incremental rendering

### Dashboard
- **Activity page** with real-time WebSocket audit event stream
- Multi-select category and outcome filters
- Live/Paused toggle with visual state indicator
- Configurable event limits (100/500/1000)
- Expandable event details with decision block, method name, principal kind

### Follow-up issues
- #2057 — emit auth-category events for OAuth device flow
- #2058 — closed (fixed in this PR)

## Test plan
- [x] Unit tests: WebSocketSink (14 tests), AuditEmitter multi-sink (9 tests), AuditPolicy system tier (13 tests), subscribeServerEvents (3 tests), renderAuditEvent/Header (4 tests), emitSystemAuditEvent (2 tests)
- [x] Existing tests: 211 connection tests, 20 wal/store sink tests all pass with `durable` field
- [x] Manual: dashboard Activity page tested with 1000+ events against live serve instance with OAuth
- [x] Verification: build 9/9, code review pass, adversarial review pass, architecture review pass
- [x] Regression analysis: 13 change areas checked, no blocking regressions

Closes #2049
Closes #2058

🤖 Generated with [Claude Code](https://claude.com/claude-code)