### PR TITLE
fix(workflows): skip guard expressions and coerce inputs in evaluate (swamp-club#2079)

### DIFF
--- a/src/libswamp/workflows/evaluate.ts
+++ b/src/libswamp/workflows/evaluate.ts
@@ -29,6 +29,7 @@ import {
 import {
   extractExpressions,
   isAssertMessagePath,
+  isGuardPath,
   isTaskGlobalArgsPath,
   isTaskInputsPath,
   replaceExpressions,
@@ -52,6 +53,7 @@ import { DataQueryService } from "../../domain/data/data_query_service.ts";
 import type { DatastorePathResolver } from "../../domain/datastore/datastore_path_resolver.ts";
 import type { LibSwampContext } from "../context.ts";
 import { notFound, type SwampError } from "../errors.ts";
+import { coerceInputTypes } from "../../domain/inputs/mod.ts";
 
 /** Evaluation result for a single workflow. */
 export interface WorkflowEvaluateItemData {
@@ -182,9 +184,12 @@ async function evaluateWorkflowInternal(
     };
   }
 
+  // Coerce string CLI inputs to schema types (matching run.ts behavior)
+  const coercedInputs = coerceInputTypes(inputs, workflow.inputs);
+
   // Build expression context with inputs
   const context = await deps.buildExpressionContext();
-  context.inputs = inputs;
+  context.inputs = coercedInputs;
 
   // Collect forEach.in expressions to skip during evaluation
   const forEachInExpressions = new Set<string>();
@@ -211,6 +216,10 @@ async function evaluateWorkflowInternal(
     }
     // Skip forEach.in expressions — they must remain as strings for forEach expansion
     if (forEachInExpressions.has(expr.raw)) {
+      continue;
+    }
+    // Skip guard expressions — they are evaluated at step execution time
+    if (isGuardPath(expr.path)) {
       continue;
     }
     // Skip task.inputs/globalArgs/message expressions that depend on step outputs (resource, file, execution, data, file.contents).

--- a/src/libswamp/workflows/evaluate_test.ts
+++ b/src/libswamp/workflows/evaluate_test.ts
@@ -679,6 +679,128 @@ Deno.test("forEach: resolves self.* in platform", async () => {
   assertEquals(steps[1].platform, "linux/arm64");
 });
 
+// --- Guard expression skipping ---
+
+Deno.test("evaluate: guard expressions remain as strings (not resolved to booleans)", async () => {
+  const workflow = Workflow.fromData({
+    id: "00000000-0000-4000-8000-000000000020",
+    name: "guarded-workflow",
+    inputs: {
+      type: "object",
+      properties: {
+        action: { type: "string", enum: ["start", "stop"], default: "start" },
+      },
+      required: ["action"],
+    },
+    jobs: [{
+      name: "main",
+      steps: [
+        {
+          name: "on-branch",
+          guard: '${{ inputs.action != "start" }}',
+          task: { type: "assert", expr: "true", message: "on-branch ran" },
+        },
+        {
+          name: "off-branch",
+          guard: '${{ inputs.action != "stop" }}',
+          task: { type: "assert", expr: "true", message: "off-branch ran" },
+        },
+      ],
+    }],
+  });
+
+  const deps = makeDeps({
+    findWorkflowByName: () => Promise.resolve(workflow),
+    findWorkflowById: () => Promise.resolve(workflow),
+    evaluateCel: (expr: string, ctx?: unknown) => {
+      const context = ctx as Record<string, Record<string, unknown>>;
+      if (expr === 'inputs.action != "start"') {
+        return context?.inputs?.action !== "start";
+      }
+      if (expr === 'inputs.action != "stop"') {
+        return context?.inputs?.action !== "stop";
+      }
+      return expr;
+    },
+  });
+
+  const events = await collect<WorkflowEvaluateEvent>(
+    workflowEvaluate(createLibSwampContext(), deps, {
+      workflowIdOrName: "guarded-workflow",
+      inputs: { action: "start" },
+    }),
+  );
+
+  assertEquals(events[events.length - 1].kind, "completed");
+  const completed = events[events.length - 1] as Extract<
+    WorkflowEvaluateEvent,
+    { kind: "completed" }
+  >;
+  const data = completed.data as WorkflowEvaluateItemData;
+  const steps = data.jobs![0].steps;
+  assertEquals(typeof steps[0].guard, "string");
+  assertEquals(steps[0].guard, '${{ inputs.action != "start" }}');
+  assertEquals(typeof steps[1].guard, "string");
+  assertEquals(steps[1].guard, '${{ inputs.action != "stop" }}');
+});
+
+// --- Input coercion ---
+
+Deno.test("evaluate: string boolean inputs are coerced to native booleans", async () => {
+  const workflow = Workflow.fromData({
+    id: "00000000-0000-4000-8000-000000000021",
+    name: "bool-input-workflow",
+    inputs: {
+      type: "object",
+      properties: {
+        dryRun: { type: "boolean", default: false },
+      },
+    },
+    jobs: [{
+      name: "main",
+      steps: [{
+        name: "check",
+        task: { type: "assert", expr: "true", message: "check ran" },
+      }],
+    }],
+  });
+
+  let capturedInputs: Record<string, unknown> | undefined;
+
+  const deps = makeDeps({
+    findWorkflowByName: () => Promise.resolve(workflow),
+    findWorkflowById: () => Promise.resolve(workflow),
+    buildExpressionContext: () => {
+      const ctx = { model: {}, env: {}, inputs: {} } as ReturnType<
+        WorkflowEvaluateDeps["buildExpressionContext"]
+      > extends Promise<infer T> ? T : never;
+      // Intercept via proxy to capture what inputs are set
+      return Promise.resolve(
+        new Proxy(ctx, {
+          set(target, prop, value) {
+            if (prop === "inputs") {
+              capturedInputs = value as Record<string, unknown>;
+            }
+            // deno-lint-ignore no-explicit-any
+            (target as any)[prop] = value;
+            return true;
+          },
+        }),
+      );
+    },
+  });
+
+  const events = await collect<WorkflowEvaluateEvent>(
+    workflowEvaluate(createLibSwampContext(), deps, {
+      workflowIdOrName: "bool-input-workflow",
+      inputs: { dryRun: "true" },
+    }),
+  );
+
+  assertEquals(events[events.length - 1].kind, "completed");
+  assertEquals(capturedInputs?.dryRun, true);
+});
+
 Deno.test("isWorkflowEvaluateAllData: returns true for AllData, false for ItemData", () => {
   const allData: WorkflowEvaluateAllData = {
     items: [],


### PR DESCRIPTION
## Summary

- **Skip guard expressions during evaluate** — guard fields with `${{ }}` expressions are now left as raw strings during `workflow evaluate`, deferred to step execution time. Uses the existing `isGuardPath()` helper, matching the pattern already in `WorkflowExpressionEvaluator` for the `run` path.
- **Add input coercion to evaluate** — string CLI inputs (e.g. `--input dryRun=true`) are now coerced to their schema-declared types before expression evaluation, matching how `run.ts` handles it at the libswamp layer.

Closes swamp-club#2079

Reported by @mellens — thank you for the detailed reproduction and analysis.

## Test plan

- [x] Unit test: guard expressions remain as strings after evaluate (not resolved to booleans)
- [x] Unit test: string boolean inputs are coerced to native booleans during evaluate
- [x] Reproduction verified: `swamp workflow evaluate guard-repro --input action=start` now succeeds (was ZodError)
- [x] Reproduction verified: `swamp workflow evaluate bool-input-repro --input dryRun=true` now succeeds (was "must be a boolean")
- [x] No regression: `swamp workflow run` still works correctly with guards
- [x] All 19 evaluate_test.ts tests pass
- [x] Full verification: lint, fmt, type-check, tests, compile, code review, adversarial review, UX review all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)