### PR TITLE
fix(verification): tolerate missing VERDICT marker in passing reviews

### DIFF
--- a/agent-constraints/verification-conventions.md
+++ b/agent-constraints/verification-conventions.md
@@ -206,7 +206,7 @@ To construct this checklist:
 
 3. For each step, extract: job name, step name, model name, duration, and
    status (succeeded/failed/skipped). For review steps that ran, include the
-   VERDICT from the review log.
+   VERDICT from the review log (explicit marker or inferred).
 
    **Timing**: Each step in the `history get` output has a `duration` field
    in milliseconds — use it directly as `durationMs`. For `totalDurationMs`,
@@ -463,9 +463,15 @@ SWAMP_WORKFLOWS_DIR=verification swamp workflow run verify-skills \
 
 ### 5. Repeat until green
 
-Repeat steps 1–4 until all build steps pass, all reviews return
-`VERDICT: pass`, and all skill checks pass or are skipped. Present the full
-verification checklist to the user after each run.
+Repeat steps 1–4 until all build steps pass, all reviews pass, and all skill
+checks pass or are skipped. Present the full verification checklist to the user
+after each run.
+
+A review passes when it outputs an explicit `VERDICT: pass` marker. If the
+marker is missing, the workflow infers the verdict: reviews with blocking
+findings (`CRITICAL`, `HIGH`, or `Blocking` severity labels) infer fail; reviews
+with no blocking findings and substantive output infer pass (with a warning).
+Empty or trivially short output (<50 bytes) is treated as a missing verdict.
 
 Do NOT open a PR until the user has seen a fully green checklist,
 confirmed they want to proceed, and the attestation has been posted to

--- a/verification/workflow-verify-reviews.yaml
+++ b/verification/workflow-verify-reviews.yaml
@@ -98,12 +98,23 @@ jobs:
               RESULT_FILE=$(mktemp)
               git diff "$MERGE_BASE" > "$DIFF_FILE"
               cat verification/review-prompts/code-review.md > "$PROMPT_FILE"
-              printf '\n\nThe diff to review is at: %s\nRead that file to see the changes.\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n' "$DIFF_FILE" >> "$PROMPT_FILE"
+              printf '\n\nThe diff to review is at: %s\nRead that file to see the changes.\n\nIMPORTANT: You MUST begin your response with exactly one of these two lines:\nVERDICT: pass\nVERDICT: fail\n\nThen provide your full review below the verdict line.\n' "$DIFF_FILE" >> "$PROMPT_FILE"
               claude -p - \
                 --model claude-opus-4-6 \
                 --allowedTools "Read,Glob,Grep" < "$PROMPT_FILE" | tee "$RESULT_FILE"
               rm -f "$PROMPT_FILE" "$DIFF_FILE"
               VERDICT=$(grep -oi 'VERDICT: *\**pass\**\|VERDICT: *\**fail\**' "$RESULT_FILE" | head -1 | grep -oi 'pass\|fail')
+              if [ -z "$VERDICT" ]; then
+                if [ "$(wc -c < "$RESULT_FILE")" -lt 50 ]; then
+                  VERDICT="missing"
+                elif grep -qiE '[*]{0,2}(CRITICAL|HIGH|Blocking)[*]{0,2}[[:space:]]*:' "$RESULT_FILE"; then
+                  VERDICT="fail"
+                  echo "::warning::No VERDICT marker found; inferred fail from blocking findings"
+                else
+                  VERDICT="pass"
+                  echo "::warning::No VERDICT marker found; inferred pass (no blocking findings detected)"
+                fi
+              fi
               rm -f "$RESULT_FILE"
               if [ "$VERDICT" != "pass" ]; then
                 echo "::error::Code review did not pass (verdict: ${VERDICT:-missing})"
@@ -127,12 +138,23 @@ jobs:
               RESULT_FILE=$(mktemp)
               git diff "$MERGE_BASE" > "$DIFF_FILE"
               cat verification/review-prompts/adversarial-review.md > "$PROMPT_FILE"
-              printf '\n\nThe diff to review is at: %s\nRead that file to see the changes.\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n' "$DIFF_FILE" >> "$PROMPT_FILE"
+              printf '\n\nThe diff to review is at: %s\nRead that file to see the changes.\n\nIMPORTANT: You MUST begin your response with exactly one of these two lines:\nVERDICT: pass\nVERDICT: fail\n\nThen provide your full review below the verdict line.\n' "$DIFF_FILE" >> "$PROMPT_FILE"
               claude -p - \
                 --model claude-opus-4-6 \
                 --allowedTools "Read,Glob,Grep" < "$PROMPT_FILE" | tee "$RESULT_FILE"
               rm -f "$PROMPT_FILE" "$DIFF_FILE"
               VERDICT=$(grep -oi 'VERDICT: *\**pass\**\|VERDICT: *\**fail\**' "$RESULT_FILE" | head -1 | grep -oi 'pass\|fail')
