### PR TITLE
fix(serve): push workflow and vault mutations to remote datastore under managedConfig

### DIFF
--- a/src/libswamp/workflows/broken_workflow.ts
+++ b/src/libswamp/workflows/broken_workflow.ts
@@ -34,6 +34,7 @@ import {
   Workflow,
   type WorkflowInput,
 } from "../../domain/workflows/workflow.ts";
+import { resolveEffectiveWorkflowsDir } from "../../infrastructure/persistence/paths.ts";
 
 /** A workflow file that failed YAML parsing or schema validation. */
 export interface BrokenWorkflow {
@@ -47,9 +48,9 @@ export interface BrokenWorkflow {
   error: string;
 }
 
-/** Returns the workflows directory for a repo. */
+/** Returns the effective workflows directory for a repo, consulting the managed config registry. */
 export function workflowsDirFor(repoDir: string): string {
-  return join(repoDir, "workflows");
+  return resolveEffectiveWorkflowsDir(repoDir);
 }
 
 /**

--- a/src/serve/handlers/vault_handlers.ts
+++ b/src/serve/handlers/vault_handlers.ts
@@ -69,6 +69,7 @@ import type {
   VaultTypeSearchPayload,
 } from "../protocol.ts";
 import { acquireVaultSync } from "../../cli/repo_context.ts";
+import { isCustomDatastoreConfig } from "../../domain/datastore/datastore_config.ts";
 import type { Principal } from "../../domain/access/principal.ts";
 import { getVaultTypes } from "../../domain/vaults/vault_types.ts";
 import { vaultTypeRegistry } from "../../domain/vaults/vault_type_registry.ts";
@@ -79,6 +80,9 @@ import {
   send,
   sendError,
 } from "./shared.ts";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+
+const logger = getSwampLogger(["serve", "connection"]);
 
 export function isReservedVaultName(name: string): boolean {
   return name.startsWith("_");
@@ -362,6 +366,25 @@ export async function handleVaultDelete(
       id: requestId,
       payload: { data: result ?? {} },
     });
+
+    if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
+      try {
+        await ctx.syncService.markDirty();
+        await ctx.syncService.pushChanged({ namespace });
+      } catch (pushError) {
+        logger.warn(
+          "Failed to push vault delete to remote datastore: {error}",
+          {
+            error: pushError instanceof Error
+              ? pushError.message
+              : String(pushError),
+          },
+        );
+      }
+    }
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
       sendError(socket, requestId, "cancelled", "Operation was cancelled");
@@ -749,6 +772,25 @@ export async function handleVaultCreate(
       id: requestId,
       payload: { data: result ?? {} },
     });
+
+    if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
+      try {
+        await ctx.syncService.markDirty();
+        await ctx.syncService.pushChanged({ namespace });
+      } catch (pushError) {
+        logger.warn(
+          "Failed to push vault create to remote datastore: {error}",
+          {
+            error: pushError instanceof Error
+              ? pushError.message
+              : String(pushError),
+          },
+        );
+      }
+    }
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "vault_create_failed", message);
@@ -803,6 +845,25 @@ export async function handleVaultEdit(
       id: requestId,
       payload: { data: result ?? {} },
     });
+
+    if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
+      try {
+        await ctx.syncService.markDirty();
+        await ctx.syncService.pushChanged({ namespace });
+      } catch (pushError) {
+        logger.warn(
+          "Failed to push vault edit to remote datastore: {error}",
+          {
+            error: pushError instanceof Error
+              ? pushError.message
+              : String(pushError),
+          },
+        );
+      }
+    }
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "vault_edit_failed", message);

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -1561,6 +1561,25 @@ export async function handleWorkflowCreate(
       id: requestId,
       payload: { data: result ?? {} },
     });
+
+    if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
+      try {
+        await ctx.syncService.markDirty();
+        await ctx.syncService.pushChanged({ namespace });
+      } catch (pushError) {
+        logger.warn(
+          "Failed to push workflow create to remote datastore: {error}",
+          {
+            error: pushError instanceof Error
+              ? pushError.message
+              : String(pushError),
+          },
+        );
+      }
+    }
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "workflow_create_failed", message);
@@ -1621,6 +1640,25 @@ export async function handleWorkflowDelete(
       id: requestId,
       payload: { data: result ?? {} },
     });
+
+    if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
+      try {
+        await ctx.syncService.markDirty();
+        await ctx.syncService.pushChanged({ namespace });
+      } catch (pushError) {
+        logger.warn(
+          "Failed to push workflow delete to remote datastore: {error}",
+          {
+            error: pushError instanceof Error
+              ? pushError.message
+              : String(pushError),
+          },
+        );
+      }
+    }
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "workflow_delete_failed", message);
@@ -1682,6 +1720,25 @@ export async function handleWorkflowEdit(
       id: requestId,
       payload: { data: result ?? {} },
     });
+
+    if (ctx.syncService) {
+      const namespace = isCustomDatastoreConfig(ctx.datastoreConfig)
+        ? ctx.datastoreConfig.namespace
+        : undefined;
+      try {
+        await ctx.syncService.markDirty();
+        await ctx.syncService.pushChanged({ namespace });
+      } catch (pushError) {
+        logger.warn(
+          "Failed to push workflow edit to remote datastore: {error}",
+          {
+            error: pushError instanceof Error
+              ? pushError.message
+              : String(pushError),
+          },
+        );
+      }
+    }
   } catch (error) {
     const message = sanitizeErrorForClient(error);
     sendError(socket, requestId, "workflow_edit_failed", message);


### PR DESCRIPTION
## Summary

Fixes swamp-club#2083 — workflow and vault create/edit/delete operations under
`managedConfig: true` never pushed to the remote datastore, so definitions
vanished on pod restart.

- Add `syncService.markDirty()` + `pushChanged()` blocks to
  `handleWorkflowCreate`, `handleWorkflowEdit`, `handleWorkflowDelete`,
  `handleVaultCreate`, `handleVaultEdit`, and `handleVaultDelete` — mirroring
  the existing working pattern from `handleModelCreate`/`handleModelDelete`
- Fix `workflowsDirFor` to delegate to `resolveEffectiveWorkflowsDir` so
  broken-workflow scanning uses the managed config path when active

## Root Cause

The original `managedConfig` commit (661f4896) only wired model handlers with
sync calls. Workflow and vault handlers were never updated — they wrote files to
the correct local managed cache path (via the `managedConfigRegistry` fallback)
but never called `syncService.markDirty()` + `pushChanged()` to push them to
S3/GCS.

## Reproduction

Confirmed with minio + `swamp serve`:
- `swamp model create` → persisted to S3, survived restart ✓
- `swamp workflow create` → missing from S3, lost on restart ✗
- `swamp vault create` → missing from S3, lost on restart ✗

After fix, all three persist correctly.

## Test Plan

- [x] All 11418 unit tests pass (0 failed)
- [x] Type check, lint, fmt pass
- [x] Compile + binary check pass
- [x] Code review: VERDICT pass (0 findings)
- [x] Adversarial review: VERDICT pass (0 findings)
- [x] UX review: VERDICT pass (0 findings)
- [x] Manual verification: minio + swamp serve confirms workflows and vaults
      now persist to S3 and survive restart

Co-authored-by: Blake Irvin <bixu@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)