### PR TITLE
feat(skills): expose swamp help to agents proactively

### DIFF
--- a/.claude/skills/swamp/SKILL.md
+++ b/.claude/skills/swamp/SKILL.md
@@ -93,8 +93,11 @@ swamp extension init <name>                    # scaffold a new extension
    Before destructive methods (delete, stop, destroy):
    `swamp model get <name> --json` to confirm the target exists and is in the
    expected state. Proceed only when validation passes.
-4. **Execute** — run the command.
-5. **On failure** — load
+4. **Verify args** — run `swamp help <subcommand>` (e.g.
+   `swamp help model method run`) to confirm exact flags and arguments before
+   executing. The output is structured JSON — the canonical CLI schema.
+5. **Execute** — run the command.
+6. **On failure** — load
    [references/troubleshooting/guide.md](references/troubleshooting/guide.md)
    and diagnose before retrying or changing definitions.
 
@@ -113,3 +116,7 @@ swamp extension init <name>                    # scaffold a new extension
    API — check with `swamp model type search`. Composing with `--json` output
    (e.g. piping through `jq`) is fine — the anti-pattern is bypassing swamp
    entirely.
+4. **Verify flags with `swamp help` before executing.** `swamp help <command>`
+   outputs the full CLI schema as structured JSON — every subcommand, argument,
+   and option. Always run it to confirm exact flags before executing a swamp
+   command (workflow step 4). Do not guess flags from memory.

--- a/.claude/skills/swamp/references/data/guide.md
+++ b/.claude/skills/swamp/references/data/guide.md
@@ -3,8 +3,8 @@
 Manage model data lifecycle through the CLI. All commands support `--json` for
 machine-readable output.
 
-**Verify CLI syntax:** If unsure about exact flags or subcommands, run
-`swamp help data` for the complete, up-to-date CLI schema.
+**Verify CLI syntax:** Always run `swamp help data` to confirm exact flags
+before executing — the output is structured JSON.
 
 ## Query is the primitive; get/list/search/versions are shortcuts
 

--- a/.claude/skills/swamp/references/issue/guide.md
+++ b/.claude/skills/swamp/references/issue/guide.md
@@ -45,8 +45,8 @@ sibling issue, or update reproduction steps discovered later), use
 `swamp issue comment` is an alias for `ripple`. Add `--close` to close the issue
 after posting, or `--reopen` to reopen it.
 
-**Verify CLI syntax:** If unsure about exact flags or subcommands, run
-`swamp help issue` for the complete, up-to-date CLI schema.
+**Verify CLI syntax:** Always run `swamp help issue` to confirm exact flags
+before executing — the output is structured JSON.
 
 ## Commands
 

--- a/.claude/skills/swamp/references/model/guide.md
+++ b/.claude/skills/swamp/references/model/guide.md
@@ -40,8 +40,8 @@ definitions referenced across multiple workflows.
   `swamp model create <type> <name> --json` first, then edit the scaffold at the
   returned `path`, preserving the assigned `id`.
 - **Never modify the `id` field** in an existing model file.
-- **Verify CLI syntax**: If unsure about exact flags or subcommands, run
-  `swamp help model` for the complete, up-to-date CLI schema.
+- **Verify CLI syntax**: Always run `swamp help model` to confirm exact flags
+  before executing — the output is structured JSON.
 
 ## Per-Input Disposable Instances
 

--- a/.claude/skills/swamp/references/model/reference.md
+++ b/.claude/skills/swamp/references/model/reference.md
@@ -467,7 +467,7 @@ The central command is `swamp run`:
 | What completed runs exist (YAML outputs)? | `swamp model output search`         |
 | Execution history with duration/status    | `swamp model method history search` |
 
-See `swamp run history --help` for full details.
+See `swamp help run history` for the full schema.
 
 ## Workflow Example
 

--- a/.claude/skills/swamp/references/repo/guide.md
+++ b/.claude/skills/swamp/references/repo/guide.md
@@ -3,8 +3,8 @@
 Manage swamp repositories through the CLI. All commands support `--json` for
 machine-readable output.
 
