### PR TITLE
feat(telemetry): enrich InvocationContext with datastore type and external vault detection

### DIFF
--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -125,6 +125,7 @@ import {
 } from "./auto_resolver_adapters.ts";
 import { TelemetryService } from "../domain/telemetry/telemetry_service.ts";
 import { JsonTelemetryRepository } from "../infrastructure/persistence/json_telemetry_repository.ts";
+import { YamlVaultConfigRepository } from "../infrastructure/persistence/yaml_vault_config_repository.ts";
 import { HttpTelemetrySender } from "../infrastructure/telemetry/http_telemetry_sender.ts";
 import {
   buildInvocationContext,
@@ -132,6 +133,7 @@ import {
   clearActiveTelemetryService,
   extractCommandInfo,
   isExternalDatastoreConfigured,
+  isExternalVaultConfigured,
   isTelemetryDisabled,
   projectEnvSnapshot,
   setActiveTelemetryContext,
@@ -1165,6 +1167,8 @@ async function initTelemetryService(
     let repoId: string | undefined;
     let configuredAiTools: string[] | undefined;
     let externalDatastore = false;
+    let datastoreType: string | undefined;
+    let externalVault = false;
     let markerEndpoint: string | undefined;
     let keepFlushed = false;
 
@@ -1182,6 +1186,18 @@ async function initTelemetryService(
       }
       configuredAiTools = marker.tools;
       externalDatastore = isExternalDatastoreConfigured(marker.datastore);
+      datastoreType = marker.datastore?.type;
+
+      try {
+        const vaultRepo = new YamlVaultConfigRepository(repoDir);
+        const vaultConfigs = await vaultRepo.findAll();
+        externalVault = isExternalVaultConfigured(
+          vaultConfigs.map((v) => v.toData()),
+        );
+      } catch {
+        // Vault dir missing or unreadable — default to false
+      }
+
       markerEndpoint = marker.telemetryEndpoint;
       keepFlushed = marker.telemetryKeepFlushed ?? false;
     } else {
@@ -1232,6 +1248,8 @@ async function initTelemetryService(
       projectEnvSnapshot(),
       configuredAiTools,
       externalDatastore,
+      datastoreType,
+      externalVault,
     );
     const service = new TelemetryService(
       repository,

--- a/src/cli/telemetry_integration.ts
+++ b/src/cli/telemetry_integration.ts
@@ -28,6 +28,9 @@ import {
 import type { TelemetryService } from "../domain/telemetry/telemetry_service.ts";
 
 import type { DatastoreConfigData } from "../domain/datastore/datastore_config.ts";
+import type { VaultConfigData } from "../domain/vaults/vault_config.ts";
+
+const BUILTIN_VAULT_TYPES = new Set(["local_encryption", "mock"]);
 
 /**
  * True when the repo marker declares a non-`filesystem` datastore. Local
@@ -39,6 +42,17 @@ export function isExternalDatastoreConfigured(
   datastore: DatastoreConfigData | undefined,
 ): boolean {
   return datastore !== undefined && datastore.type !== "filesystem";
+}
+
+/**
+ * True when any vault in the repo uses a non-builtin provider. Builtin
+ * types (`local_encryption`, `mock`) report false — the signal is "secrets
+ * live behind an external vault provider."
+ */
+export function isExternalVaultConfigured(
+  vaults: VaultConfigData[],
+): boolean {
+  return vaults.some((v) => !BUILTIN_VAULT_TYPES.has(v.type));
 }
 
 /**
@@ -344,18 +358,24 @@ export function buildInvocationContext(
   envSnapshot: Record<string, string>,
   configuredAiTools: string[] | undefined,
   externalDatastoreConfigured: boolean,
+  datastoreType: string | undefined,
+  externalVaultConfigured: boolean,
 ): InvocationContextData {
   const detection = detectAgentHarness(envSnapshot);
   const data: InvocationContextData = {
     agentSessionDetected: detection.agentSessionDetected,
     isInteractive: Deno.stdin.isTerminal(),
     externalDatastoreConfigured,
+    externalVaultConfigured,
   };
   if (configuredAiTools !== undefined) {
     data.configuredAiTools = configuredAiTools;
   }
   if (detection.detectedAiTool !== undefined) {
     data.detectedAiTool = detection.detectedAiTool;
+  }
+  if (datastoreType !== undefined) {
+    data.datastoreType = datastoreType;
   }
   return data;
 }

--- a/src/cli/telemetry_integration_test.ts
+++ b/src/cli/telemetry_integration_test.ts
@@ -22,6 +22,7 @@ import {
   buildInvocationContext,
   extractCommandInfo,
   isExternalDatastoreConfigured,
+  isExternalVaultConfigured,
   isTelemetryDisabled,
   projectEnvSnapshot,
 } from "./telemetry_integration.ts";
@@ -323,43 +324,80 @@ Deno.test("buildInvocationContext: claude detected, tools configured", () => {
     { CLAUDECODE: "1" },
     ["claude", "cursor"],
     false,
+    undefined,
+    false,
   );
   assertEquals(ctx.configuredAiTools, ["claude", "cursor"]);
   assertEquals(ctx.detectedAiTool, "claude");
   assertEquals(ctx.agentSessionDetected, true);
   assertEquals(ctx.externalDatastoreConfigured, false);
+  assertEquals(ctx.externalVaultConfigured, false);
 });
 
 Deno.test("buildInvocationContext: configuredAiTools=undefined when no marker passed", () => {
-  const ctx = buildInvocationContext({ CLAUDECODE: "1" }, undefined, false);
+  const ctx = buildInvocationContext(
+    { CLAUDECODE: "1" },
+    undefined,
+    false,
+    undefined,
+    false,
+  );
   assertEquals("configuredAiTools" in ctx, false);
   assertEquals(ctx.detectedAiTool, "claude");
   assertEquals(ctx.agentSessionDetected, true);
 });
 
 Deno.test("buildInvocationContext: configuredAiTools=[] preserved (legacy opt-out)", () => {
-  const ctx = buildInvocationContext({}, [], false);
+  const ctx = buildInvocationContext({}, [], false, undefined, false);
   assertEquals(ctx.configuredAiTools, []);
   assertEquals("detectedAiTool" in ctx, false);
   assertEquals(ctx.agentSessionDetected, false);
 });
 
 Deno.test("buildInvocationContext: generic AGENT fallback flips agentSessionDetected", () => {
-  const ctx = buildInvocationContext({ AGENT: "1" }, ["claude"], false);
+  const ctx = buildInvocationContext(
+    { AGENT: "1" },
+    ["claude"],
+    false,
+    undefined,
+    false,
+  );
   assertEquals(ctx.configuredAiTools, ["claude"]);
   assertEquals("detectedAiTool" in ctx, false);
   assertEquals(ctx.agentSessionDetected, true);
 });
 
 Deno.test("buildInvocationContext: empty env yields no detection", () => {
-  const ctx = buildInvocationContext({}, ["claude"], false);
+  const ctx = buildInvocationContext({}, ["claude"], false, undefined, false);
   assertEquals("detectedAiTool" in ctx, false);
   assertEquals(ctx.agentSessionDetected, false);
 });
 
 Deno.test("buildInvocationContext: externalDatastoreConfigured=true is recorded", () => {
-  const ctx = buildInvocationContext({}, ["claude"], true);
+  const ctx = buildInvocationContext({}, ["claude"], true, undefined, false);
   assertEquals(ctx.externalDatastoreConfigured, true);
+});
+
+Deno.test("buildInvocationContext: datastoreType is recorded", () => {
+  const ctx = buildInvocationContext(
+    {},
+    ["claude"],
+    true,
+    "@swamp/s3",
+    false,
+  );
+  assertEquals(ctx.datastoreType, "@swamp/s3");
+  assertEquals(ctx.externalDatastoreConfigured, true);
+});
+
+Deno.test("buildInvocationContext: datastoreType omitted when undefined", () => {
+  const ctx = buildInvocationContext({}, ["claude"], false, undefined, false);
+  assertEquals("datastoreType" in ctx, false);
+});
+
+Deno.test("buildInvocationContext: externalVaultConfigured=true is recorded", () => {
+  const ctx = buildInvocationContext({}, ["claude"], false, undefined, true);
+  assertEquals(ctx.externalVaultConfigured, true);
 });
 
 Deno.test("isExternalDatastoreConfigured: undefined marker datastore is not external", () => {
@@ -376,6 +414,84 @@ Deno.test("isExternalDatastoreConfigured: filesystem type is not external", () =
 Deno.test("isExternalDatastoreConfigured: custom (non-filesystem) type is external", () => {
   assertEquals(
     isExternalDatastoreConfigured({ type: "s3", bucket: "my-bucket" }),
+    true,
+  );
+});
+
+Deno.test("isExternalVaultConfigured: empty vault list is not external", () => {
+  assertEquals(isExternalVaultConfigured([]), false);
+});
+
+Deno.test("isExternalVaultConfigured: only local_encryption vaults is not external", () => {
+  assertEquals(
+    isExternalVaultConfigured([
+      {
+        id: "v1",
+        name: "default",
+        type: "local_encryption",
+        config: {},
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+    ]),
+    false,
+  );
+});
+
+Deno.test("isExternalVaultConfigured: mock vault type is not external", () => {
+  assertEquals(
+    isExternalVaultConfigured([
+      {
+        id: "v1",
+        name: "test",
+        type: "mock",
+        config: {},
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+    ]),
+    false,
+  );
+});
+
+Deno.test("isExternalVaultConfigured: external vault type detected", () => {
+  assertEquals(
+    isExternalVaultConfigured([
+      {
+        id: "v1",
+        name: "default",
+        type: "local_encryption",
+        config: {},
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "v2",
+        name: "aws",
+        type: "@swamp/aws-sm",
+        config: {},
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+    ]),
+    true,
+  );
+});
+
+Deno.test("isExternalVaultConfigured: all external vaults detected", () => {
+  assertEquals(
+    isExternalVaultConfigured([
+      {
+        id: "v1",
+        name: "aws",
+        type: "@swamp/aws-sm",
+        config: {},
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "v2",
+        name: "op",
+        type: "@swamp/1password",
+        config: {},
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+    ]),
     true,
   );
 });

--- a/src/domain/telemetry/invocation_context.ts
+++ b/src/domain/telemetry/invocation_context.ts
@@ -45,6 +45,8 @@ export interface InvocationContext {
   readonly agentSessionDetected: boolean;
   readonly isInteractive: boolean;
   readonly externalDatastoreConfigured: boolean;
+  readonly datastoreType?: string;
+  readonly externalVaultConfigured: boolean;
 }
 
 /**
@@ -56,6 +58,8 @@ export interface InvocationContextData {
   agentSessionDetected: boolean;
   isInteractive: boolean;
   externalDatastoreConfigured: boolean;
+  datastoreType?: string;
+  externalVaultConfigured: boolean;
 }
 
 /**
@@ -72,6 +76,8 @@ export function createInvocationContext(
     agentSessionDetected: props.agentSessionDetected,
     isInteractive: props.isInteractive,
     externalDatastoreConfigured: props.externalDatastoreConfigured,
+    datastoreType: props.datastoreType,
+    externalVaultConfigured: props.externalVaultConfigured,
   };
 }
 
@@ -85,7 +91,11 @@ export function invocationContextToData(
     agentSessionDetected: context.agentSessionDetected,
     isInteractive: context.isInteractive,
     externalDatastoreConfigured: context.externalDatastoreConfigured,
+    externalVaultConfigured: context.externalVaultConfigured,
   };
+  if (context.datastoreType !== undefined) {
+    data.datastoreType = context.datastoreType;
+  }
   if (context.configuredAiTools !== undefined) {
     data.configuredAiTools = [...context.configuredAiTools];
   }

--- a/src/domain/telemetry/invocation_context_test.ts
+++ b/src/domain/telemetry/invocation_context_test.ts
@@ -30,12 +30,15 @@ Deno.test("createInvocationContext: minimal context with mandatory fields only",
     agentSessionDetected: false,
     isInteractive: true,
     externalDatastoreConfigured: false,
+    externalVaultConfigured: false,
   });
   assertEquals(ctx.configuredAiTools, undefined);
   assertEquals(ctx.detectedAiTool, undefined);
   assertEquals(ctx.agentSessionDetected, false);
   assertEquals(ctx.isInteractive, true);
   assertEquals(ctx.externalDatastoreConfigured, false);
+  assertEquals(ctx.datastoreType, undefined);
+  assertEquals(ctx.externalVaultConfigured, false);
 });
 
 Deno.test("createInvocationContext: configuredAiTools=[] preserved (not coerced to undefined)", () => {
@@ -44,6 +47,7 @@ Deno.test("createInvocationContext: configuredAiTools=[] preserved (not coerced 
     agentSessionDetected: false,
     isInteractive: false,
     externalDatastoreConfigured: false,
+    externalVaultConfigured: false,
   });
   assertEquals(ctx.configuredAiTools, []);
 });
@@ -55,6 +59,7 @@ Deno.test("createInvocationContext: copies configuredAiTools array (no aliasing)
     agentSessionDetected: true,
     isInteractive: false,
     externalDatastoreConfigured: false,
+    externalVaultConfigured: false,
   });
   tools.push("kiro");
   assertEquals(ctx.configuredAiTools, ["claude", "cursor"]);
@@ -65,6 +70,7 @@ Deno.test("createInvocationContext: externalDatastoreConfigured=true preserved",
     agentSessionDetected: false,
     isInteractive: false,
     externalDatastoreConfigured: true,
+    externalVaultConfigured: false,
   });
   assertEquals(ctx.externalDatastoreConfigured, true);
 });
@@ -76,6 +82,7 @@ Deno.test("invocationContextToData: round-trip with detectedAiTool and tools", (
     agentSessionDetected: true,
     isInteractive: false,
     externalDatastoreConfigured: true,
+    externalVaultConfigured: false,
   });
   const data = invocationContextToData(ctx);
   assertEquals(data, {
@@ -84,6 +91,7 @@ Deno.test("invocationContextToData: round-trip with detectedAiTool and tools", (
     agentSessionDetected: true,
     isInteractive: false,
     externalDatastoreConfigured: true,
+    externalVaultConfigured: false,
   });
 });
 
@@ -92,10 +100,12 @@ Deno.test("invocationContextToData: omits absent optional fields", () => {
     agentSessionDetected: false,
     isInteractive: true,
     externalDatastoreConfigured: false,
+    externalVaultConfigured: false,
   });
   const data = invocationContextToData(ctx);
   assertEquals("configuredAiTools" in data, false);
   assertEquals("detectedAiTool" in data, false);
+  assertEquals("datastoreType" in data, false);
 });
 
 Deno.test("invocationContextToData: empty configuredAiTools array is preserved on the wire", () => {
@@ -104,6 +114,7 @@ Deno.test("invocationContextToData: empty configuredAiTools array is preserved o
     agentSessionDetected: false,
     isInteractive: false,
     externalDatastoreConfigured: false,
+    externalVaultConfigured: false,
   });
   const data = invocationContextToData(ctx);
   assertEquals(data.configuredAiTools, []);
@@ -116,6 +127,8 @@ Deno.test("invocationContextFromData: round-trip preserves every field", () => {
     agentSessionDetected: true,
     isInteractive: true,
     externalDatastoreConfigured: true,
+    datastoreType: "@swamp/s3",
+    externalVaultConfigured: true,
   });
   const restored = invocationContextFromData(invocationContextToData(original));
   assertEquals(restored.configuredAiTools, ["claude"]);
@@ -123,6 +136,8 @@ Deno.test("invocationContextFromData: round-trip preserves every field", () => {
   assertEquals(restored.agentSessionDetected, true);
   assertEquals(restored.isInteractive, true);
   assertEquals(restored.externalDatastoreConfigured, true);
+  assertEquals(restored.datastoreType, "@swamp/s3");
+  assertEquals(restored.externalVaultConfigured, true);
 });
 
 Deno.test("invocationContextFromData: agent detected without specific tool round-trips", () => {
@@ -130,8 +145,43 @@ Deno.test("invocationContextFromData: agent detected without specific tool round
     agentSessionDetected: true,
     isInteractive: false,
     externalDatastoreConfigured: false,
+    externalVaultConfigured: false,
   });
   const restored = invocationContextFromData(invocationContextToData(original));
   assertEquals(restored.detectedAiTool, undefined);
   assertEquals(restored.agentSessionDetected, true);
+});
+
+Deno.test("createInvocationContext: externalVaultConfigured=true preserved", () => {
+  const ctx = createInvocationContext({
+    agentSessionDetected: false,
+    isInteractive: false,
+    externalDatastoreConfigured: false,
+    externalVaultConfigured: true,
+  });
+  assertEquals(ctx.externalVaultConfigured, true);
+});
+
+Deno.test("createInvocationContext: datastoreType preserved", () => {
+  const ctx = createInvocationContext({
+    agentSessionDetected: false,
+    isInteractive: false,
+    externalDatastoreConfigured: true,
+    datastoreType: "@swamp/s3",
+    externalVaultConfigured: false,
+  });
+  assertEquals(ctx.datastoreType, "@swamp/s3");
+});
+
+Deno.test("invocationContextToData: datastoreType included when set", () => {
+  const ctx = createInvocationContext({
+    agentSessionDetected: false,
+    isInteractive: false,
+    externalDatastoreConfigured: true,
+    datastoreType: "@swamp/gcs",
+    externalVaultConfigured: true,
+  });
+  const data = invocationContextToData(ctx);
+  assertEquals(data.datastoreType, "@swamp/gcs");
+  assertEquals(data.externalVaultConfigured, true);
 });

--- a/src/domain/telemetry/telemetry_entry_test.ts
+++ b/src/domain/telemetry/telemetry_entry_test.ts
@@ -173,6 +173,7 @@ Deno.test("TelemetryEntry.create accepts invocationContext", () => {
       agentSessionDetected: true,
       isInteractive: false,
       externalDatastoreConfigured: false,
+      externalVaultConfigured: false,
     },
   });
 
@@ -205,6 +206,7 @@ Deno.test("TelemetryEntry round-trips invocationContext through toData/fromData"
       agentSessionDetected: true,
       isInteractive: false,
       externalDatastoreConfigured: true,
+      externalVaultConfigured: false,
     },
   });
 

--- a/src/domain/telemetry/telemetry_service_test.ts
+++ b/src/domain/telemetry/telemetry_service_test.ts
@@ -420,6 +420,7 @@ Deno.test("TelemetryService.recordSuccess stamps invocationContext on entries", 
     agentSessionDetected: true,
     isInteractive: false,
     externalDatastoreConfigured: false,
+    externalVaultConfigured: false,
   });
 
   await service.recordSuccess(
@@ -446,6 +447,7 @@ Deno.test("TelemetryService.recordError stamps invocationContext on entries", as
     agentSessionDetected: true,
     isInteractive: false,
     externalDatastoreConfigured: false,
+    externalVaultConfigured: false,
   });
 
   await service.recordError(

--- a/src/infrastructure/persistence/json_telemetry_repository_test.ts
+++ b/src/infrastructure/persistence/json_telemetry_repository_test.ts
@@ -676,6 +676,7 @@ Deno.test("JsonTelemetryRepository round-trips invocationContext (with detected 
         agentSessionDetected: true,
         isInteractive: false,
         externalDatastoreConfigured: false,
+        externalVaultConfigured: false,
       },
     });
 
@@ -717,6 +718,7 @@ Deno.test("JsonTelemetryRepository round-trips invocationContext (legacy opt-out
         agentSessionDetected: false,
         isInteractive: true,
         externalDatastoreConfigured: false,
+        externalVaultConfigured: false,
       },
     });
 

--- a/src/infrastructure/telemetry/http_telemetry_sender_test.ts
+++ b/src/infrastructure/telemetry/http_telemetry_sender_test.ts
@@ -345,6 +345,7 @@ Deno.test("HttpTelemetrySender.sendBatch lands invocationContext at properties.i
       agentSessionDetected: true,
       isInteractive: false,
       externalDatastoreConfigured: true,
+      externalVaultConfigured: false,
     },
   });
 


### PR DESCRIPTION
## Summary

- Add `datastoreType: string | undefined` to `InvocationContext` — propagates the actual datastore provider type (e.g. `@swamp/s3`, `@swamp/gcs`) from the repo marker, turning the existing bare boolean into actionable signal
- Add `externalVaultConfigured: boolean` to `InvocationContext` — derived by scanning vault configs at CLI init time and checking for any vault with a non-builtin type (`local_encryption` and `mock` excluded)
- Every CLI telemetry event now carries both fields automatically via the existing pipeline — no new events needed

Closes #2067

## Test Plan

- Unit tests for `isExternalVaultConfigured` helper covering: empty list, only local_encryption, only mock, mixed, all external
- Updated `invocation_context_test.ts` to verify round-tripping of new fields
- Updated `buildInvocationContext` tests for new parameters (datastoreType, externalVaultConfigured)
- All 140 affected tests pass across 6 test files
- Type checking passes for the full dependency graph