### PR TITLE
fix(paths): make marker the sole authority for managedConfig activation

### DIFF
--- a/design/enablers/datastores.md
+++ b/design/enablers/datastores.md
@@ -1386,13 +1386,14 @@ process left a lock that hasn't expired yet.
   (`datastore_compact.ts`).
 - `swamp datastore config migrate` — copy definitions, vault configs, the
   extension lockfile and pulled extensions into the datastore `config/` tier
-  and set `managedConfig: true`; once the sentinel exists,
-  `resolveManagedConfigPaths` (`src/cli/repo_context.ts`) points the
-  pulled-extensions root and lockfile at the datastore-resolved config path.
-  For custom datastores (S3, GCS), `ensureManagedConfigBase` resolves the
-  datastore config to derive the cache-relative config path — extension
-  commands call it before `resolveManagedConfigPaths` so the module-level
-  registry is populated correctly (`datastore_config_migrate.ts`).
+  and set `managedConfig: true`; the marker flag is the sole authority for
+  activation — `resolveManagedConfigPaths` (`src/cli/repo_context.ts`)
+  points the pulled-extensions root and lockfile at the datastore-resolved
+  config path whenever `managedConfig` is true. For custom datastores
+  (S3, GCS), `ensureManagedConfigBase` resolves the datastore config to
+  derive the cache-relative config path — extension commands call it before
+  `resolveManagedConfigPaths` so the module-level registry is populated
+  correctly (`datastore_config_migrate.ts`).
 - `swamp doctor datastores [--repair [-y]]` — health check plus optional
   repair of catalog completeness, root-level unmigrated data and foreign
   namespace contamination, the last via the optional

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -242,8 +242,9 @@ export interface RequireRepoOptions {
  * Pre-populates the module-level managed config registry by resolving the
  * datastore config. Call this before {@link resolveManagedConfigPaths} in
  * commands that use {@link requireRepoMarker} (lightweight, no datastore
- * resolution) so the registry-based fallback in resolveManagedConfigPaths
- * returns the correct cache-relative paths for custom datastores (S3, GCS).
+ * resolution) so resolveManagedConfigPaths resolves the correct
+ * cache-relative base path for custom datastores (S3, GCS) when no
+ * explicit `configBasePath` argument is provided.
  *
  * Commands that go through {@link requireInitializedRepo} /
  * {@link requireInitializedRepoReadOnly} / {@link requireInitializedRepoUnlocked}
@@ -282,10 +283,10 @@ export async function ensureManagedConfigBase(
     logger.debug`Failed to resolve datastore for managedConfig base: ${
       error instanceof Error ? error.message : String(error)
     }`;
-    // Datastore extension not loadable — fall back to sentinel-based
-    // detection in resolveManagedConfigPaths. This can happen when
-    // pulling the datastore extension itself, but managedConfig is
-    // only true after config migrate which requires a working
+    // Datastore extension not loadable — resolveManagedConfigPaths
+    // will use the default .swamp/config/ base path. This can happen
+    // when pulling the datastore extension itself, but managedConfig
+    // is only true after config migrate which requires a working
     // datastore, so this is an edge case.
   }
 }
