### PR TITLE
fix(shell): force UTF-8 output encoding in PowerShellStrategy (swamp-club#2070)

### DIFF
--- a/src/domain/models/command/shell/powershell_strategy.ts
+++ b/src/domain/models/command/shell/powershell_strategy.ts
@@ -35,11 +35,15 @@ import type { ShellStrategy } from "./shell_strategy.ts";
  * Inside WSL the host OS is `linux` and `PosixShellStrategy` is
  * selected automatically.
  */
+const UTF8_ENCODING_PREFIX =
+  "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; " +
+  "$OutputEncoding = [System.Text.Encoding]::UTF8; ";
+
 export class PowerShellStrategy implements ShellStrategy {
   buildInvocation(command: string): { command: string; args: string[] } {
     return {
       command: "powershell.exe",
-      args: ["-NoProfile", "-Command", command],
+      args: ["-NoProfile", "-Command", UTF8_ENCODING_PREFIX + command],
     };
   }
 

--- a/src/domain/models/command/shell/powershell_strategy_test.ts
+++ b/src/domain/models/command/shell/powershell_strategy_test.ts
@@ -21,26 +21,29 @@ import { assertEquals } from "@std/assert";
 import { PowerShellStrategy } from "./powershell_strategy.ts";
 import { VaultSecretBag } from "../../../vaults/vault_secret_bag.ts";
 
-Deno.test("PowerShellStrategy.buildInvocation: wraps command in powershell.exe -NoProfile -Command", () => {
+const UTF8_PREFIX =
+  "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; " +
+  "$OutputEncoding = [System.Text.Encoding]::UTF8; ";
+
+Deno.test("PowerShellStrategy.buildInvocation: wraps command in powershell.exe -NoProfile -Command with UTF-8 prefix", () => {
   const strategy = new PowerShellStrategy();
   assertEquals(
     strategy.buildInvocation("Get-ChildItem"),
     {
       command: "powershell.exe",
-      args: ["-NoProfile", "-Command", "Get-ChildItem"],
+      args: ["-NoProfile", "-Command", UTF8_PREFIX + "Get-ChildItem"],
     },
   );
 });
 
-Deno.test("PowerShellStrategy.buildInvocation: passes command through verbatim (no escaping)", () => {
-  // The shell handles parsing — strategy doesn't pre-escape.
+Deno.test("PowerShellStrategy.buildInvocation: passes command through verbatim after UTF-8 prefix", () => {
   const strategy = new PowerShellStrategy();
   const cmd = `Write-Output "hello $env:USERNAME"; exit 0`;
   assertEquals(
     strategy.buildInvocation(cmd),
     {
       command: "powershell.exe",
-      args: ["-NoProfile", "-Command", cmd],
+      args: ["-NoProfile", "-Command", UTF8_PREFIX + cmd],
     },
   );
 });


### PR DESCRIPTION
## Summary

- Force UTF-8 output encoding in `PowerShellStrategy.buildInvocation()` by prepending `[Console]::OutputEncoding` and `$OutputEncoding` assignments to every PowerShell command
- Fixes Windows model output containing UTF-16LE null-byte-interleaved text instead of UTF-8

## Root Cause

`PowerShellStrategy` wraps commands with `powershell.exe -NoProfile -Command <cmd>` but never configured output encoding. Windows PowerShell 5.1 defaults to the system OEM code page (or UTF-16LE for piped output). The `TextDecoder` in `process_executor.ts` always decodes as UTF-8, producing garbled text with null bytes interleaved between characters.

## Changes

- `src/domain/models/command/shell/powershell_strategy.ts` — Add `UTF8_ENCODING_PREFIX` constant and prepend it in `buildInvocation()`
- `src/domain/models/command/shell/powershell_strategy_test.ts` — Update both `buildInvocation` tests to assert UTF-8 prefix is present

## Test plan

- [x] PowerShell strategy unit tests pass (6/6)
- [x] All shell model tests pass (36 passed, 20 ignored — PowerShell-only tests that only run on Windows)
- [x] Full verification workflow: lint, fmt, type-check, tests, compile, code review, adversarial review all pass
- [ ] Windows CI: 5 failing vault roundtrip UAT tests in swamp-uat should pass with this fix

Fixes swamp-club#2070

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>