+              if [ -z "$VERDICT" ]; then
+                if [ "$(wc -c < "$RESULT_FILE")" -lt 50 ]; then
+                  VERDICT="missing"
+                elif grep -qiE '[*]{0,2}(CRITICAL|HIGH|Blocking)[*]{0,2}[[:space:]]*:' "$RESULT_FILE"; then
+                  VERDICT="fail"
+                  echo "::warning::No VERDICT marker found; inferred fail from blocking findings"
+                else
+                  VERDICT="pass"
+                  echo "::warning::No VERDICT marker found; inferred pass (no blocking findings detected)"
+                fi
+              fi
               rm -f "$RESULT_FILE"
               if [ "$VERDICT" != "pass" ]; then
                 echo "::error::Adversarial review did not pass (verdict: ${VERDICT:-missing})"
@@ -156,12 +178,23 @@ jobs:
               RESULT_FILE=$(mktemp)
               git diff "$MERGE_BASE" > "$DIFF_FILE"
               cat verification/review-prompts/ux-review.md > "$PROMPT_FILE"
-              printf '\n\nThe diff to review is at: %s\nRead that file to see the changes.\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n' "$DIFF_FILE" >> "$PROMPT_FILE"
+              printf '\n\nThe diff to review is at: %s\nRead that file to see the changes.\n\nIMPORTANT: You MUST begin your response with exactly one of these two lines:\nVERDICT: pass\nVERDICT: fail\n\nThen provide your full review below the verdict line.\n' "$DIFF_FILE" >> "$PROMPT_FILE"
               claude -p - \
                 --model claude-sonnet-4-6 \
                 --allowedTools "Read,Glob,Grep" < "$PROMPT_FILE" | tee "$RESULT_FILE"
               rm -f "$PROMPT_FILE" "$DIFF_FILE"
               VERDICT=$(grep -oi 'VERDICT: *\**pass\**\|VERDICT: *\**fail\**' "$RESULT_FILE" | head -1 | grep -oi 'pass\|fail')
+              if [ -z "$VERDICT" ]; then
+                if [ "$(wc -c < "$RESULT_FILE")" -lt 50 ]; then
+                  VERDICT="missing"
+                elif grep -qiE '[*]{0,2}(CRITICAL|HIGH|Blocking)[*]{0,2}[[:space:]]*:' "$RESULT_FILE"; then
+                  VERDICT="fail"
+                  echo "::warning::No VERDICT marker found; inferred fail from blocking findings"
+                else
+                  VERDICT="pass"
+                  echo "::warning::No VERDICT marker found; inferred pass (no blocking findings detected)"
+                fi
+              fi
               rm -f "$RESULT_FILE"
               if [ "$VERDICT" != "pass" ]; then
                 echo "::error::UX review did not pass (verdict: ${VERDICT:-missing})"
@@ -185,12 +218,23 @@ jobs:
               RESULT_FILE=$(mktemp)
               git diff "$MERGE_BASE" > "$DIFF_FILE"
               cat verification/review-prompts/ci-security-review.md > "$PROMPT_FILE"
-              printf '\n\nThe diff to review is at: %s\nRead that file to see the changes.\n\nOutput your review. Start with a single line: VERDICT: pass or VERDICT: fail\nThen provide your full review.\n' "$DIFF_FILE" >> "$PROMPT_FILE"
+              printf '\n\nThe diff to review is at: %s\nRead that file to see the changes.\n\nIMPORTANT: You MUST begin your response with exactly one of these two lines:\nVERDICT: pass\nVERDICT: fail\n\nThen provide your full review below the verdict line.\n' "$DIFF_FILE" >> "$PROMPT_FILE"
               claude -p - \
                 --model claude-opus-4-6 \
                 --allowedTools "Read,Glob,Grep" < "$PROMPT_FILE" | tee "$RESULT_FILE"
               rm -f "$PROMPT_FILE" "$DIFF_FILE"
               VERDICT=$(grep -oi 'VERDICT: *\**pass\**\|VERDICT: *\**fail\**' "$RESULT_FILE" | head -1 | grep -oi 'pass\|fail')
+              if [ -z "$VERDICT" ]; then
+                if [ "$(wc -c < "$RESULT_FILE")" -lt 50 ]; then
+                  VERDICT="missing"
+                elif grep -qiE '[*]{0,2}(CRITICAL|HIGH|Blocking)[*]{0,2}[[:space:]]*:' "$RESULT_FILE"; then
+                  VERDICT="fail"
+                  echo "::warning::No VERDICT marker found; inferred fail from blocking findings"
+                else
+                  VERDICT="pass"
+                  echo "::warning::No VERDICT marker found; inferred pass (no blocking findings detected)"
+                fi
+              fi
               rm -f "$RESULT_FILE"
               if [ "$VERDICT" != "pass" ]; then
                 echo "::error::CI security review did not pass (verdict: ${VERDICT:-missing})"


### PR DESCRIPTION
## Summary

- Add a fallback heuristic to the VERDICT extraction in all four verify-reviews
  steps: when the explicit `VERDICT: pass/fail` marker is missing, scan for
  blocking-severity labels (`CRITICAL`, `HIGH`, `Blocking`) to infer fail, or
  infer pass when no blocking findings are present and output is substantive
- Strengthen the VERDICT prompt instruction to reduce how often the fallback
  fires
- Document the inference behavior in verification-conventions.md

Closes swamp-club#2069

## Test plan

- [x] Verification workflow passed (build 9/9, code-review VERDICT: pass, 
  adversarial/ux/ci-security skipped by guard, skills skipped by guard)
- [x] Attestation posted to swamp-club

🤖 Generated with [Claude Code](https://claude.com/claude-code)