@@ -296,42 +297,27 @@ export async function ensureManagedConfigBase(
  * these paths point into .swamp/config/ (the datastore interface
  * layer). When false, they use the traditional locations.
  *
- * When the sentinel check fails but managedConfig is set in the marker,
- * checks the module-level registry for a base path populated by a prior
- * {@link ensureManagedConfigBase} call. This handles custom datastores
- * (S3, GCS) where the sentinel lives at the cache path, not the
- * repo-local `.swamp/config/`.
+ * The marker flag (`managedConfig: true` in `.swamp.yaml`) is the sole
+ * authority for activation. When no explicit `configBasePath` is provided,
+ * the module-level registry (populated by {@link ensureManagedConfigBase})
+ * supplies the correct base for custom datastores (S3, GCS) whose config
+ * tier lives at the cache path rather than repo-local `.swamp/config/`.
  */
 export function resolveManagedConfigPaths(
   repoDir: string,
   marker: RepoMarkerData | null,
   configBasePath?: string,
-  options?: { skipSentinelCheck?: boolean },
 ): { pulledExtensionsRoot: string; lockfilePath: string; active: boolean } {
   const managedConfig = marker?.datastore?.managedConfig === true;
   let effectiveBase = configBasePath ?? swampPath(repoDir, "config");
 
   let active = false;
   if (managedConfig) {
-    if (options?.skipSentinelCheck) {
-      active = true;
-    } else {
-      try {
-        Deno.statSync(join(effectiveBase, "managed-config-migrated.json"));
-        active = true;
-      } catch {
-        // Sentinel not found at the default path — check the registry
-        // for a base path populated by ensureManagedConfigBase (which
-        // resolves the datastore to find the cache-relative path).
-        // Only fall back to the registry when no explicit configBasePath
-        // was provided — an explicit argument takes precedence.
-        if (!configBasePath) {
-          const registeredBase = getManagedConfigBase(repoDir);
-          if (registeredBase) {
-            effectiveBase = registeredBase;
-            active = true;
-          }
-        }
+    active = true;
+    if (!configBasePath) {
+      const registeredBase = getManagedConfigBase(repoDir);
+      if (registeredBase) {
+        effectiveBase = registeredBase;
       }
     }
   }
@@ -951,7 +937,6 @@ export async function requireInitializedRepoUnlocked(
     repoPath.value,
     marker,
     configBase,
-    { skipSentinelCheck: true },
   );
   const definitionsDir = managedActive
     ? join(configBase, "models")

--- a/src/cli/repo_context_test.ts
+++ b/src/cli/repo_context_test.ts
@@ -2268,80 +2268,50 @@ Deno.test("resolveManagedConfigPaths: managedConfig=false returns default paths"
   );
 });
 
-Deno.test("resolveManagedConfigPaths: managedConfig=true returns managed pulled-extensions root", async () => {
-  const tmpDir = await Deno.makeTempDir();
-  try {
-    const configDir = `${tmpDir}/.swamp/config`;
-    await Deno.mkdir(configDir, { recursive: true });
-    await Deno.writeTextFile(
-      `${configDir}/managed-config-migrated.json`,
-      "{}",
-    );
-    const marker: RepoMarkerData = {
-      swampVersion: "1.0.0",
-      initializedAt: "2026-01-01T00:00:00.000Z",
-      datastore: { type: "@swamp/s3-datastore", managedConfig: true },
-    };
-    const { pulledExtensionsRoot } = resolveManagedConfigPaths(tmpDir, marker);
-    assertPathEquals(
-      pulledExtensionsRoot,
-      `${tmpDir}/.swamp/config/pulled-extensions`,
-    );
-  } finally {
-    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
-  }
+Deno.test("resolveManagedConfigPaths: managedConfig=true returns managed pulled-extensions root", () => {
+  const repo = resolve("/repo");
+  const marker: RepoMarkerData = {
+    swampVersion: "1.0.0",
+    initializedAt: "2026-01-01T00:00:00.000Z",
+    datastore: { type: "@swamp/s3-datastore", managedConfig: true },
+  };
+  const { pulledExtensionsRoot } = resolveManagedConfigPaths(repo, marker);
+  assertPathEquals(
+    pulledExtensionsRoot,
+    join(repo, ".swamp", "config", "pulled-extensions"),
+  );
 });
 
-Deno.test("resolveManagedConfigPaths: managedConfig=true returns managed lockfile path", async () => {
-  const tmpDir = await Deno.makeTempDir();
-  try {
-    const configDir = `${tmpDir}/.swamp/config`;
-    await Deno.mkdir(configDir, { recursive: true });
-    await Deno.writeTextFile(
-      `${configDir}/managed-config-migrated.json`,
-      "{}",
-    );
-    const marker: RepoMarkerData = {
-      swampVersion: "1.0.0",
-      initializedAt: "2026-01-01T00:00:00.000Z",
-      datastore: { type: "@swamp/s3-datastore", managedConfig: true },
-    };
-    const { lockfilePath } = resolveManagedConfigPaths(tmpDir, marker);
-    assertPathEquals(
-      lockfilePath,
-      `${tmpDir}/.swamp/config/upstream_extensions.json`,
-    );
-  } finally {
-    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
-  }
+Deno.test("resolveManagedConfigPaths: managedConfig=true returns managed lockfile path", () => {
+  const repo = resolve("/repo");
+  const marker: RepoMarkerData = {
+    swampVersion: "1.0.0",
+    initializedAt: "2026-01-01T00:00:00.000Z",
+    datastore: { type: "@swamp/s3-datastore", managedConfig: true },
+  };
+  const { lockfilePath } = resolveManagedConfigPaths(repo, marker);
+  assertPathEquals(
+    lockfilePath,
+    join(repo, ".swamp", "config", "upstream_extensions.json"),
+  );
 });
 
-Deno.test("resolveManagedConfigPaths: managedConfig=true with custom modelsDir still uses managed path", async () => {
-  const tmpDir = await Deno.makeTempDir();
-  try {
-    const configDir = `${tmpDir}/.swamp/config`;
-    await Deno.mkdir(configDir, { recursive: true });
-    await Deno.writeTextFile(
-      `${configDir}/managed-config-migrated.json`,
-      "{}",
-    );
-    const marker: RepoMarkerData = {
-      swampVersion: "1.0.0",
-      initializedAt: "2026-01-01T00:00:00.000Z",
-      modelsDir: "custom/models",
-      datastore: { type: "@swamp/s3-datastore", managedConfig: true },
-    };
-    const { lockfilePath } = resolveManagedConfigPaths(tmpDir, marker);
-    assertPathEquals(
-      lockfilePath,
-      `${tmpDir}/.swamp/config/upstream_extensions.json`,
-    );
-  } finally {
-    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
-  }
+Deno.test("resolveManagedConfigPaths: managedConfig=true with custom modelsDir still uses managed path", () => {
+  const repo = resolve("/repo");
+  const marker: RepoMarkerData = {
+    swampVersion: "1.0.0",
+    initializedAt: "2026-01-01T00:00:00.000Z",
+    modelsDir: "custom/models",
+    datastore: { type: "@swamp/s3-datastore", managedConfig: true },
+  };
+  const { lockfilePath } = resolveManagedConfigPaths(repo, marker);
+  assertPathEquals(
+    lockfilePath,
+    join(repo, ".swamp", "config", "upstream_extensions.json"),
+  );
 });
 
-Deno.test("resolveManagedConfigPaths: managedConfig=true without sentinel falls back to default paths", () => {
+Deno.test("resolveManagedConfigPaths: managedConfig=true uses managed paths regardless of sentinel file", () => {
   const repo = resolve("/nonexistent-repo");
   const marker: RepoMarkerData = {
     swampVersion: "1.0.0",
@@ -2354,11 +2324,11 @@ Deno.test("resolveManagedConfigPaths: managedConfig=true without sentinel falls 
   );
   assertPathEquals(
     pulledExtensionsRoot,
-    join(repo, ".swamp", "pulled-extensions"),
+    join(repo, ".swamp", "config", "pulled-extensions"),
   );
   assertPathEquals(
     lockfilePath,
-    join(repo, "extensions", "models", "upstream_extensions.json"),
+    join(repo, ".swamp", "config", "upstream_extensions.json"),
   );
 });
 
@@ -2466,17 +2436,7 @@ Deno.test("ensureManagedConfigBase: explicit configBasePath still takes preceden
   const tmpDir = await Deno.makeTempDir();
   try {
     const explicitBase = join(tmpDir, "explicit-config");
-    await Deno.mkdir(
-      join(explicitBase, "managed-config-migrated.json").replace(
-        "managed-config-migrated.json",
-        "",
-      ),
-      { recursive: true },
-    );
-    await Deno.writeTextFile(
-      join(explicitBase, "managed-config-migrated.json"),
-      "{}",
-    );
+    await Deno.mkdir(explicitBase, { recursive: true });
     const cachePath = join(tmpDir, "cache");
     await Deno.mkdir(cachePath, { recursive: true });
     const marker: RepoMarkerData = {


### PR DESCRIPTION
## Summary

Fixes swamp-club#2043.

- Remove the sentinel file check (`managed-config-migrated.json`) from `resolveManagedConfigPaths` — the marker flag (`managedConfig: true` in `.swamp.yaml`) is now the sole authority for managed config activation
- Remove the `skipSentinelCheck` option that `requireInitializedRepoUnlocked` (serve path) used to bypass the sentinel check
- All processes (CLI and serve) now agree on path resolution when `managedConfig` is set, eliminating the cross-process disagreement that caused "Unknown model type" errors in k8s pods where init containers run before the sentinel file exists
- The sentinel file is preserved in the migration flow as an idempotency guard

## Test plan

- [x] `deno run test src/cli/repo_context_test.ts` — 65/65 pass
- [x] `deno run test src/domain/datastore/managed_config_migration_test.ts` — 10/10 pass
- [x] `deno check src/cli/repo_context.ts` — clean
- [x] Full verification workflow (build, reviews, skills) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)