-**Verify CLI syntax:** If unsure about exact flags or subcommands, run
-`swamp help repo` for the complete, up-to-date CLI schema.
+**Verify CLI syntax:** Always run `swamp help repo` to confirm exact flags
+before executing — the output is structured JSON.
 
 ## Quick Reference
 

--- a/.claude/skills/swamp/references/report/guide.md
+++ b/.claude/skills/swamp/references/report/guide.md
@@ -2,9 +2,9 @@
 
 Create and run reports that analyze model and workflow executions. Reports
 produce markdown (human-readable) and JSON (machine-readable) output. All
-commands support `--json`. If unsure about exact flags or subcommands, run
-`swamp report --help` or `swamp model method run --help` for the up-to-date
-schema.
+commands support `--json`. Always run `swamp help report` or
+`swamp help model method run` to confirm exact flags before executing — the
+output is structured JSON.
 
 ## Quick Reference
 

--- a/.claude/skills/swamp/references/share/guide.md
+++ b/.claude/skills/swamp/references/share/guide.md
@@ -30,8 +30,8 @@ assess → datastore (gate) → vaults (gate) → commit → joiner instructions
   working (e.g. `op whoami` for 1Password, `aws sts get-caller-identity` for
   AWS). Surface the auth requirement and let the user fix it before attempting
   the migration.
-- **Verify CLI syntax**: If unsure about exact flags, run `swamp help <command>`
-  for the up-to-date schema.
+- **Verify CLI syntax**: Always run `swamp help <command>` to confirm exact
+  flags before executing — the output is structured JSON.
 - **VCS detection**: Check for `.jj` directory to determine if the repo uses
   jujutsu or git. Hand off to the `jujutsu` skill or `github-pr` skill
   accordingly for the commit step.

--- a/.claude/skills/swamp/references/troubleshooting/guide.md
+++ b/.claude/skills/swamp/references/troubleshooting/guide.md
@@ -4,8 +4,8 @@ Diagnose swamp problems by working through four diagnostic tiers, cheapest
 first. Each tier answers a different kind of question; escalate only when the
 current tier doesn't resolve the issue.
 
-**Verify CLI syntax:** If unsure about exact flags or subcommands, run
-`swamp help <command>` for the up-to-date schema. Every swamp command supports
+**Verify CLI syntax:** Always run `swamp help <command>` to confirm exact flags
+before executing — the output is structured JSON. Every swamp command supports
 both `log` (default, human-readable) and `--json` (structured) output, and
 returns non-zero on user-facing failure.
 

--- a/.claude/skills/swamp/references/vault/guide.md
+++ b/.claude/skills/swamp/references/vault/guide.md
@@ -11,8 +11,8 @@ for machine-readable output.
   `swamp vault create <type> <name> --json` first, then edit the scaffold at the
   returned `path`, preserving the assigned `id`.
 - **Never modify the `id` field** in an existing vault file.
-- **Verify CLI syntax**: If unsure about exact flags or subcommands, run
-  `swamp help vault` for the complete, up-to-date CLI schema.
+- **Verify CLI syntax**: Always run `swamp help vault` to confirm exact flags
+  before executing — the output is structured JSON.
 
 Correct flow: `swamp vault create <type> <name> --json` → edit config if needed
 → store secrets.

--- a/.claude/skills/swamp/references/workflow/guide.md
+++ b/.claude/skills/swamp/references/workflow/guide.md
@@ -11,8 +11,8 @@ machine-readable output.
   `swamp workflow create <name> --json` first, then edit the scaffold at the
   returned `path`, preserving the assigned `id`.
 - **Never modify the `id` field** in an existing workflow file.
-- **Verify CLI syntax**: If unsure about exact flags or subcommands, run
-  `swamp help workflow` for the complete, up-to-date CLI schema.
+- **Verify CLI syntax**: Always run `swamp help workflow` to confirm exact flags
+  before executing — the output is structured JSON.
 
 Correct flow: `swamp workflow create <name> --json` → edit the YAML → validate →
 run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,8 @@ isn't part of the task. Keep the blast radius small.
 ## Commands
 
 Use `deno run` to get a complete list of custom tasks. `deno run dev` runs the
-CLI.
+CLI. `swamp help <command>` outputs the full CLI schema as structured JSON — use
+it to verify exact flags and arguments before running any swamp command.
 
 ## Verification
 

