### PR TITLE
feat(audit): emit auth-category events for OAuth device flow

### DIFF
--- a/design/enablers/serve-audit.md
+++ b/design/enablers/serve-audit.md
@@ -125,6 +125,31 @@ re-authorized every 60 seconds — revoked grants terminate the stream.
 No durability guarantee — this is live streaming, not a replay mechanism. Missed
 events are queryable via `audit.query`.
 
+## Auth events
+
+The `auth` audit category captures OAuth device flow operations. Unlike other
+categories that flow through the `audited()` wrapper on WebSocket handlers, auth
+events are emitted inline from the HTTP device auth handler
+(`src/serve/device_auth_handler.ts`) via `buildAuditEvent` + `emitter.emit`.
+This is because the device auth flow runs in the HTTP request path
+pre-authentication — there is no WebSocket connection or authenticated principal
+at this point.
+
+Actions:
+
+- `auth.login.started` — device grant initiated (anonymous principal)
+- `auth.login.completed` — OAuth flow completed, server token minted (success)
+- `auth.login.denied` — admission check failed or user denied authorization
+- `auth.login.expired` — device code expired before completion
+
+The `AuditEmitter` and `instanceId` are threaded through `DeviceAuthDeps`; the
+`sourceIp` is resolved by the serve HTTP handler (respecting `trustProxy` /
+`X-Forwarded-For`) and passed through. When audit is not configured (no
+`auditEmitter`), the emit helper is a no-op.
+
+Token revocation is audited separately via the `access.token.revoke` WebSocket
+handler under the `admin` category.
+
 ## System events
 
 The `system` audit category captures infrastructure lifecycle events with

