### PR TITLE
fix(access): bind datastore namespace before control-plane vault init

### DIFF
--- a/src/cli/commands/access_token_mint.ts
+++ b/src/cli/commands/access_token_mint.ts
@@ -123,9 +123,17 @@ export const accessTokenMintCommand = new Command()
 
     cliCtx.logger.debug`Minting server token ${name}`;
 
+    const namespace = isCustomDatastoreConfig(datastoreConfig)
+      ? datastoreConfig.namespace
+      : undefined;
+
     const controlPlaneResult = await initializeControlPlaneVaultForCli(
       repoDir,
       syncService,
+      {
+        namespace,
+        catalogInvalidate: () => repoContext.catalogStore.invalidate(),
+      },
     );
 
     let effectiveVault = options.vault as string | undefined;
@@ -238,33 +246,19 @@ export const accessTokenMintCommand = new Command()
       }
 
       if (syncService) {
-        const namespace = isCustomDatastoreConfig(datastoreConfig)
-          ? datastoreConfig.namespace
-          : undefined;
-        try {
-          await syncService.markDirty();
-          await syncService.pushChanged({ namespace });
+        await syncService.markDirty();
+        await syncService.pushChanged({ namespace });
 
-          repoContext.catalogStore.invalidate();
-          const verifyResult = await findDefinitionByIdOrName(
-            repoContext.definitionRepo,
-            name,
-          );
-          if (!verifyResult) {
-            cliCtx.logger.warn(
-              "Server token {name} was minted but its definition could not be read back — it may not survive a pod restart. Re-mint the token if authentication fails after restart.",
-              { name },
-            );
-          }
-        } catch (syncError) {
-          cliCtx.logger.warn(
-            "Sync failed after minting token {name} — token is local only and may not survive a pod restart: {error}",
-            {
-              name,
-              error: syncError instanceof Error
-                ? syncError.message
-                : String(syncError),
-            },
+        repoContext.catalogStore.invalidate();
+        const verifyResult = await findDefinitionByIdOrName(
+          repoContext.definitionRepo,
+          name,
+        );
+        if (!verifyResult) {
+          throw new UserError(
+            `Server token '${name}' was minted but its definition could not be ` +
+              `read back after sync — the token will not be usable by serve. ` +
+              `Re-mint the token after resolving the datastore issue.`,
           );
         }
       }

--- a/src/cli/commands/access_token_reveal.ts
+++ b/src/cli/commands/access_token_reveal.ts
@@ -25,6 +25,7 @@ import {
 } from "../context.ts";
 import { requireInitializedRepoUnlocked } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import {
   consumeStream,
   createLibSwampContext,
@@ -76,13 +77,20 @@ export const accessTokenRevealCommand = new Command()
       "reveal",
     ]);
 
-    const { repoDir, repoContext, syncService } =
+    const { repoDir, repoContext, datastoreConfig, syncService } =
       await requireInitializedRepoUnlocked({
         repoDir: resolveRepoDir(options.repoDir),
         outputMode: cliCtx.outputMode,
       });
 
-    await initializeControlPlaneVaultForCli(repoDir, syncService);
+    const namespace = isCustomDatastoreConfig(datastoreConfig)
+      ? datastoreConfig.namespace
+      : undefined;
+
+    await initializeControlPlaneVaultForCli(repoDir, syncService, {
+      namespace,
+      catalogInvalidate: () => repoContext.catalogStore.invalidate(),
+    });
 
     const vaultService = await VaultService.fromRepository(repoDir);
     const deps = createServerTokenRevealDeps(

--- a/src/cli/commands/access_token_rotate.ts
+++ b/src/cli/commands/access_token_rotate.ts
@@ -28,6 +28,7 @@ import {
   requireInitializedRepoUnlocked,
 } from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import { findDefinitionByIdOrName } from "../../domain/models/model_lookup.ts";
 import {
   consumeStream,
@@ -136,9 +137,17 @@ export const accessTokenRotateCommand = withRemoteOptions(
 
   cliCtx.logger.debug`Rotating server token ${name}`;
 
+  const namespace = isCustomDatastoreConfig(datastoreConfig)
+    ? datastoreConfig.namespace
+    : undefined;
+
   const controlPlaneResult = await initializeControlPlaneVaultForCli(
     repoDir,
     syncService,
+    {
+      namespace,
+      catalogInvalidate: () => repoContext.catalogStore.invalidate(),
+    },
   );
 
   let effectiveVault = options.vault as string | undefined;

--- a/src/cli/control_plane_vault.ts
+++ b/src/cli/control_plane_vault.ts
@@ -25,12 +25,29 @@ import {
 import { FileSystemControlPlaneStore } from "../infrastructure/persistence/fs_control_plane_store.ts";
 import { swampPath } from "../infrastructure/persistence/paths.ts";
 
+export interface ControlPlaneVaultCliOptions {
+  namespace?: string;
+  catalogInvalidate?: () => void;
+}
+
 export async function initializeControlPlaneVaultForCli(
   repoDir: string,
   syncService?: DatastoreSyncService,
+  options?: ControlPlaneVaultCliOptions,
 ): Promise<ControlPlaneVaultInitResult | null> {
   const caps = syncService?.capabilities?.();
   const hasRemote = !!(caps?.controlPlane && syncService?.controlPlaneStore);
+
+  // Bind the sync service's namespace before obtaining the control plane
+  // store. The S3/GCS extensions irrevocably bind namespace on the first
+  // call to any sync or control-plane method — calling controlPlaneStore()
+  // without a prior pullChanged({ namespace }) binds to root (undefined),
+  // causing all subsequent namespace-aware pushChanged calls to fail with
+  // "Namespace mismatch". This mirrors the serve.ts boot sequence.
+  if (hasRemote && options?.namespace) {
+    await syncService!.pullChanged({ namespace: options.namespace });
+    options.catalogInvalidate?.();
+  }
 
   const store = hasRemote
     ? syncService!.controlPlaneStore!()

--- a/src/cli/control_plane_vault_test.ts
+++ b/src/cli/control_plane_vault_test.ts
@@ -1,0 +1,195 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
+import { initializeLogging } from "../infrastructure/logging/logger.ts";
+import type {
+  DatastoreSyncOptions,
+  DatastoreSyncService,
+  SyncCapabilities,
+} from "../domain/datastore/datastore_sync_service.ts";
+import type { ControlPlaneStore } from "../domain/datastore/control_plane_store.ts";
+import { initializeControlPlaneVaultForCli } from "./control_plane_vault.ts";
+
+await initializeLogging({});
+
+function createMockStore(): ControlPlaneStore {
+  const data = new Map<string, Uint8Array>();
+  return {
+    put(key: string, value: Uint8Array): Promise<void> {
+      data.set(key, new Uint8Array(value));
+      return Promise.resolve();
+    },
+    putIfAbsent(key: string, value: Uint8Array): Promise<boolean> {
+      if (data.has(key)) return Promise.resolve(false);
+      data.set(key, new Uint8Array(value));
+      return Promise.resolve(true);
+    },
+    get(key: string): Promise<Uint8Array | null> {
+      return Promise.resolve(data.get(key) ?? null);
+    },
+    delete(key: string): Promise<void> {
+      data.delete(key);
+      return Promise.resolve();
+    },
+    list(prefix: string): Promise<string[]> {
+      return Promise.resolve(
+        [...data.keys()].filter((k) => k.startsWith(prefix)),
+      );
+    },
+  };
+}
+
+interface MockSyncServiceOptions {
+  pullShouldFail?: boolean;
+}
+
+function createMockSyncService(
+  opts: MockSyncServiceOptions = {},
+): {
+  syncService: DatastoreSyncService;
+  calls: { method: string; options?: DatastoreSyncOptions }[];
+} {
+  const calls: { method: string; options?: DatastoreSyncOptions }[] = [];
+  const store = createMockStore();
+
+  const syncService: DatastoreSyncService = {
+    pullChanged(
+      options?: DatastoreSyncOptions,
+    ): Promise<number> {
+      calls.push({ method: "pullChanged", options });
+      if (opts.pullShouldFail) {
+        return Promise.reject(new Error("S3 unreachable"));
+      }
+      return Promise.resolve(0);
+    },
+    pushChanged(
+      options?: DatastoreSyncOptions,
+    ): Promise<number> {
+      calls.push({ method: "pushChanged", options });
+      return Promise.resolve(0);
+    },
+    capabilities(): SyncCapabilities {
+      return { controlPlane: true };
+    },
+    markDirty(): Promise<void> {
+      calls.push({ method: "markDirty" });
+      return Promise.resolve();
+    },
+    controlPlaneStore(): ControlPlaneStore {
+      calls.push({ method: "controlPlaneStore" });
+      return store;
+    },
+  };
+
+  return { syncService, calls };
+}
+
+Deno.test("initializeControlPlaneVaultForCli: calls pullChanged with namespace before controlPlaneStore", async () => {
+  const { syncService, calls } = createMockSyncService();
+
+  const result = await initializeControlPlaneVaultForCli(
+    "/tmp/test-repo",
+    syncService,
+    {
+      namespace: "my-namespace",
+      catalogInvalidate: () => {},
+    },
+  );
+
+  assertNotEquals(result, null);
+
+  const pullIndex = calls.findIndex((c) => c.method === "pullChanged");
+  const storeIndex = calls.findIndex((c) => c.method === "controlPlaneStore");
+
+  assertNotEquals(pullIndex, -1, "pullChanged must be called");
+  assertNotEquals(storeIndex, -1, "controlPlaneStore must be called");
+  assertEquals(
+    pullIndex < storeIndex,
+    true,
+    "pullChanged must be called before controlPlaneStore",
+  );
+  assertEquals(calls[pullIndex].options?.namespace, "my-namespace");
+});
+
+Deno.test("initializeControlPlaneVaultForCli: calls catalogInvalidate after pullChanged", async () => {
+  const { syncService } = createMockSyncService();
+
+  let invalidated = false;
+  await initializeControlPlaneVaultForCli(
+    "/tmp/test-repo",
+    syncService,
+    {
+      namespace: "my-namespace",
+      catalogInvalidate: () => {
+        invalidated = true;
+      },
+    },
+  );
+
+  assertEquals(invalidated, true);
+});
+
+Deno.test("initializeControlPlaneVaultForCli: skips pullChanged when no namespace", async () => {
+  const { syncService, calls } = createMockSyncService();
+
+  const result = await initializeControlPlaneVaultForCli(
+    "/tmp/test-repo",
+    syncService,
+  );
+
+  assertNotEquals(result, null);
+
+  const pullCalls = calls.filter((c) => c.method === "pullChanged");
+  assertEquals(
+    pullCalls.length,
+    0,
+    "pullChanged must not be called without namespace",
+  );
+
+  const storeCalls = calls.filter((c) => c.method === "controlPlaneStore");
+  assertEquals(storeCalls.length, 1, "controlPlaneStore must still be called");
+});
+
+Deno.test("initializeControlPlaneVaultForCli: propagates pullChanged failure", async () => {
+  const { syncService } = createMockSyncService({ pullShouldFail: true });
+
+  await assertRejects(
+    () =>
+      initializeControlPlaneVaultForCli(
+        "/tmp/test-repo",
+        syncService,
+        { namespace: "my-namespace" },
+      ),
+    Error,
+    "S3 unreachable",
+  );
+});
+
+Deno.test("initializeControlPlaneVaultForCli: works without sync service", async () => {
+  const result = await initializeControlPlaneVaultForCli(
+    "/tmp/test-repo",
+    undefined,
+  );
+
+  // Falls back to FileSystemControlPlaneStore — init may fail because
+  // /tmp/test-repo/.swamp doesn't exist, returning null. That's fine;
+  // we're testing that it doesn't throw on the sync path.
+  assertEquals(result === null || result !== undefined, true);
+});


### PR DESCRIPTION
## Summary

- Fix namespace binding in CLI access token commands (mint, rotate, reveal) so the control-plane vault store reads/writes at the correct namespaced `_control/` path instead of root
- Add `namespace` parameter to `initializeControlPlaneVaultForCli()` — calls `pullChanged({ namespace })` before `controlPlaneStore()` to bind the sync service's namespace, matching the pattern `serve.ts` already uses
- Promote sync failure in `access token mint` from a misleading warning to a hard error — a local-only token is unusable by serve

Fixes swamp-club#2066

Co-authored-by: Blake Irvin <blakeirvin@me.com>

## Test plan

- [x] Unit tests for namespace binding ordering in `initializeControlPlaneVaultForCli` (5 tests)
- [x] Existing control-plane vault tests pass (12 tests)
- [x] Full verification workflow: lint, fmt, type-check, tests, compile, code review, adversarial review, UX review all pass
- [ ] Deploy to a namespaced S3 datastore and verify `access token mint` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)