--- a/scripts/review_skills.ts
+++ b/scripts/review_skills.ts
@@ -18,7 +18,7 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Skill review script that runs `npx tessl skill review` on each bundled skill
+ * Skill review script that runs `npx tessl review run` on each bundled skill
  * and reports scores. Fails if any skill's average score drops below 90%.
  *
  * Usage: deno run review-skills
@@ -34,8 +34,11 @@ const THRESHOLD = 0.9;
 
 interface ReviewResult {
   validation: { overallPassed: boolean };
-  descriptionJudge: { normalizedScore: number };
-  contentJudge: { normalizedScore: number };
+  judges: {
+    description: { normalizedScore: number };
+    content: { normalizedScore: number };
+  };
+  review: { reviewScore: number };
 }
 
 interface SkillScore {
@@ -48,7 +51,15 @@ interface SkillScore {
 
 async function reviewSkill(skillDir: string): Promise<ReviewResult> {
   const command = new Deno.Command("npx", {
-    args: ["tessl", "skill", "review", skillDir, "--json"],
+    args: [
+      "tessl",
+      "review",
+      "run",
+      skillDir,
+      "--json",
+      "--workspace",
+      "swamp-club",
+    ],
     stdout: "piped",
     stderr: "piped",
   });
@@ -94,13 +105,11 @@ async function reviewSkill(skillDir: string): Promise<ReviewResult> {
     unknown
   >;
 
-  // Validate required fields are present and scores are finite numbers
-  const descScore =
-    (parsed.descriptionJudge as Record<string, unknown> | undefined)
-      ?.normalizedScore;
-  const contScore =
-    (parsed.contentJudge as Record<string, unknown> | undefined)
-      ?.normalizedScore;
+  const judges = parsed.judges as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  const descScore = judges?.description?.normalizedScore;
+  const contScore = judges?.content?.normalizedScore;
 
   if (
     typeof descScore !== "number" || !Number.isFinite(descScore) ||
@@ -120,10 +129,18 @@ async function reviewSkill(skillDir: string): Promise<ReviewResult> {
     );
   }
 
+  const reviewScore = (parsed.review as Record<string, unknown> | undefined)
+    ?.reviewScore;
+
   return {
     validation: { overallPassed: validation.overallPassed },
-    descriptionJudge: { normalizedScore: descScore },
-    contentJudge: { normalizedScore: contScore },
+    judges: {
+      description: { normalizedScore: descScore },
+      content: { normalizedScore: contScore },
+    },
+    review: {
+      reviewScore: typeof reviewScore === "number" ? reviewScore : 0,
+    },
   };
 }
 
@@ -177,8 +194,8 @@ async function main(): Promise<void> {
 
     try {
       const result = await reviewSkill(skillDir);
-      const descriptionScore = result.descriptionJudge.normalizedScore;
-      const contentScore = result.contentJudge.normalizedScore;
+      const descriptionScore = result.judges.description.normalizedScore;
+      const contentScore = result.judges.content.normalizedScore;
       const averageScore = (descriptionScore + contentScore) / 2;
       const validationPassed = result.validation.overallPassed;
 


### PR DESCRIPTION
## Summary

- Add a "Verify args" workflow step to the swamp skill so agents always run
  `swamp help <subcommand>` to confirm exact CLI flags before executing
- Add a rule to SKILL.md and a mention in AGENTS.md so agents know `swamp help`
  outputs structured JSON — the canonical CLI schema
- Change "If unsure" framing to unconditional "Always verify" across 9 guide
  files, and standardize inconsistent `--help` references to `swamp help`
- Migrate `scripts/review_skills.ts` to `tessl review run` (replaces deprecated
  `tessl skill review`)

## Test plan

- [x] `deno fmt` — all modified markdown formatted
- [x] `deno check` — type check passes on review_skills.ts
- [x] Local verification workflows passed (build, reviews, skills) on rebased commit
- [x] Skill review scores: swamp 96%, swamp-getting-started 98%
- [x] Attestation posted for rebased commit e3d71263

Closes #2071

🤖 Generated with [Claude Code](https://claude.com/claude-code)