--- a/packages/dashboard/src/client/useAuditStream.ts
+++ b/packages/dashboard/src/client/useAuditStream.ts
@@ -90,11 +90,15 @@ export function useAuditStream(): {
   useEffect(() => {
     if (!connected || !liveEnabled) {
       if (wsRef.current) {
-        wsRef.current.send(JSON.stringify({
-          type: "audit.unsubscribe",
-          id: crypto.randomUUID(),
-        }));
-        wsRef.current.close();
+        if (wsRef.current.readyState === WebSocket.OPEN) {
+          wsRef.current.send(JSON.stringify({
+            type: "audit.unsubscribe",
+            id: crypto.randomUUID(),
+          }));
+          wsRef.current.close();
+        } else {
+          wsRef.current.close();
+        }
         wsRef.current = null;
       }
       setStreaming(false);

--- a/src/cli/commands/audit_log.ts
+++ b/src/cli/commands/audit_log.ts
@@ -81,7 +81,7 @@ export const auditLogCommand = withRemoteOptions(
     })
     .option(
       "--follow",
-      "Stream new audit events in real-time after the initial query",
+      "Stream new audit events in real-time after the initial query (Ctrl+C to stop). In JSON mode, emits one event object per line (NDJSON).",
     ),
 ).action(async function (options: AnyOptions) {
   const ctx = createContext(options as GlobalOptions, ["audit", "log"]);

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -4004,16 +4004,16 @@ export const serveCommand = new Command()
 
         // Device authorization endpoints (OAuth mode only)
         if (authConfig.mode === "oauth" && authConfig.oauthClientId) {
+          const deviceRemoteAddr = trustProxy
+            ? (req.headers.get("x-forwarded-for")
+              ?.split(",")[0]?.trim() ??
+              info.remoteAddr.hostname)
+            : info.remoteAddr.hostname;
           const url = new URL(req.url);
           if (
             url.pathname === "/auth/device" ||
             url.pathname === "/auth/device/token"
           ) {
-            const deviceRemoteAddr = trustProxy
-              ? (req.headers.get("x-forwarded-for")
-                ?.split(",")[0]?.trim() ??
-                info.remoteAddr.hostname)
-              : info.remoteAddr.hostname;
             const deviceRateCheck = checkIpBurst(deviceRemoteAddr);
             if (!deviceRateCheck.allowed) {
               return new Response(
@@ -4040,6 +4040,9 @@ export const serveCommand = new Command()
             repoMarker?.defaultVault,
             syncService,
             serveNamespace,
+            connectionCtx.auditEmitter,
+            connectionCtx.instanceId,
+            deviceRemoteAddr,
           );
           const deviceAuthResponse = await handleDeviceAuth(
             req,

--- a/src/serve/device_auth_handler.ts
+++ b/src/serve/device_auth_handler.ts
@@ -22,6 +22,12 @@ import { checkAdmission } from "../domain/access/admission.ts";
 import type { ServeAuthConfig } from "../domain/access/serve_auth_config.ts";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
 import { getSwampLogger } from "../infrastructure/logging/logger.ts";
+import type { AuditEmitter } from "../domain/serve_audit/audit_emitter.ts";
+import type {
+  AuditEvent,
+  AuditOutcome,
+} from "../domain/serve_audit/audit_event.ts";
+import { buildAuditEvent } from "../domain/serve_audit/audit_event_builder.ts";
 import {
   DeviceGrantPollError,
   type DeviceGrantResponse,
@@ -96,6 +102,36 @@ export interface DeviceAuthDeps {
     accessToken: string,
   ) => Promise<void>;
   readonly clientSecret: string;
+  readonly auditEmitter?: AuditEmitter;
+  readonly instanceId?: string;
+  readonly sourceIp?: string;
+}
+
+function emitAuthAuditEvent(
+  deps: DeviceAuthDeps,
+  action: string,
+  outcome: AuditOutcome,
+  principalId?: string,
+  detail?: string,
+): AuditEvent | undefined {
+  if (!deps.auditEmitter) return undefined;
+  const event = buildAuditEvent({
+    instanceId: deps.instanceId ?? "unknown",
+    category: "auth",
+    stage: "response",
+    outcome,
+    action,
+    resourceKind: "server",
+    resourceName: deps.instanceId ?? "unknown",
+    principalKind: principalId ? "user" : "anonymous",
+    principalId: principalId ?? "anonymous",
+    initiatedBy: principalId ? `user:${principalId}` : "anonymous",
+    sourceIp: deps.sourceIp ?? "unknown",
+    requestId: crypto.randomUUID(),
+    detail,
+  });
+  deps.auditEmitter.emit(event);
+  return event;
 }
 
 function jsonResponse(
@@ -155,6 +191,7 @@ async function handleStartDeviceGrant(
     logger.info("Device grant started for provider {provider}", {
       provider: deps.authConfig.oauthProvider,
     });
+    emitAuthAuditEvent(deps, "auth.login.started", "success");
     return jsonResponse(200, {
       deviceCode: grant.deviceCode,
       userCode: grant.userCode,
@@ -218,6 +255,13 @@ async function handleDeviceToken(
         sub: userInfo.sub,
         reason: admissionResult.reason,
       });
+      emitAuthAuditEvent(
+        deps,
+        "auth.login.denied",
+        "denied",
+        userInfo.sub,
+        admissionResult.reason,
+      );
       return jsonResponse(403, {
         error: "Not admitted",
         reason: admissionResult.reason,
@@ -243,6 +287,12 @@ async function handleDeviceToken(
     logger.info("OAuth device flow completed for {principal}", {
       principal: principalId,
     });
+    emitAuthAuditEvent(
+      deps,
+      "auth.login.completed",
+      "success",
+      userInfo.sub,
+    );
     return jsonResponse(200, {
       token,
       principal: {
@@ -261,8 +311,10 @@ async function handleDeviceToken(
         case "slow_down":
           return jsonResponse(202, { status: "pending", slowDown: true });
         case "expired_token":
+          emitAuthAuditEvent(deps, "auth.login.expired", "failure");
           return jsonResponse(410, { error: "Device code expired" });
         case "access_denied":
+          emitAuthAuditEvent(deps, "auth.login.denied", "denied");
           return jsonResponse(403, {
             error: "Authorization denied by user",
           });
@@ -402,6 +454,9 @@ export function createDeviceAuthDeps(
   defaultVault?: string,
   syncService?: DatastoreSyncService,
   namespace?: string,
+  auditEmitter?: AuditEmitter,
+  instanceId?: string,
+  sourceIp?: string,
 ): DeviceAuthDeps {
   return {
     authConfig,
@@ -442,5 +497,8 @@ export function createDeviceAuthDeps(
         accessToken,
       );
     },
+    auditEmitter,
+    instanceId,
+    sourceIp,
   };
 }

--- a/src/serve/device_auth_handler_test.ts
+++ b/src/serve/device_auth_handler_test.ts
@@ -24,6 +24,28 @@ import {
 } from "./device_auth_handler.ts";
 import { DeviceGrantPollError } from "./oauth_client.ts";
 import type { RepositoryContext } from "../infrastructure/persistence/repository_factory.ts";
+import { AuditEmitter } from "../domain/serve_audit/audit_emitter.ts";
+import type { AuditEvent } from "../domain/serve_audit/audit_event.ts";
+import type { AuditSink } from "../domain/serve_audit/audit_sink.ts";
+
+function createCollectingSink(): AuditSink & { events: AuditEvent[] } {
+  const sink = {
+    name: "test-collector",
+    durable: false,
+    events: [] as AuditEvent[],
+    write(events: readonly AuditEvent[]): Promise<void> {
+      sink.events.push(...events);
+      return Promise.resolve();
+    },
+    flush(): Promise<void> {
+      return Promise.resolve();
+    },
+    close(): Promise<void> {
+      return Promise.resolve();
+    },
+  };
+  return sink;
+}
 
 function makeMockDeps(
   overrides: Partial<DeviceAuthDeps> = {},
@@ -527,4 +549,149 @@ Deno.test("handleDeviceAuth: POST /auth/device/token returns 500 on mintServerTo
   assertEquals(result?.status, 500);
   const body = await result!.json();
   assertEquals(body.error, "Internal error during token exchange");
+});
+
+// ── Audit event emission ─────────────────────────────────────────────
+
+Deno.test("handleDeviceAuth: POST /auth/device emits auth.login.started event", async () => {
+  const sink = createCollectingSink();
+  const emitter = new AuditEmitter([sink]);
+  const deps = makeMockDeps({
+    auditEmitter: emitter,
+    instanceId: "test-instance",
+    sourceIp: "192.168.1.1",
+  });
+  const result = await handleDeviceAuth(postRequest("/auth/device"), deps);
+  assertEquals(result?.status, 200);
+  await emitter.flush();
+  assertEquals(sink.events.length, 1);
+  assertEquals(sink.events[0].category, "auth");
+  assertEquals(sink.events[0].action, "auth.login.started");
+  assertEquals(sink.events[0].outcome, "success");
+  assertEquals(sink.events[0].instanceId, "test-instance");
+  assertEquals(sink.events[0].sourceIp, "192.168.1.1");
+  assertEquals(sink.events[0].principalKind, "anonymous");
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device/token emits auth.login.completed on success", async () => {
+  const sink = createCollectingSink();
+  const emitter = new AuditEmitter([sink]);
+  const deps = makeMockDeps({
+    auditEmitter: emitter,
+    instanceId: "test-instance",
+    sourceIp: "10.0.0.1",
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 200);
+  await emitter.flush();
+  assertEquals(sink.events.length, 1);
+  assertEquals(sink.events[0].category, "auth");
+  assertEquals(sink.events[0].action, "auth.login.completed");
+  assertEquals(sink.events[0].outcome, "success");
+  assertEquals(sink.events[0].principalKind, "user");
+  assertEquals(sink.events[0].principalId, "user-1");
+  assertEquals(sink.events[0].sourceIp, "10.0.0.1");
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device/token emits auth.login.denied on admission failure", async () => {
+  const sink = createCollectingSink();
+  const emitter = new AuditEmitter([sink]);
+  const deps = makeMockDeps({
+    auditEmitter: emitter,
+    instanceId: "test-instance",
+    sourceIp: "10.0.0.1",
+    checkAdmission: () => ({
+      admitted: false,
+      reason: "user is not a member of any allowed collective",
+    }),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 403);
+  await emitter.flush();
+  assertEquals(sink.events.length, 1);
+  assertEquals(sink.events[0].category, "auth");
+  assertEquals(sink.events[0].action, "auth.login.denied");
+  assertEquals(sink.events[0].outcome, "denied");
+  assertEquals(sink.events[0].principalId, "user-1");
+  assertEquals(
+    sink.events[0].detail,
+    "user is not a member of any allowed collective",
+  );
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device/token emits auth.login.expired on expired_token", async () => {
+  const sink = createCollectingSink();
+  const emitter = new AuditEmitter([sink]);
+  const deps = makeMockDeps({
+    auditEmitter: emitter,
+    instanceId: "test-instance",
+    sourceIp: "10.0.0.1",
+    pollForToken: () =>
+      Promise.reject(new DeviceGrantPollError("expired_token")),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 410);
+  await emitter.flush();
+  assertEquals(sink.events.length, 1);
+  assertEquals(sink.events[0].category, "auth");
+  assertEquals(sink.events[0].action, "auth.login.expired");
+  assertEquals(sink.events[0].outcome, "failure");
+  assertEquals(sink.events[0].principalKind, "anonymous");
+});
+
+Deno.test("handleDeviceAuth: POST /auth/device/token emits auth.login.denied on access_denied", async () => {
+  const sink = createCollectingSink();
+  const emitter = new AuditEmitter([sink]);
+  const deps = makeMockDeps({
+    auditEmitter: emitter,
+    instanceId: "test-instance",
+    sourceIp: "10.0.0.1",
+    pollForToken: () =>
+      Promise.reject(new DeviceGrantPollError("access_denied")),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 403);
+  await emitter.flush();
+  assertEquals(sink.events.length, 1);
+  assertEquals(sink.events[0].category, "auth");
+  assertEquals(sink.events[0].action, "auth.login.denied");
+  assertEquals(sink.events[0].outcome, "denied");
+});
+
+Deno.test("handleDeviceAuth: no audit events emitted when auditEmitter is undefined", async () => {
+  const deps = makeMockDeps();
+  const result = await handleDeviceAuth(postRequest("/auth/device"), deps);
+  assertEquals(result?.status, 200);
+  // No crash, no events — auditEmitter is undefined by default in makeMockDeps
+});
+
+Deno.test("handleDeviceAuth: no audit events on pending poll (not a security event)", async () => {
+  const sink = createCollectingSink();
+  const emitter = new AuditEmitter([sink]);
+  const deps = makeMockDeps({
+    auditEmitter: emitter,
+    instanceId: "test-instance",
+    sourceIp: "10.0.0.1",
+    pollForToken: () =>
+      Promise.reject(new DeviceGrantPollError("authorization_pending")),
+  });
+  const result = await handleDeviceAuth(
+    postRequest("/auth/device/token", { deviceCode: "dev-123" }),
+    deps,
+  );
+  assertEquals(result?.status, 202);
+  await emitter.flush();
+  assertEquals(sink.events.length, 0);
 });


### PR DESCRIPTION
## Summary

- Thread `AuditEmitter` through `DeviceAuthDeps` and emit `auth`-category audit events for all OAuth device flow operations: `auth.login.started`, `auth.login.completed`, `auth.login.denied`, `auth.login.expired`
- Fix three Phase 3 followups from #2408: `useAuditStream.ts` readyState guard, `--follow` Ctrl+C hint, `--follow --json` NDJSON format documentation
- Update `design/enablers/serve-audit.md` with auth events section

The device auth handler runs in the HTTP request path (not the WebSocket pipeline), so events are emitted inline via `buildAuditEvent` + `emitter.emit` following the `emitSystemAuditEvent` pattern, rather than the `audited()` wrapper.

Token revocation (`auth.token.revoked`) is explicitly deferred — already audited via the `access.token.revoke` WebSocket handler under the `admin` category.

## Test plan

- [x] 7 new unit tests covering all auth audit events (started, completed, denied, expired, access_denied), no-op when emitter undefined, no events on pending poll
- [x] All 30 tests pass in `device_auth_handler_test.ts`
- [x] Type checking passes
- [x] Build verification: 9/9 steps passed (lint, fmt, type-check, vuln-scan, tests, compile, binary-check)
- [x] Agent reviews: code-review pass, adversarial-review pass, ux-review pass

Closes #2057

🤖 Generated with [Claude Code](https://claude.com/claude-code)