### PR TITLE
fix(repo): use bare swamp in Kiro hook commands for cross-machine portability

### DIFF
--- a/design/surfaces/audit-doctor.md
+++ b/design/surfaces/audit-doctor.md
@@ -31,12 +31,9 @@ Run in fixed order so output is stable:
 
 1. **`binary-on-path`** — the AI tool's own binary (`claude`, `cursor`,
    `kiro-cli`, `opencode`, `copilot`) is resolvable on PATH.
-2. **`swamp-binary-on-path`** — swamp is on PATH (all five tools invoke
-   `swamp audit record --from-hook` from their hook configs). For Kiro
-   only, also verifies the absolute swamp path baked into
-   `.kiro/hooks/swamp-audit.kiro.hook` at init time still resolves —
-   catches the "user ran `brew upgrade` and orphaned the baked path"
-   case.
+2. **`swamp-binary-on-path`** — swamp is on PATH (all tools invoke
+   `swamp audit record --from-hook` from their hook configs and rely on
+   PATH lookup at hook-fire time).
 3. **`agent-config-loadable`** — per-tool parser checks the config
    `swamp init` wrote is present, parses, and has the expected shape
    (e.g. Kiro's `.kiro/agents/swamp.json` must not contain `tools: ["*"]`
@@ -59,7 +56,7 @@ src/domain/audit/doctor/
 └── checks/
     ├── resolve_binary.ts          — ResolveBinary port + binaryNameFor(); CLI wires defaultCommandResolver()
     ├── binary_on_path.ts
-    ├── swamp_binary_on_path.ts    — includes Kiro baked-path sub-check
+    ├── swamp_binary_on_path.ts    — PATH lookup for swamp binary
     ├── agent_config_loadable.ts   — tool-dispatched parser
     ├── default_agent_set.ts       — Kiro-only
     └── recording_smoke.ts         — uses ctx.spawnSwamp + reads today's JSONL

--- a/integration/ddd_layer_rules_test.ts
+++ b/integration/ddd_layer_rules_test.ts
@@ -125,7 +125,6 @@ const PINNED_DOMAIN_INFRA_EDGES: readonly string[] = [
   "src/domain/repo/repo_service.ts -> src/infrastructure/persistence/repo_marker_repository.ts",
   "src/domain/repo/repo_service.ts -> src/infrastructure/persistence/telemetry_spool_migration.ts",
   "src/domain/repo/repo_service.ts -> src/infrastructure/persistence/upstream_extensions.ts",
-  "src/domain/repo/repo_service.ts -> src/infrastructure/process/resolve_command.ts",
   "src/domain/repo/skill_dirs.ts -> src/infrastructure/persistence/paths.ts",
   "src/domain/vaults/local_encryption_vault_provider.ts -> src/infrastructure/persistence/atomic_write.ts",
   "src/domain/vaults/local_encryption_vault_provider.ts -> src/infrastructure/persistence/paths.ts",

--- a/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
+++ b/src/domain/audit/doctor/checks/swamp_binary_on_path.ts
@@ -17,76 +17,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
-import { join } from "@std/path";
-import type { CheckContext, CheckResult, PreflightCheck } from "../check.ts";
+import type { CheckResult, PreflightCheck } from "../check.ts";
 import type { ResolveBinary } from "./resolve_binary.ts";
 
 /**
- * Verifies swamp itself is invocable from the hook. All four supported
- * tools embed the string `swamp audit record --from-hook` in their hook
- * configs and rely on PATH lookup at hook-fire time; without swamp on
- * PATH, every hook silently fails on every tool.
- *
- * For Kiro only, the init command also bakes an absolute swamp path into
- * `.kiro/hooks/swamp-audit.kiro.hook` (kiro-cli doesn't do PATH lookup).
- * A later `brew upgrade` or path change can orphan that baked reference.
- * This check surfaces both conditions.
+ * Verifies swamp itself is invocable from the hook. All supported tools
+ * embed the string `swamp audit record --from-hook` in their hook configs
+ * and rely on PATH lookup at hook-fire time; without swamp on PATH, every
+ * hook silently fails on every tool.
  */
 
 function appliesTo(tool: string): boolean {
   return tool === "claude" || tool === "cursor" || tool === "kiro" ||
     tool === "opencode" || tool === "copilot" || tool === "pi" ||
     tool === "antigravity";
-}
-
-async function checkKiroBakedPath(ctx: CheckContext): Promise<{
-  ok: boolean;
-  bakedPath?: string;
-  message?: string;
-}> {
-  const hookPath = join(ctx.repoPath, ".kiro/hooks/swamp-audit.kiro.hook");
-  try {
-    const content = await Deno.readTextFile(hookPath);
-    const parsed = JSON.parse(content) as {
-      then?: { command?: string };
-    };
-    const command = parsed.then?.command;
-    if (!command) {
-      return { ok: false, message: "kiro hook has no `then.command`" };
-    }
-    // Command format is `"<absolute-swamp-path>" audit record --from-hook --tool kiro`
-    const match = command.match(/^"([^"]+)"/);
-    const bakedPath = match?.[1];
-    if (!bakedPath) {
-      return {
-        ok: false,
-        message:
-          `could not extract absolute path from kiro hook command: ${command}`,
-      };
-    }
-    try {
-      const stat = await Deno.stat(bakedPath);
-      if (!stat.isFile) {
-        return {
-          ok: false,
-          bakedPath,
-          message: `kiro hook's baked path ${bakedPath} is not a file`,
-        };
-      }
-      return { ok: true, bakedPath };
-    } catch {
-      return {
-        ok: false,
-        bakedPath,
-        message: `kiro hook's baked path ${bakedPath} does not exist`,
-      };
-    }
-  } catch (error) {
-    if (error instanceof Deno.errors.NotFound) {
-      return { ok: false, message: `${hookPath} is missing` };
-    }
-    throw error;
-  }
 }
 
 /**
@@ -99,10 +43,9 @@ export function makeSwampBinaryOnPathCheck(
   const { resolveBinary } = opts;
   return {
     name: "swamp-binary-on-path",
-    description:
-      "swamp binary is invokable from the hook (PATH lookup; Kiro also checks the baked absolute path)",
+    description: "swamp binary is invokable from the hook (PATH lookup)",
     appliesTo,
-    async run(ctx): Promise<CheckResult> {
+    async run(_ctx): Promise<CheckResult> {
       const pathResolved = await resolveBinary("swamp");
       if (!pathResolved) {
         return {
@@ -111,27 +54,6 @@ export function makeSwampBinaryOnPathCheck(
           message: "swamp is not on PATH",
           hint:
             "The audit hooks invoke `swamp audit record` — without swamp on PATH, every hook silently fails. Install swamp or add it to PATH.",
-        };
-      }
-
-      if (ctx.tool === "kiro") {
-        const baked = await checkKiroBakedPath(ctx);
-        if (!baked.ok) {
-          return {
-            name: "swamp-binary-on-path",
-            status: "fail",
-            message: baked.message ?? "kiro baked swamp path is not usable",
-            hint:
-              "Run `swamp init --tool kiro --force` to re-bake the absolute swamp path into the hook file.",
-            details: { pathResolved, bakedPath: baked.bakedPath },
-          };
-        }
-        return {
-          name: "swamp-binary-on-path",
-          status: "pass",
-          message:
-            `swamp is on PATH at ${pathResolved}; kiro hook points at ${baked.bakedPath}`,
-          details: { pathResolved, bakedPath: baked.bakedPath },
         };
       }
 

--- a/src/domain/audit/doctor/checks/swamp_binary_on_path_test.ts
+++ b/src/domain/audit/doctor/checks/swamp_binary_on_path_test.ts
@@ -18,7 +18,6 @@
 // along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import { ensureDir } from "@std/fs";
 import { join } from "@std/path";
 import type { AiTool } from "../../../repo/repo_service.ts";
 import type { CheckContext } from "../check.ts";
@@ -43,24 +42,6 @@ function makeCtx(repoPath: string, tool: AiTool): CheckContext {
   };
 }
 
-async function writeKiroHook(repo: string, swampPath: string): Promise<void> {
-  const path = join(repo, ".kiro/hooks/swamp-audit.kiro.hook");
-  await ensureDir(join(path, ".."));
-  await Deno.writeTextFile(
-    path,
-    JSON.stringify({
-      name: "Swamp Audit",
-      version: "1",
-      when: { type: "postToolUse", toolTypes: ["*"] },
-      then: {
-        type: "runCommand",
-        command: `"${swampPath}" audit record --from-hook --tool kiro`,
-        timeout: 5,
-      },
-    }),
-  );
-}
-
 Deno.test("swampBinaryOnPath: fails when swamp is not on PATH", async () => {
   const check = makeSwampBinaryOnPathCheck({
     resolveBinary: () => Promise.resolve(null),
@@ -72,55 +53,25 @@ Deno.test("swampBinaryOnPath: fails when swamp is not on PATH", async () => {
   });
 });
 
-Deno.test("swampBinaryOnPath: passes for non-kiro when PATH resolves", async () => {
+Deno.test("swampBinaryOnPath: passes for all tools when PATH resolves", async () => {
   const check = makeSwampBinaryOnPathCheck({
     resolveBinary: () => Promise.resolve("/usr/local/bin/swamp"),
   });
   await withTempRepo(async (repo) => {
-    for (const tool of ["claude", "cursor", "opencode", "copilot"] as const) {
+    for (
+      const tool of [
+        "claude",
+        "cursor",
+        "kiro",
+        "opencode",
+        "copilot",
+        "pi",
+        "antigravity",
+      ] as const
+    ) {
       const result = await check.run(makeCtx(repo, tool));
       assertEquals(result.status, "pass", `failed for tool ${tool}`);
+      assertStringIncludes(result.message, "/usr/local/bin/swamp");
     }
-  });
-});
-
-Deno.test("swampBinaryOnPath: kiro passes when baked path exists", async () => {
-  const check = makeSwampBinaryOnPathCheck({
-    resolveBinary: () => Promise.resolve("/usr/local/bin/swamp"),
-  });
-  await withTempRepo(async (repo) => {
-    const fakeBinary = await Deno.makeTempFile({ prefix: "fake-swamp-" });
-    try {
-      await writeKiroHook(repo, fakeBinary);
-      const result = await check.run(makeCtx(repo, "kiro"));
-      assertEquals(result.status, "pass");
-      assertStringIncludes(result.message, fakeBinary);
-    } finally {
-      await Deno.remove(fakeBinary);
-    }
-  });
-});
-
-Deno.test("swampBinaryOnPath: kiro fails when baked path is stale", async () => {
-  const check = makeSwampBinaryOnPathCheck({
-    resolveBinary: () => Promise.resolve("/usr/local/bin/swamp"),
-  });
-  await withTempRepo(async (repo) => {
-    await writeKiroHook(repo, "/nonexistent/swamp");
-    const result = await check.run(makeCtx(repo, "kiro"));
-    assertEquals(result.status, "fail");
-    assertStringIncludes(result.message, "/nonexistent/swamp");
-    assertStringIncludes(result.hint ?? "", "re-bake");
-  });
-});
-
-Deno.test("swampBinaryOnPath: kiro fails when hook file is missing", async () => {
-  const check = makeSwampBinaryOnPathCheck({
-    resolveBinary: () => Promise.resolve("/usr/local/bin/swamp"),
-  });
-  await withTempRepo(async (repo) => {
-    const result = await check.run(makeCtx(repo, "kiro"));
-    assertEquals(result.status, "fail");
-    assertStringIncludes(result.message, "missing");
   });
 });

--- a/src/domain/repo/repo_service.ts
+++ b/src/domain/repo/repo_service.ts
@@ -22,7 +22,6 @@ import { ensureDir } from "@std/fs";
 import { getLogger } from "@logtape/logtape";
 import { atomicWriteTextFile } from "../../infrastructure/persistence/atomic_write.ts";
 import { migrateRepoTelemetryToGlobal } from "../../infrastructure/persistence/telemetry_spool_migration.ts";
-import { defaultCommandResolver } from "../../infrastructure/process/resolve_command.ts";
 import type { RepoPath } from "./repo_path.ts";
 import {
   homeDirectory,
@@ -1874,13 +1873,7 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
     return true;
   }
 
-  /**
-   * Generates the content for Kiro's .kiro/hooks/swamp-audit.kiro.hook.
-   * Uses the absolute path to the swamp binary because kiro-cli does not
-   * perform PATH resolution when executing hook commands.
-   */
-  private async generateKiroHookContent(): Promise<string> {
-    const swampBin = await this.resolveSwampBinaryPath();
+  private generateKiroHookContent(): string {
     const hook = {
       name: "Swamp Audit",
       description: "Records agent tool usage for swamp audit tracking",
@@ -1888,20 +1881,11 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
       when: { type: "postToolUse", toolTypes: ["*"] },
       then: {
         type: "runCommand",
-        command: `"${swampBin}" audit record --from-hook --tool kiro`,
+        command: "swamp audit record --from-hook --tool kiro",
         timeout: 5,
       },
     };
     return JSON.stringify(hook, null, 2) + "\n";
-  }
-
-  /**
-   * Resolves the absolute path to the swamp binary.
-   * Falls back to bare "swamp" if resolution fails.
-   */
-  private async resolveSwampBinaryPath(): Promise<string> {
-    const path = await defaultCommandResolver().resolve("swamp");
-    return path ?? "swamp";
   }
 
   /**
@@ -1918,7 +1902,7 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
     );
     return await this.createFileIfNotExists(
       hookPath,
-      await this.generateKiroHookContent(),
+      this.generateKiroHookContent(),
     );
   }
 
@@ -1947,7 +1931,7 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
     );
     return this.overwriteIfChanged(
       hookPath,
-      await this.generateKiroHookContent(),
+      this.generateKiroHookContent(),
     );
   }
 
@@ -2063,8 +2047,7 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
    * This provides kiro-cli with trusted commands, audit hooks, and resource
    * references that the IDE gets from .vscode/settings.local.json and .kiro/hooks/.
    */
-  private async generateKiroAgentConfigContent(): Promise<string> {
-    const swampBin = await this.resolveSwampBinaryPath();
+  private generateKiroAgentConfigContent(): string {
     const config = {
       name: "swamp",
       description: "Swamp automation agent with audit tracking",
@@ -2084,7 +2067,7 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
       hooks: {
         postToolUse: [
           {
-            command: `"${swampBin}" audit record --from-hook --tool kiro`,
+            command: "swamp audit record --from-hook --tool kiro",
           },
         ],
       },
@@ -2106,7 +2089,7 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
     );
     return await this.createFileIfNotExists(
       configPath,
-      await this.generateKiroAgentConfigContent(),
+      this.generateKiroAgentConfigContent(),
     );
   }
 
@@ -2122,7 +2105,7 @@ the full tree, and \`swamp help model method run\` scopes to a subtree.
     );
     return await this.overwriteIfChanged(
       configPath,
-      await this.generateKiroAgentConfigContent(),
+      this.generateKiroAgentConfigContent(),
     );
   }
 

--- a/src/domain/repo/repo_service_test.ts
+++ b/src/domain/repo/repo_service_test.ts
@@ -1682,9 +1682,9 @@ Deno.test("RepoService.init with kiro creates .kiro/hooks/swamp-audit.kiro.hook"
     assertEquals(hook.when.toolTypes, ["*"]);
     assertEquals(hook.then.type, "runCommand");
     assertEquals(hook.then.timeout, 5);
-    assertStringIncludes(
+    assertEquals(
       hook.then.command,
-      "audit record --from-hook --tool kiro",
+      "swamp audit record --from-hook --tool kiro",
     );
 
     // Also verify .vscode/settings.local.json was created
@@ -1718,9 +1718,9 @@ Deno.test("RepoService.upgrade with kiro updates hooks", async () => {
     );
     const content = await Deno.readTextFile(hookPath);
     const hook = JSON.parse(content);
-    assertStringIncludes(
+    assertEquals(
       hook.then.command,
-      "audit record --from-hook --tool kiro",
+      "swamp audit record --from-hook --tool kiro",
     );
   });
 });
@@ -1779,9 +1779,9 @@ Deno.test("RepoService.init with kiro creates .kiro/agents/swamp.json", async ()
       JSON.stringify(config.toolsSettings.shell.allowedCommands),
       "swamp .*",
     );
-    assertStringIncludes(
-      JSON.stringify(config.hooks.postToolUse),
-      "audit record --from-hook --tool kiro",
+    assertEquals(
+      config.hooks.postToolUse[0].command,
+      "swamp audit record --from-hook --tool kiro",
     );
     assertStringIncludes(
       JSON.stringify(config.resources),
@@ -1803,9 +1803,9 @@ Deno.test("RepoService.upgrade with kiro updates agent config", async () => {
     const configPath = join(tempDir, ".kiro", "agents", "swamp.json");
     const content = await Deno.readTextFile(configPath);
     const config = JSON.parse(content);
-    assertStringIncludes(
-      JSON.stringify(config.hooks.postToolUse),
-      "audit record --from-hook --tool kiro",
+    assertEquals(
+      config.hooks.postToolUse[0].command,
+      "swamp audit record --from-hook --tool kiro",
     );
   });
 });


### PR DESCRIPTION
## Summary

- Switch Kiro hook generators from absolute binary path to bare `swamp`, matching all other tools (Claude, Cursor, Copilot, Pi, AntiGravity, OpenCode) which already rely on PATH lookup at hook-fire time
- Remove `resolveSwampBinaryPath()` and its `defaultCommandResolver` import from `RepoService`
- Simplify doctor check to treat Kiro like all other tools (PATH-only validation)
- Update `design/surfaces/audit-doctor.md` to reflect removal of baked-path sub-check
- Remove resolved domain→infra import from DDD architecture fitness pinned ratchet list
- Tighten tests to `assertEquals` on exact bare command string

## Test plan

- [x] `repo_service_test.ts` — 126 tests pass, including all Kiro hook/agent config tests
- [x] `swamp_binary_on_path_test.ts` — 2 tests pass, verifying Kiro uses same PATH check as other tools
- [x] `ddd_layer_rules_test.ts` — architecture fitness test passes with updated ratchet list
- [x] Full verification workflow: lint, fmt, type-check, tests, compile, code review, adversarial review all pass

Closes swamp-club#2072

Co-authored-by: Sean Escriva <webframp@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6SrFd6VPsXTmpFtPUq1tQ