### PR TITLE
feat(audit): Phase 4 — SIEM sinks, bulk export, HMAC (#2074)

### DIFF
--- a/design/enablers/serve-audit.md
+++ b/design/enablers/serve-audit.md
@@ -157,6 +157,10 @@ The `system` audit category captures infrastructure lifecycle events with
 
 - `instance.start` — emitted when the serve instance starts (with version)
 - `instance.stop` — emitted on graceful shutdown
+- `instance.join` — emitted when a new peer instance appears in the cluster
+- `instance.leave` — emitted when a peer instance disappears from the cluster
+- `health.transition` — emitted when the instance health status changes
+  (healthy/degraded/unhealthy)
 
 System events are always at `metadata` audit level (management tier).
 
@@ -186,9 +190,15 @@ System events are always at `metadata` audit level (management tier).
 | StoreSink               | Adapter            | `src/serve/audit_sinks/`          |
 | WalSink                 | Adapter            | `src/serve/audit_sinks/`          |
 | WebSocketSink           | Adapter            | `src/serve/audit_sinks/`          |
+| WebhookSink             | Adapter            | `src/serve/audit_sinks/`          |
+| SyslogSink              | Adapter            | `src/serve/audit_sinks/`          |
+| CefFormatter            | Domain Service     | `src/serve/audit_sinks/`          |
+| AuditHmac               | Domain Service     | `src/domain/serve_audit/`         |
+| SinkFilterConfig        | Value Object       | `src/domain/serve_audit/`         |
+| HmacContext             | Value Object       | `src/domain/serve_audit/`         |
 
 ## Future phases
 
-- **Phase 4**: Webhook and syslog sinks, bulk export, HMAC, HA join/leave
-  system events, health state transition events
-- **Phase 5**: Extension sinks, alerting, compliance templates
+- **Phase 5**: Extension sink API, alert rules (pattern triggers), compliance
+  templates, HMAC key rotation, streaming bulk export, hot-reload of external
+  sinks

--- a/integration/audit_sinks_test.ts
+++ b/integration/audit_sinks_test.ts
@@ -69,11 +69,16 @@ class CollectorSink implements AuditSink {
   readonly durable = false;
   readonly events: AuditEvent[] = [];
 
-  async write(events: readonly AuditEvent[]): Promise<void> {
+  write(events: readonly AuditEvent[]): Promise<void> {
     this.events.push(...events);
+    return Promise.resolve();
   }
-  async flush(): Promise<void> {}
-  async close(): Promise<void> {}
+  flush(): Promise<void> {
+    return Promise.resolve();
+  }
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 Deno.test("Integration: HMAC applied through emitter to collector sink", async () => {

--- a/integration/audit_sinks_test.ts
+++ b/integration/audit_sinks_test.ts
@@ -1,0 +1,421 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import dgram from "node:dgram";
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertStringIncludes,
+} from "@std/assert";
+import { AuditEmitter } from "../src/domain/serve_audit/audit_emitter.ts";
+import {
+  type AuditEvent,
+  createAuditEvent,
+} from "../src/domain/serve_audit/audit_event.ts";
+import type { AuditSink } from "../src/domain/serve_audit/audit_sink.ts";
+import {
+  generateHmacKeyBytes,
+  type HmacContext,
+  importHmacKey,
+} from "../src/domain/serve_audit/audit_hmac.ts";
+import { WebhookSink } from "../src/serve/audit_sinks/webhook_sink.ts";
+import { SyslogSink } from "../src/serve/audit_sinks/syslog_sink.ts";
+
+function makeEvent(
+  overrides?: Partial<Parameters<typeof createAuditEvent>[0]>,
+): AuditEvent {
+  return createAuditEvent({
+    instanceId: "test",
+    category: "secrets",
+    stage: "response",
+    outcome: "success",
+    action: "vault.read-secret",
+    resourceKind: "vault",
+    resourceName: "api-keys",
+    principalKind: "user",
+    principalId: "paul",
+    initiatedBy: "paul",
+    sourceIp: "127.0.0.1",
+    requestId: crypto.randomUUID(),
+    ...overrides,
+  });
+}
+
+async function makeHmacContext(): Promise<HmacContext> {
+  const raw = await generateHmacKeyBytes();
+  const key = await importHmacKey(raw);
+  return { key, keyVersion: 1 };
+}
+
+class CollectorSink implements AuditSink {
+  readonly name = "collector";
+  readonly durable = false;
+  readonly events: AuditEvent[] = [];
+
+  async write(events: readonly AuditEvent[]): Promise<void> {
+    this.events.push(...events);
+  }
+  async flush(): Promise<void> {}
+  async close(): Promise<void> {}
+}
+
+Deno.test("Integration: HMAC applied through emitter to collector sink", async () => {
+  const hmacContext = await makeHmacContext();
+  const collector = new CollectorSink();
+  const emitter = new AuditEmitter({
+    sinks: [collector],
+    hmacContext,
+  });
+
+  emitter.emit(makeEvent({ resourceName: "my-secret-key" }));
+  await emitter.flush();
+
+  assertEquals(collector.events.length, 1);
+  const event = collector.events[0];
+  assertNotEquals(event.resourceName, "my-secret-key");
+  assertEquals(event.resourceName.length, 64);
+  assertEquals(event.hmacKeyVersion, 1);
+});
+
+Deno.test("Integration: HMAC emitter to webhook sink end-to-end", async () => {
+  const received: string[] = [];
+
+  const server = Deno.serve({
+    port: 0,
+    onListen: () => {},
+  }, async (req) => {
+    received.push(await req.text());
+    return new Response("ok");
+  });
+
+  const addr = server.addr as Deno.NetAddr;
+  const url = `http://127.0.0.1:${addr.port}/ingest`;
+
+  const hmacContext = await makeHmacContext();
+  const webhookSink = new WebhookSink({
+    url,
+    format: "json",
+    batchIntervalMs: 60_000,
+  });
+  const emitter = new AuditEmitter({
+    sinks: [webhookSink],
+    hmacContext,
+  });
+
+  emitter.emit(makeEvent({ resourceName: "sensitive-resource" }));
+  await emitter.flush();
+  await emitter.close();
+
+  server.shutdown();
+  await server.finished;
+
+  assert(received.length > 0, "Webhook should have received events");
+  const events = JSON.parse(received[0]) as AuditEvent[];
+  assertEquals(events.length, 1);
+  assertNotEquals(events[0].resourceName, "sensitive-resource");
+  assertEquals(events[0].resourceName.length, 64);
+  assertEquals(events[0].hmacKeyVersion, 1);
+});
+
+Deno.test("Integration: filtered events not delivered to webhook sink", async () => {
+  const received: string[] = [];
+
+  const server = Deno.serve({
+    port: 0,
+    onListen: () => {},
+  }, async (req) => {
+    received.push(await req.text());
+    return new Response("ok");
+  });
+
+  const addr = server.addr as Deno.NetAddr;
+  const url = `http://127.0.0.1:${addr.port}/ingest`;
+
+  const webhookSink = new WebhookSink({
+    url,
+    filter: { categories: ["auth"] },
+    batchIntervalMs: 60_000,
+  });
+  const collector = new CollectorSink();
+  const emitter = new AuditEmitter({
+    sinks: [collector, webhookSink],
+  });
+
+  emitter.emit(makeEvent({ category: "secrets" }));
+  emitter.emit(makeEvent({ category: "auth", action: "auth.login" }));
+  await emitter.flush();
+  await emitter.close();
+
+  server.shutdown();
+  await server.finished;
+
+  assertEquals(collector.events.length, 2);
+  assert(received.length > 0, "Webhook should have received the auth event");
+  const events = JSON.parse(received[0]) as AuditEvent[];
+  assertEquals(events.length, 1);
+  assertEquals(events[0].category, "auth");
+});
+
+// ── Webhook sink transport tests ─────────────────────────────────────
+
+interface CapturedRequest {
+  body: string;
+  headers: Record<string, string>;
+}
+
+async function startMockServer(): Promise<{
+  url: string;
+  requests: CapturedRequest[];
+  close: () => Promise<void>;
+}> {
+  const requests: CapturedRequest[] = [];
+  let resolveUrl: (url: string) => void;
+  const urlPromise = new Promise<string>((r) => resolveUrl = r);
+  const server = Deno.serve({
+    port: 0,
+    onListen: (addr) => {
+      resolveUrl!(`http://127.0.0.1:${addr.port}/ingest`);
+    },
+  }, async (req) => {
+    const body = await req.text();
+    const headers: Record<string, string> = {};
+    req.headers.forEach((v, k) => headers[k] = v);
+    requests.push({ body, headers });
+    return new Response("ok", { status: 200 });
+  });
+  const url = await urlPromise;
+  return {
+    url,
+    requests,
+    close: async () => {
+      server.shutdown();
+      await server.finished;
+    },
+  };
+}
+
+Deno.test("WebhookSink: sends JSON batch on flush", async () => {
+  const mock = await startMockServer();
+  try {
+    const sink = new WebhookSink({
+      url: mock.url,
+      format: "json",
+      batchIntervalMs: 60_000,
+    });
+    await sink.write([makeEvent(), makeEvent()]);
+    await sink.flush();
+    await sink.close();
+    assertEquals(mock.requests.length, 1);
+    const parsed = JSON.parse(mock.requests[0].body);
+    assertEquals(parsed.length, 2);
+    assertEquals(mock.requests[0].headers["content-type"], "application/json");
+  } finally {
+    await mock.close();
+  }
+});
+
+Deno.test("WebhookSink: sends CEF format on flush", async () => {
+  const mock = await startMockServer();
+  try {
+    const sink = new WebhookSink({
+      url: mock.url,
+      format: "cef",
+      batchIntervalMs: 60_000,
+    });
+    await sink.write([makeEvent()]);
+    await sink.flush();
+    await sink.close();
+    assertEquals(mock.requests.length, 1);
+    assertStringIncludes(mock.requests[0].body, "CEF:0|SwampClub|");
+    assertStringIncludes(
+      mock.requests[0].headers["content-type"],
+      "text/plain",
+    );
+  } finally {
+    await mock.close();
+  }
+});
+
+Deno.test("WebhookSink: includes bearer auth header", async () => {
+  const mock = await startMockServer();
+  try {
+    const sink = new WebhookSink({
+      url: mock.url,
+      auth: { type: "bearer", value: "test-token" },
+      batchIntervalMs: 60_000,
+    });
+    await sink.write([makeEvent()]);
+    await sink.flush();
+    await sink.close();
+    assertEquals(
+      mock.requests[0].headers["authorization"],
+      "Bearer test-token",
+    );
+  } finally {
+    await mock.close();
+  }
+});
+
+Deno.test("WebhookSink: batches at configured size", async () => {
+  const mock = await startMockServer();
+  try {
+    const sink = new WebhookSink({
+      url: mock.url,
+      batchSize: 2,
+      batchIntervalMs: 60_000,
+    });
+    await sink.write([makeEvent(), makeEvent(), makeEvent()]);
+    await sink.flush();
+    await sink.close();
+    assertEquals(mock.requests.length, 2);
+    assertEquals(JSON.parse(mock.requests[0].body).length, 2);
+    assertEquals(JSON.parse(mock.requests[1].body).length, 1);
+  } finally {
+    await mock.close();
+  }
+});
+
+Deno.test("WebhookSink: close flushes remaining events", async () => {
+  const mock = await startMockServer();
+  try {
+    const sink = new WebhookSink({
+      url: mock.url,
+      batchIntervalMs: 60_000,
+    });
+    await sink.write([makeEvent()]);
+    await sink.close();
+    assertEquals(mock.requests.length, 1);
+  } finally {
+    await mock.close();
+  }
+});
+
+// ── Syslog sink transport tests ──────────────────────────────────────
+
+Deno.test("SyslogSink: sends messages to TCP server", async () => {
+  const received: string[] = [];
+  const listener = Deno.listen({ port: 0 });
+  const addr = listener.addr as Deno.NetAddr;
+  const serverDone = (async () => {
+    const conn = await listener.accept();
+    const buf = new Uint8Array(4096);
+    try {
+      while (true) {
+        const n = await conn.read(buf);
+        if (n === null) break;
+        received.push(new TextDecoder().decode(buf.subarray(0, n)));
+      }
+    } catch {
+      // connection closed
+    }
+    conn.close();
+  })();
+  const sink = new SyslogSink({
+    host: "127.0.0.1",
+    port: addr.port,
+    transport: "tcp",
+  });
+  try {
+    await sink.write([makeEvent()]);
+    await sink.close();
+    await serverDone;
+    assert(received.length > 0, "Expected at least one message");
+    assertStringIncludes(received[0], "vault.read-secret");
+  } finally {
+    try {
+      listener.close();
+    } catch { /* already closed */ }
+  }
+});
+
+Deno.test("SyslogSink: sends messages via UDP", async () => {
+  const received: Buffer[] = [];
+  const server = dgram.createSocket("udp4");
+  const port = await new Promise<number>((resolve) => {
+    server.bind(0, "127.0.0.1", () => {
+      resolve(server.address().port);
+    });
+  });
+  const recvDone = new Promise<void>((resolve) => {
+    server.once("message", (msg) => {
+      received.push(msg);
+      resolve();
+    });
+  });
+  const sink = new SyslogSink({
+    host: "127.0.0.1",
+    port,
+    transport: "udp",
+  });
+  try {
+    await sink.write([makeEvent()]);
+    await sink.close();
+    await Promise.race([
+      recvDone,
+      new Promise((r) => setTimeout(r, 2000)),
+    ]);
+    assert(received.length > 0, "Expected at least one UDP message");
+    assertStringIncludes(received[0].toString("utf-8"), "vault.read-secret");
+  } finally {
+    server.close();
+  }
+});
+
+Deno.test("SyslogSink: filters events over TCP", async () => {
+  const received: string[] = [];
+  const listener = Deno.listen({ port: 0 });
+  const addr = listener.addr as Deno.NetAddr;
+  const serverDone = (async () => {
+    const conn = await listener.accept();
+    const buf = new Uint8Array(4096);
+    try {
+      while (true) {
+        const n = await conn.read(buf);
+        if (n === null) break;
+        received.push(new TextDecoder().decode(buf.subarray(0, n)));
+      }
+    } catch {
+      // connection closed
+    }
+    conn.close();
+  })();
+  const sink = new SyslogSink({
+    host: "127.0.0.1",
+    port: addr.port,
+    transport: "tcp",
+    filter: { categories: ["auth"] },
+  });
+  try {
+    await sink.write([
+      makeEvent({ category: "secrets" }),
+      makeEvent({ category: "auth", action: "auth.login" }),
+    ]);
+    await sink.close();
+    await serverDone;
+    assert(received.length > 0, "Expected at least one message");
+    const allData = received.join("");
+    assertStringIncludes(allData, "auth.login");
+    assert(!allData.includes("vault.read-secret"), "Filtered event leaked");
+  } finally {
+    try {
+      listener.close();
+    } catch { /* already closed */ }
+  }
+});

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -53,6 +53,7 @@ import {
   createLibSwampContext,
 } from "../../libswamp/mod.ts";
 import { createAuditTimelineRenderer } from "../../presentation/renderers/audit_timeline.ts";
+import { auditExportCommand } from "./audit_export.ts";
 import { auditLogCommand } from "./audit_log.ts";
 import { auditVerifyCommand } from "./audit_verify.ts";
 
@@ -248,5 +249,6 @@ export const auditCommand = withRemoteOptions(
 
   ctx.logger.debug("Audit command completed");
 }).command("record", auditRecordCommand)
+  .command("export", auditExportCommand)
   .command("log", auditLogCommand)
   .command("verify", auditVerifyCommand);

--- a/src/cli/commands/audit_export.ts
+++ b/src/cli/commands/audit_export.ts
@@ -1,0 +1,132 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { Command } from "@cliffy/command";
+import { createContext, type GlobalOptions } from "../context.ts";
+import {
+  requestServerResponse,
+  resolveServerToken,
+  resolveServeUrl,
+  withRemoteOptions,
+} from "../remote_run.ts";
+import { UserError } from "../../domain/errors.ts";
+import { createAuditExportRenderer } from "../../presentation/output/audit_export_output.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnyOptions = any;
+
+interface AuditExportResponse {
+  readonly format: string;
+  readonly count: number;
+  readonly truncated?: boolean;
+  readonly data: string;
+  readonly events?: unknown[];
+}
+
+export const auditExportCommand = withRemoteOptions(
+  new Command()
+    .name("export")
+    .description("Bulk export audit events for compliance")
+    .example(
+      "Export as JSON",
+      "swamp audit export --server http://localhost:7443 --from 2026-09-01 --to 2026-09-08",
+    )
+    .example(
+      "Export as CEF",
+      "swamp audit export --server http://localhost:7443 --from 2026-09-01 --to 2026-09-08 --format cef",
+    )
+    .example(
+      "Export to file",
+      "swamp audit export --server http://localhost:7443 --from 2026-09-01 --to 2026-09-08 --output audit.csv --format csv",
+    )
+    .option("--from <date:string>", "Start time (ISO 8601)", { required: true })
+    .option("--to <date:string>", "End time (ISO 8601)", { required: true })
+    .option(
+      "--format <fmt:string>",
+      "Output format: json, cef, csv [default: json]",
+      { default: "json" },
+    )
+    .option("--output <path:string>", "Write output to file instead of stdout")
+    .option("--principal <id:string>", "Filter by principal ID")
+    .option(
+      "--category <cat:string>",
+      "Filter by audit category (auth, access, execution, secrets, admin, data, system)",
+    )
+    .option("--action <action:string>", "Filter by action")
+    .option(
+      "--outcome <outcome:string>",
+      "Filter by outcome (success, failure, denied)",
+    ),
+).action(async function (options: AnyOptions) {
+  const ctx = createContext(options as GlobalOptions, ["audit", "export"]);
+
+  const server = resolveServeUrl(options.server as string | undefined);
+  if (!server) {
+    throw new UserError(
+      "The audit export command requires a running serve instance. Use --server to specify the URL.",
+    );
+  }
+
+  const token = await resolveServerToken(
+    server,
+    options.token as string | undefined,
+  );
+
+  const format = options.format as string;
+  if (!["json", "cef", "csv"].includes(format)) {
+    throw new UserError(
+      `Invalid format "${format}": expected one of json, cef, csv`,
+    );
+  }
+
+  const response = await requestServerResponse<AuditExportResponse>(
+    { server, token },
+    {
+      type: "audit.export",
+      payload: {
+        from: options.from,
+        to: options.to,
+        format,
+        principal: options.principal,
+        category: options.category,
+        action: options.action,
+        outcome: options.outcome,
+      },
+    },
+  );
+
+  const outputData = response.data ??
+    (response.events ? JSON.stringify(response.events, null, 2) : "");
+
+  if (options.output) {
+    await Deno.writeTextFile(options.output, outputData);
+  }
+
+  const renderer = createAuditExportRenderer(ctx.outputMode);
+  renderer.handlers().completed({
+    kind: "completed",
+    data: {
+      format: response.format,
+      count: response.count,
+      truncated: response.truncated,
+      data: outputData,
+      outputPath: options.output,
+    },
+  });
+});

--- a/src/cli/commands/audit_export.ts
+++ b/src/cli/commands/audit_export.ts
@@ -72,7 +72,8 @@ export const auditExportCommand = withRemoteOptions(
     .option(
       "--outcome <outcome:string>",
       "Filter by outcome (success, failure, denied)",
-    ),
+    )
+    .option("--resource <name:string>", "Filter by resource name"),
 ).action(async function (options: AnyOptions) {
   const ctx = createContext(options as GlobalOptions, ["audit", "export"]);
 
@@ -107,6 +108,7 @@ export const auditExportCommand = withRemoteOptions(
         category: options.category,
         action: options.action,
         outcome: options.outcome,
+        resource: options.resource,
       },
     },
   );

--- a/src/cli/commands/audit_export.ts
+++ b/src/cli/commands/audit_export.ts
@@ -45,18 +45,22 @@ export const auditExportCommand = withRemoteOptions(
     .description("Bulk export audit events for compliance")
     .example(
       "Export as JSON",
-      "swamp audit export --server http://localhost:7443 --from 2026-09-01 --to 2026-09-08",
+      "swamp audit export --server http://localhost:7443 --since 2026-09-01 --until 2026-09-08",
     )
     .example(
       "Export as CEF",
-      "swamp audit export --server http://localhost:7443 --from 2026-09-01 --to 2026-09-08 --format cef",
+      "swamp audit export --server http://localhost:7443 --since 2026-09-01 --until 2026-09-08 --format cef",
     )
     .example(
       "Export to file",
-      "swamp audit export --server http://localhost:7443 --from 2026-09-01 --to 2026-09-08 --output audit.csv --format csv",
+      "swamp audit export --server http://localhost:7443 --since 2026-09-01 --until 2026-09-08 --output audit.csv --format csv",
     )
-    .option("--from <date:string>", "Start time (ISO 8601)", { required: true })
-    .option("--to <date:string>", "End time (ISO 8601)", { required: true })
+    .option("--since <date:string>", "Start time (ISO 8601)", {
+      required: true,
+    })
+    .option("--until <date:string>", "End time (ISO 8601)", {
+      required: true,
+    })
     .option(
       "--format <fmt:string>",
       "Output format: json, cef, csv [default: json]",
@@ -101,8 +105,8 @@ export const auditExportCommand = withRemoteOptions(
     {
       type: "audit.export",
       payload: {
-        from: options.from,
-        to: options.to,
+        from: options.since,
+        to: options.until,
         format,
         principal: options.principal,
         category: options.category,

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -101,6 +101,7 @@ import {
 import {
   isSensitiveHeader,
   parseWebhookFlag,
+  resolveSecret,
   type WebhookEndpoint,
   WebhookService,
 } from "../../serve/webhook.ts";
@@ -118,12 +119,21 @@ import {
   type AuditLevel,
   AuditPolicy,
   type AuditPolicyRule,
+  type AuditSink,
   type AuditStore,
   AuditWal,
 } from "../../domain/serve_audit/mod.ts";
 import { StoreSink } from "../../serve/audit_sinks/store_sink.ts";
 import { WalSink } from "../../serve/audit_sinks/wal_sink.ts";
 import { WebSocketSink } from "../../serve/audit_sinks/websocket_sink.ts";
+import { WebhookSink } from "../../serve/audit_sinks/webhook_sink.ts";
+import { SyslogSink } from "../../serve/audit_sinks/syslog_sink.ts";
+import { parseSinkFilter } from "../../domain/serve_audit/sink_filter.ts";
+import {
+  generateHmacKeyBytes,
+  type HmacContext,
+  importHmacKey,
+} from "../../domain/serve_audit/audit_hmac.ts";
 import { RemoteAuditStore } from "../../infrastructure/persistence/remote_audit_store.ts";
 import { resolveDatastoreExpressions } from "../datastore_expression_resolver.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";
@@ -2944,20 +2954,166 @@ export const serveCommand = new Command()
         }
 
         const webSocketSink = new WebSocketSink();
+        const auditSinks: AuditSink[] = [walSink, webSocketSink];
+
+        let auditVaultService: VaultService | null = null;
+        const needsVault = auditConfig.sinks.length > 0 ||
+          auditConfig.hmacEnabled;
+        if (needsVault) {
+          try {
+            auditVaultService = await VaultService.fromRepository(
+              resolvedRepoDir,
+              { defaultVaultName: repoMarker?.defaultVault },
+            );
+          } catch {
+            logger.warn("Could not initialize vault for audit sinks/HMAC");
+          }
+        }
+
+        for (const sinkEntry of auditConfig.sinks) {
+          try {
+            if (sinkEntry.type === "webhook") {
+              const cfg = sinkEntry.config;
+              let auth: {
+                type: "bearer" | "basic" | "header";
+                value: string;
+                headerName?: string;
+              } | undefined;
+              const authCfg = cfg.auth as Record<string, unknown> | undefined;
+              if (authCfg) {
+                const authType = authCfg.type as string;
+                const rawValue =
+                  (authCfg.token ?? authCfg.value ?? authCfg.password ??
+                    "") as string;
+                const resolvedValue = await resolveSecret(
+                  rawValue,
+                  auditVaultService ?? undefined,
+                );
+                auth = {
+                  type: authType as "bearer" | "basic" | "header",
+                  value: resolvedValue,
+                  headerName: authCfg["header-name"] as string | undefined,
+                };
+              }
+              const batchCfg = cfg.batch as Record<string, unknown> | undefined;
+              const retryCfg = cfg.retry as Record<string, unknown> | undefined;
+              auditSinks.push(
+                new WebhookSink({
+                  url: cfg.url as string,
+                  format: (cfg.format as "json" | "cef") ?? "json",
+                  auth,
+                  filter: parseSinkFilter(cfg),
+                  batchSize: batchCfg?.size as number | undefined,
+                  batchIntervalMs: batchCfg?.["interval-ms"] as
+                    | number
+                    | undefined,
+                  maxAttempts: retryCfg?.["max-attempts"] as number | undefined,
+                  backoffMs: retryCfg?.["backoff-ms"] as number | undefined,
+                  maxPending: cfg["max-pending"] as number | undefined,
+                  signal: ac.signal,
+                  namespace: serveNamespace,
+                }),
+              );
+              logger.info("Audit webhook sink enabled: {url}", {
+                url: cfg.url,
+              });
+            } else if (sinkEntry.type === "syslog") {
+              const cfg = sinkEntry.config;
+              let caCert: string | undefined;
+              const transport = (cfg.transport as string | undefined) ?? "tcp";
+              if (transport === "tcp+tls" && cfg["ca-cert"]) {
+                caCert = await resolveSecret(
+                  cfg["ca-cert"] as string,
+                  auditVaultService ?? undefined,
+                );
+              }
+              auditSinks.push(
+                new SyslogSink({
+                  host: cfg.host as string,
+                  port: cfg.port as number,
+                  transport: transport as "tcp" | "tcp+tls" | "udp",
+                  filter: parseSinkFilter(cfg),
+                  caCert,
+                  signal: ac.signal,
+                }),
+              );
+              logger.info("Audit syslog sink enabled: {host}:{port}", {
+                host: cfg.host,
+                port: cfg.port,
+              });
+            }
+          } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : String(error);
+            if (auditConfig.failOpen) {
+              logger.warn("Failed to create audit sink, skipping: {error}", {
+                error: msg,
+              });
+            } else {
+              throw error;
+            }
+          }
+        }
+
+        let hmacContext: HmacContext | undefined;
+        if (auditConfig.hmacEnabled && auditVaultService) {
+          try {
+            const vaultName = auditConfig.hmacVault;
+            const keyName = auditConfig.hmacKey;
+            let rawKey: string | null = null;
+            try {
+              rawKey = await auditVaultService.get(vaultName, keyName);
+            } catch {
+              // key doesn't exist yet
+            }
+            if (!rawKey) {
+              const newKey = await generateHmacKeyBytes();
+              const hex = Array.from(newKey).map((b) =>
+                b.toString(16).padStart(2, "0")
+              ).join("");
+              await auditVaultService.put(vaultName, keyName, hex);
+              rawKey = hex;
+              logger.info("Generated HMAC key in vault {vault}:{key}", {
+                vault: vaultName,
+                key: keyName,
+              });
+            }
+            if (!/^[0-9a-f]+$/i.test(rawKey)) {
+              throw new Error(
+                `HMAC key in vault ${vaultName}:${keyName} is not valid hex`,
+              );
+            }
+            const keyBytes = new Uint8Array(
+              rawKey.match(/.{2}/g)!.map((h) => parseInt(h, 16)),
+            );
+            const cryptoKey = await importHmacKey(keyBytes);
+            hmacContext = { key: cryptoKey, keyVersion: 1 };
+            logger.info("HMAC enabled for audit events");
+          } catch (error: unknown) {
+            logger.warn(
+              "Failed to initialize HMAC, continuing without: {error}",
+              {
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
+          }
+        }
+
         connectionCtx.auditEmitter = new AuditEmitter({
-          sinks: [walSink, webSocketSink],
+          sinks: auditSinks,
           policy,
           chainState,
+          hmacContext,
         });
         connectionCtx.auditStores = auditStores;
         connectionCtx.auditPolicy = policy;
         connectionCtx.auditFailOpen = auditConfig.failOpen;
         connectionCtx.auditWal = wal;
         connectionCtx.auditWebSocketSink = webSocketSink;
+        connectionCtx.auditNamespace = serveNamespace;
 
         logger.info(
-          "Audit pipeline enabled with {count} store target(s), WAL at {walDir}",
-          { count: auditStores.length, walDir },
+          "Audit pipeline enabled with {count} store target(s), {sinkCount} sink(s), WAL at {walDir}",
+          { count: auditStores.length, sinkCount: auditSinks.length, walDir },
         );
 
         emitSystemAuditEvent(
@@ -3470,6 +3626,13 @@ export const serveCommand = new Command()
       scheduleEnabled: enableSchedule,
       webhookProvider: webhookService ?? null,
       remoteOnly: merged.remoteOnly,
+      onHealthTransition: (previous, current) => {
+        emitSystemAuditEvent(
+          connectionCtx,
+          "health.transition",
+          `${previous}->${current}`,
+        );
+      },
     });
 
     connectionCtx.healthCollector = healthCollector;
@@ -4436,6 +4599,7 @@ export const serveCommand = new Command()
 
       const RECONCILIATION_INTERVAL_MS = reconciliationIntervalMs ?? 60_000;
       const RECONCILIATION_JITTER_MS = 500;
+      let knownPeerIds: Set<string> | null = null;
       const runReconciliationTick = async () => {
         try {
           const reaped = await reconcileRemoteInterruptedRuns({
@@ -4461,6 +4625,40 @@ export const serveCommand = new Command()
         } catch (err: unknown) {
           logger.warn(
             "Reconciliation claim cleanup failed: {error}",
+            { error: err instanceof Error ? err.message : String(err) },
+          );
+        }
+        try {
+          const keys = await controlPlaneStore.list("heartbeats/");
+          const currentPeerIds = new Set<string>();
+          for (const key of keys) {
+            const parts = key.split("/");
+            if (parts.length >= 2) currentPeerIds.add(parts[1]);
+          }
+          if (knownPeerIds !== null) {
+            for (const id of currentPeerIds) {
+              if (!knownPeerIds.has(id)) {
+                emitSystemAuditEvent(
+                  connectionCtx,
+                  "instance.join",
+                  `instanceId=${id}`,
+                );
+              }
+            }
+            for (const id of knownPeerIds) {
+              if (!currentPeerIds.has(id)) {
+                emitSystemAuditEvent(
+                  connectionCtx,
+                  "instance.leave",
+                  `instanceId=${id}`,
+                );
+              }
+            }
+          }
+          knownPeerIds = currentPeerIds;
+        } catch (err: unknown) {
+          logger.warn(
+            "Peer delta check failed: {error}",
             { error: err instanceof Error ? err.message : String(err) },
           );
         }

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -128,12 +128,12 @@ import { WalSink } from "../../serve/audit_sinks/wal_sink.ts";
 import { WebSocketSink } from "../../serve/audit_sinks/websocket_sink.ts";
 import { WebhookSink } from "../../serve/audit_sinks/webhook_sink.ts";
 import { SyslogSink } from "../../serve/audit_sinks/syslog_sink.ts";
-import { parseSinkFilter } from "../../domain/serve_audit/sink_filter.ts";
 import {
   generateHmacKeyBytes,
   type HmacContext,
   importHmacKey,
-} from "../../domain/serve_audit/audit_hmac.ts";
+  parseSinkFilter,
+} from "../../domain/serve_audit/mod.ts";
 import { RemoteAuditStore } from "../../infrastructure/persistence/remote_audit_store.ts";
 import { resolveDatastoreExpressions } from "../datastore_expression_resolver.ts";
 import { registerShutdownHandler } from "../../infrastructure/process/shutdown_handlers.ts";

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -3077,9 +3077,9 @@ export const serveCommand = new Command()
                 key: keyName,
               });
             }
-            if (!/^[0-9a-f]+$/i.test(rawKey)) {
+            if (!/^[0-9a-f]+$/i.test(rawKey) || rawKey.length % 2 !== 0) {
               throw new Error(
-                `HMAC key in vault ${vaultName}:${keyName} is not valid hex`,
+                `HMAC key in vault ${vaultName}:${keyName} is not valid hex (must be even-length hex string)`,
               );
             }
             const keyBytes = new Uint8Array(

--- a/src/domain/serve_audit/audit_emitter.ts
+++ b/src/domain/serve_audit/audit_emitter.ts
@@ -27,6 +27,7 @@ import type { AuditSink } from "./audit_sink.ts";
 import { AuditChainState } from "./audit_chain.ts";
 import type { AuditPolicy } from "./audit_policy.ts";
 import { RingBuffer } from "./ring_buffer.ts";
+import { applyHmac, type HmacContext } from "./audit_hmac.ts";
 
 const logger = getSwampLogger(["serve", "audit", "emitter"]);
 
@@ -37,6 +38,7 @@ export interface AuditEmitterOptions {
   readonly capacity?: number;
   readonly chainState?: AuditChainState;
   readonly policy?: AuditPolicy;
+  readonly hmacContext?: HmacContext;
 }
 
 export class AuditEmitter {
@@ -46,6 +48,7 @@ export class AuditEmitter {
   readonly #deniedRequests = new Set<string>();
   readonly #chainState: AuditChainState;
   readonly #policy: AuditPolicy | undefined;
+  readonly #hmacContext: HmacContext | undefined;
   #drainPending = false;
   #drainPromise: Promise<void> | null = null;
 
@@ -64,6 +67,7 @@ export class AuditEmitter {
       this.#sinks = sinksOrOptions.sinks;
       this.#chainState = sinksOrOptions.chainState ?? new AuditChainState();
       this.#policy = sinksOrOptions.policy;
+      this.#hmacContext = sinksOrOptions.hmacContext;
     }
     for (const sink of this.#sinks) {
       this.#cursors.set(sink.name, 0);
@@ -104,6 +108,14 @@ export class AuditEmitter {
     }
   }
 
+  #shouldHmac(event: AuditEvent): boolean {
+    if (!this.#policy) return true;
+    return this.#policy.shouldHmac(
+      event.category as AuditCategory,
+      event.action,
+    );
+  }
+
   #drainSerialized(): void {
     if (this.#drainPromise) return;
     this.#drainPromise = this.#drain().then(() => {
@@ -129,9 +141,18 @@ export class AuditEmitter {
     const { items, throughSeq } = this.#buffer.readFrom(minCursor);
     if (items.length === 0) return;
 
+    const processed: AuditEvent[] = [];
+    for (const event of items) {
+      if (this.#hmacContext && this.#shouldHmac(event)) {
+        processed.push(await applyHmac(this.#hmacContext, event));
+      } else {
+        processed.push(event);
+      }
+    }
+
     const chainSnapshot = this.#chainState.snapshot();
     const chained: ChainedAuditEvent[] = [];
-    for (const event of items) {
+    for (const event of processed) {
       chained.push(await this.#chainState.chain(event));
     }
 

--- a/src/domain/serve_audit/audit_event.ts
+++ b/src/domain/serve_audit/audit_event.ts
@@ -60,6 +60,7 @@ export interface AuditEvent {
   readonly sequence?: number;
   readonly digest?: string;
   readonly decision?: AuditDecision;
+  readonly hmacKeyVersion?: number;
 }
 
 export type ChainedAuditEvent = AuditEvent & {

--- a/src/domain/serve_audit/audit_hmac.ts
+++ b/src/domain/serve_audit/audit_hmac.ts
@@ -1,0 +1,93 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AuditEvent } from "./audit_event.ts";
+
+export interface HmacContext {
+  readonly key: CryptoKey;
+  readonly keyVersion: number;
+}
+
+export interface HmacKeyProvider {
+  getOrCreate(
+    vaultName: string,
+    keyName: string,
+  ): Promise<{ key: Uint8Array; version: number }>;
+}
+
+const encoder = new TextEncoder();
+
+export async function hmacField(
+  key: CryptoKey,
+  value: string,
+): Promise<string> {
+  const data = encoder.encode(value);
+  const sig = await crypto.subtle.sign("HMAC", key, data);
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function importHmacKey(raw: Uint8Array): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    raw.buffer as ArrayBuffer,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+}
+
+export async function applyHmac(
+  ctx: HmacContext,
+  event: AuditEvent,
+): Promise<AuditEvent> {
+  const resourceName = await hmacField(ctx.key, event.resourceName);
+  const detail = event.detail !== undefined
+    ? await hmacField(ctx.key, event.detail)
+    : undefined;
+  const methodName = event.methodName !== undefined
+    ? await hmacField(ctx.key, event.methodName)
+    : undefined;
+
+  let decision = event.decision;
+  if (decision) {
+    const hashedResourceName = await hmacField(ctx.key, decision.resourceName);
+    decision = { ...decision, resourceName: hashedResourceName };
+  }
+
+  return {
+    ...event,
+    resourceName,
+    detail,
+    methodName,
+    decision,
+    hmacKeyVersion: ctx.keyVersion,
+  };
+}
+
+export async function generateHmacKeyBytes(): Promise<Uint8Array> {
+  const key = await crypto.subtle.generateKey(
+    { name: "HMAC", hash: "SHA-256" },
+    true,
+    ["sign"],
+  );
+  const raw = await crypto.subtle.exportKey("raw", key);
+  return new Uint8Array(raw);
+}

--- a/src/domain/serve_audit/audit_hmac.ts
+++ b/src/domain/serve_audit/audit_hmac.ts
@@ -44,10 +44,14 @@ export async function hmacField(
     .join("");
 }
 
-export async function importHmacKey(raw: Uint8Array): Promise<CryptoKey> {
+export function importHmacKey(raw: Uint8Array): Promise<CryptoKey> {
+  const buf = raw.buffer.slice(
+    raw.byteOffset,
+    raw.byteOffset + raw.byteLength,
+  ) as ArrayBuffer;
   return crypto.subtle.importKey(
     "raw",
-    raw.buffer as ArrayBuffer,
+    buf,
     { name: "HMAC", hash: "SHA-256" },
     false,
     ["sign"],

--- a/src/domain/serve_audit/audit_hmac_test.ts
+++ b/src/domain/serve_audit/audit_hmac_test.ts
@@ -1,0 +1,161 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import {
+  applyHmac,
+  generateHmacKeyBytes,
+  type HmacContext,
+  hmacField,
+  importHmacKey,
+} from "./audit_hmac.ts";
+import { createAuditEvent } from "./audit_event.ts";
+
+async function makeContext(version = 1): Promise<HmacContext> {
+  const raw = await generateHmacKeyBytes();
+  const key = await importHmacKey(raw);
+  return { key, keyVersion: version };
+}
+
+function makeEvent(
+  overrides?: Partial<Parameters<typeof createAuditEvent>[0]>,
+) {
+  return createAuditEvent({
+    instanceId: "test-instance",
+    category: "secrets",
+    stage: "response",
+    outcome: "success",
+    action: "vault.read-secret",
+    resourceKind: "vault",
+    resourceName: "api-keys",
+    principalKind: "user",
+    principalId: "paul",
+    initiatedBy: "paul",
+    sourceIp: "127.0.0.1",
+    requestId: "req-1",
+    ...overrides,
+  });
+}
+
+Deno.test("hmacField: produces consistent hex output for same input", async () => {
+  const ctx = await makeContext();
+  const a = await hmacField(ctx.key, "test-value");
+  const b = await hmacField(ctx.key, "test-value");
+  assertEquals(a, b);
+  assertEquals(a.length, 64);
+});
+
+Deno.test("hmacField: different inputs produce different hashes", async () => {
+  const ctx = await makeContext();
+  const a = await hmacField(ctx.key, "value-a");
+  const b = await hmacField(ctx.key, "value-b");
+  assertNotEquals(a, b);
+});
+
+Deno.test("hmacField: different keys produce different hashes", async () => {
+  const ctx1 = await makeContext();
+  const ctx2 = await makeContext();
+  const a = await hmacField(ctx1.key, "same-value");
+  const b = await hmacField(ctx2.key, "same-value");
+  assertNotEquals(a, b);
+});
+
+Deno.test("applyHmac: hashes resourceName", async () => {
+  const ctx = await makeContext();
+  const event = makeEvent();
+  const hashed = await applyHmac(ctx, event);
+  assertNotEquals(hashed.resourceName, "api-keys");
+  assertEquals(hashed.resourceName.length, 64);
+});
+
+Deno.test("applyHmac: hashes detail when present", async () => {
+  const ctx = await makeContext();
+  const event = makeEvent({ detail: "sensitive-detail" });
+  const hashed = await applyHmac(ctx, event);
+  assertNotEquals(hashed.detail, "sensitive-detail");
+  assertEquals(hashed.detail!.length, 64);
+});
+
+Deno.test("applyHmac: preserves undefined detail", async () => {
+  const ctx = await makeContext();
+  const event = makeEvent();
+  const hashed = await applyHmac(ctx, event);
+  assertEquals(hashed.detail, undefined);
+});
+
+Deno.test("applyHmac: hashes methodName when present", async () => {
+  const ctx = await makeContext();
+  const event = makeEvent({ methodName: "readSecret" });
+  const hashed = await applyHmac(ctx, event);
+  assertNotEquals(hashed.methodName, "readSecret");
+  assertEquals(hashed.methodName!.length, 64);
+});
+
+Deno.test("applyHmac: hashes decision.resourceName when present", async () => {
+  const ctx = await makeContext();
+  const event = makeEvent({
+    decision: {
+      action: "vault.read-secret",
+      resourceKind: "vault",
+      resourceName: "api-keys",
+      effect: "allow",
+      grantId: "g-1",
+      principalGroups: [],
+    },
+  });
+  const hashed = await applyHmac(ctx, event);
+  assertNotEquals(hashed.decision!.resourceName, "api-keys");
+  assertEquals(hashed.decision!.resourceName.length, 64);
+  assertEquals(hashed.decision!.effect, "allow");
+  assertEquals(hashed.decision!.grantId, "g-1");
+});
+
+Deno.test("applyHmac: sets hmacKeyVersion", async () => {
+  const ctx = await makeContext(3);
+  const event = makeEvent();
+  const hashed = await applyHmac(ctx, event);
+  assertEquals(hashed.hmacKeyVersion, 3);
+});
+
+Deno.test("applyHmac: preserves non-hashed fields", async () => {
+  const ctx = await makeContext();
+  const event = makeEvent();
+  const hashed = await applyHmac(ctx, event);
+  assertEquals(hashed.id, event.id);
+  assertEquals(hashed.timestamp, event.timestamp);
+  assertEquals(hashed.instanceId, event.instanceId);
+  assertEquals(hashed.category, event.category);
+  assertEquals(hashed.action, event.action);
+  assertEquals(hashed.principalKind, event.principalKind);
+  assertEquals(hashed.principalId, event.principalId);
+  assertEquals(hashed.sourceIp, event.sourceIp);
+});
+
+Deno.test("generateHmacKeyBytes: produces key bytes", async () => {
+  const raw = await generateHmacKeyBytes();
+  assertEquals(raw.length, 64);
+});
+
+Deno.test("applyHmac: verification round-trip works", async () => {
+  const ctx = await makeContext();
+  const event = makeEvent();
+  const hashed = await applyHmac(ctx, event);
+  const expectedHash = await hmacField(ctx.key, "api-keys");
+  assertEquals(hashed.resourceName, expectedHash);
+});

--- a/src/domain/serve_audit/audit_policy.ts
+++ b/src/domain/serve_audit/audit_policy.ts
@@ -28,6 +28,7 @@ export interface AuditPolicyRule {
   readonly action?: string;
   readonly tier?: AuditEventTier;
   readonly level: AuditLevel;
+  readonly hmac?: boolean;
 }
 
 const MANAGEMENT_ACTIONS = new Set([
@@ -80,6 +81,17 @@ export class AuditPolicy {
       return rule.level;
     }
     return this.#defaultLevel;
+  }
+
+  shouldHmac(category: AuditCategory, action: string): boolean {
+    const tier = classifyTier(action, category);
+    for (const rule of this.#rules) {
+      if (rule.category !== undefined && rule.category !== category) continue;
+      if (rule.action !== undefined && rule.action !== action) continue;
+      if (rule.tier !== undefined && rule.tier !== tier) continue;
+      return rule.hmac !== false;
+    }
+    return true;
   }
 }
 

--- a/src/domain/serve_audit/audit_policy_test.ts
+++ b/src/domain/serve_audit/audit_policy_test.ts
@@ -124,3 +124,38 @@ Deno.test("DEFAULT_AUDIT_POLICY: data tier uses default metadata", () => {
     "metadata",
   );
 });
+
+Deno.test("shouldHmac: returns true by default with no rules", () => {
+  const policy = new AuditPolicy();
+  assertEquals(policy.shouldHmac("secrets", "vault.read-secret"), true);
+});
+
+Deno.test("shouldHmac: returns true when matching rule has no hmac field", () => {
+  const policy = new AuditPolicy([
+    { category: "secrets", level: "metadata" },
+  ]);
+  assertEquals(policy.shouldHmac("secrets", "vault.read-secret"), true);
+});
+
+Deno.test("shouldHmac: returns false when matching rule has hmac: false", () => {
+  const policy = new AuditPolicy([
+    { category: "execution", level: "requestResponse", hmac: false },
+  ]);
+  assertEquals(policy.shouldHmac("execution", "model.method.run"), false);
+});
+
+Deno.test("shouldHmac: returns true when matching rule has hmac: true", () => {
+  const policy = new AuditPolicy([
+    { category: "secrets", level: "metadata", hmac: true },
+  ]);
+  assertEquals(policy.shouldHmac("secrets", "vault.read-secret"), true);
+});
+
+Deno.test("shouldHmac: first matching rule wins", () => {
+  const policy = new AuditPolicy([
+    { category: "secrets", level: "metadata", hmac: false },
+    { level: "metadata", hmac: true },
+  ]);
+  assertEquals(policy.shouldHmac("secrets", "vault.read-secret"), false);
+  assertEquals(policy.shouldHmac("auth", "auth.login"), true);
+});

--- a/src/domain/serve_audit/audit_query_service.ts
+++ b/src/domain/serve_audit/audit_query_service.ts
@@ -35,6 +35,7 @@ export interface AuditQueryFilters {
   readonly resource?: string;
   readonly limit?: number;
   readonly cursor?: string;
+  readonly export?: boolean;
 }
 
 export interface AuditQueryResult {
@@ -147,7 +148,8 @@ export class AuditQueryService {
       cursorIndex = idx + 1;
     }
 
-    const limit = Math.min(filters.limit ?? 100, MAX_QUERY_LIMIT);
+    const maxLimit = filters.export ? MAX_LOADED_EVENTS : MAX_QUERY_LIMIT;
+    const limit = Math.min(filters.limit ?? 100, maxLimit);
     const page = filtered.slice(cursorIndex, cursorIndex + limit);
     const nextCursor = cursorIndex + limit < filtered.length
       ? filtered[cursorIndex + limit - 1]?.id

--- a/src/domain/serve_audit/mod.ts
+++ b/src/domain/serve_audit/mod.ts
@@ -64,6 +64,21 @@ export {
 
 export type { AuditSink } from "./audit_sink.ts";
 
+export {
+  applyHmac,
+  generateHmacKeyBytes,
+  type HmacContext,
+  hmacField,
+  type HmacKeyProvider,
+  importHmacKey,
+} from "./audit_hmac.ts";
+
 export type { AuditStore } from "./audit_store.ts";
+
+export {
+  matchesSinkFilter,
+  parseSinkFilter,
+  type SinkFilterConfig,
+} from "./sink_filter.ts";
 
 export { RingBuffer } from "./ring_buffer.ts";

--- a/src/domain/serve_audit/sink_filter.ts
+++ b/src/domain/serve_audit/sink_filter.ts
@@ -62,7 +62,7 @@ export function parseSinkFilter(
 
   return {
     categories: filter.categories as AuditCategory[] | undefined,
-    tier: (filter.tier as AuditEventTier | "all" | undefined) ?? "management",
+    tier: filter.tier as AuditEventTier | "all" | undefined,
     outcomes: filter.outcomes as AuditOutcome[] | undefined,
   };
 }

--- a/src/domain/serve_audit/sink_filter.ts
+++ b/src/domain/serve_audit/sink_filter.ts
@@ -1,0 +1,68 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { AuditCategory, AuditEvent, AuditOutcome } from "./audit_event.ts";
+import { type AuditEventTier, classifyTier } from "./audit_policy.ts";
+
+export interface SinkFilterConfig {
+  readonly categories?: readonly AuditCategory[];
+  readonly tier?: AuditEventTier | "all";
+  readonly outcomes?: readonly AuditOutcome[];
+}
+
+export function matchesSinkFilter(
+  event: AuditEvent,
+  filter: SinkFilterConfig,
+): boolean {
+  if (
+    filter.categories &&
+    filter.categories.length > 0 &&
+    !filter.categories.includes(event.category)
+  ) {
+    return false;
+  }
+
+  if (filter.tier && filter.tier !== "all") {
+    const eventTier = classifyTier(event.action, event.category);
+    if (eventTier !== filter.tier) return false;
+  }
+
+  if (
+    filter.outcomes &&
+    filter.outcomes.length > 0 &&
+    !filter.outcomes.includes(event.outcome)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export function parseSinkFilter(
+  raw: Record<string, unknown>,
+): SinkFilterConfig {
+  const filter = raw.filter as Record<string, unknown> | undefined;
+  if (!filter) return { tier: "management" };
+
+  return {
+    categories: filter.categories as AuditCategory[] | undefined,
+    tier: (filter.tier as AuditEventTier | "all" | undefined) ?? "management",
+    outcomes: filter.outcomes as AuditOutcome[] | undefined,
+  };
+}

--- a/src/domain/serve_audit/sink_filter_test.ts
+++ b/src/domain/serve_audit/sink_filter_test.ts
@@ -1,0 +1,128 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { matchesSinkFilter, parseSinkFilter } from "./sink_filter.ts";
+import { createAuditEvent } from "./audit_event.ts";
+
+function makeEvent(
+  overrides?: Partial<Parameters<typeof createAuditEvent>[0]>,
+) {
+  return createAuditEvent({
+    instanceId: "test",
+    category: "auth",
+    stage: "response",
+    outcome: "success",
+    action: "auth.login",
+    resourceKind: "user",
+    resourceName: "paul",
+    principalKind: "user",
+    principalId: "paul",
+    initiatedBy: "paul",
+    sourceIp: "127.0.0.1",
+    requestId: "req-1",
+    ...overrides,
+  });
+}
+
+Deno.test("matchesSinkFilter: empty filter matches all events", () => {
+  const event = makeEvent();
+  assertEquals(matchesSinkFilter(event, {}), true);
+});
+
+Deno.test("matchesSinkFilter: categories filter matches included category", () => {
+  const event = makeEvent({ category: "secrets" });
+  assertEquals(
+    matchesSinkFilter(event, { categories: ["secrets", "auth"] }),
+    true,
+  );
+});
+
+Deno.test("matchesSinkFilter: categories filter rejects excluded category", () => {
+  const event = makeEvent({ category: "execution" });
+  assertEquals(
+    matchesSinkFilter(event, { categories: ["secrets", "auth"] }),
+    false,
+  );
+});
+
+Deno.test("matchesSinkFilter: tier management matches system events", () => {
+  const event = makeEvent({ category: "system", action: "instance.start" });
+  assertEquals(matchesSinkFilter(event, { tier: "management" }), true);
+});
+
+Deno.test("matchesSinkFilter: tier management rejects data events", () => {
+  const event = makeEvent({ category: "execution", action: "model.run" });
+  assertEquals(matchesSinkFilter(event, { tier: "management" }), false);
+});
+
+Deno.test("matchesSinkFilter: tier all matches everything", () => {
+  const event = makeEvent({ category: "execution", action: "model.run" });
+  assertEquals(matchesSinkFilter(event, { tier: "all" }), true);
+});
+
+Deno.test("matchesSinkFilter: outcomes filter matches", () => {
+  const event = makeEvent({ outcome: "denied" });
+  assertEquals(
+    matchesSinkFilter(event, { outcomes: ["denied", "failure"] }),
+    true,
+  );
+});
+
+Deno.test("matchesSinkFilter: outcomes filter rejects", () => {
+  const event = makeEvent({ outcome: "success" });
+  assertEquals(
+    matchesSinkFilter(event, { outcomes: ["denied", "failure"] }),
+    false,
+  );
+});
+
+Deno.test("matchesSinkFilter: combined filters all must match", () => {
+  const event = makeEvent({
+    category: "secrets",
+    outcome: "success",
+    action: "vault.read-secret",
+  });
+  assertEquals(
+    matchesSinkFilter(event, {
+      categories: ["secrets"],
+      outcomes: ["success"],
+      tier: "data",
+    }),
+    true,
+  );
+});
+
+Deno.test("parseSinkFilter: defaults to management tier", () => {
+  const filter = parseSinkFilter({});
+  assertEquals(filter.tier, "management");
+});
+
+Deno.test("parseSinkFilter: parses filter from raw config", () => {
+  const filter = parseSinkFilter({
+    filter: {
+      categories: ["auth", "secrets"],
+      tier: "all",
+      outcomes: ["denied"],
+    },
+  });
+  assertEquals(filter.categories, ["auth", "secrets"]);
+  assertEquals(filter.tier, "all");
+  assertEquals(filter.outcomes, ["denied"]);
+});

--- a/src/presentation/output/audit_export_output.ts
+++ b/src/presentation/output/audit_export_output.ts
@@ -56,8 +56,8 @@ export function createAuditExportRenderer(outputMode: OutputMode) {
           }
 
           if (data.truncated) {
-            writeOutput(
-              "\nWarning: Results truncated. Narrow the date range for complete data.",
+            console.error(
+              "Warning: Results truncated. Narrow the date range for complete data.",
             );
           }
         },

--- a/src/presentation/output/audit_export_output.ts
+++ b/src/presentation/output/audit_export_output.ts
@@ -1,0 +1,67 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type { OutputMode } from "./output.ts";
+import { writeOutput } from "../../infrastructure/logging/logger.ts";
+
+export interface AuditExportOutputData {
+  readonly format: string;
+  readonly count: number;
+  readonly truncated?: boolean;
+  readonly data: string;
+  readonly outputPath?: string;
+}
+
+export function createAuditExportRenderer(outputMode: OutputMode) {
+  return {
+    handlers() {
+      return {
+        completed(event: { kind: "completed"; data: AuditExportOutputData }) {
+          const { data } = event;
+
+          if (outputMode === "json") {
+            writeOutput(
+              JSON.stringify({
+                format: data.format,
+                count: data.count,
+                truncated: data.truncated ?? false,
+                outputPath: data.outputPath,
+              }),
+            );
+            return;
+          }
+
+          if (data.outputPath) {
+            writeOutput(
+              `Exported ${data.count} event(s) in ${data.format} format to ${data.outputPath}`,
+            );
+          } else {
+            writeOutput(data.data);
+          }
+
+          if (data.truncated) {
+            writeOutput(
+              "\nWarning: Results truncated. Narrow the date range for complete data.",
+            );
+          }
+        },
+      };
+    },
+  };
+}

--- a/src/presentation/output/audit_export_output.ts
+++ b/src/presentation/output/audit_export_output.ts
@@ -36,14 +36,17 @@ export function createAuditExportRenderer(outputMode: OutputMode) {
           const { data } = event;
 
           if (outputMode === "json") {
-            writeOutput(
-              JSON.stringify({
-                format: data.format,
-                count: data.count,
-                truncated: data.truncated ?? false,
-                outputPath: data.outputPath,
-              }),
-            );
+            const jsonOutput: Record<string, unknown> = {
+              format: data.format,
+              count: data.count,
+              truncated: data.truncated ?? false,
+            };
+            if (data.outputPath) {
+              jsonOutput.outputPath = data.outputPath;
+            } else {
+              jsonOutput.data = data.data;
+            }
+            writeOutput(JSON.stringify(jsonOutput));
             return;
           }
 

--- a/src/presentation/output/audit_export_output_test.ts
+++ b/src/presentation/output/audit_export_output_test.ts
@@ -1,0 +1,33 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert } from "@std/assert";
+import { createAuditExportRenderer } from "./audit_export_output.ts";
+
+Deno.test("createAuditExportRenderer: creates renderer for log mode", () => {
+  const renderer = createAuditExportRenderer("log");
+  assert(renderer.handlers());
+  assert(typeof renderer.handlers().completed === "function");
+});
+
+Deno.test("createAuditExportRenderer: creates renderer for json mode", () => {
+  const renderer = createAuditExportRenderer("json");
+  assert(renderer.handlers());
+  assert(typeof renderer.handlers().completed === "function");
+});

--- a/src/serve/audit_sinks/cef_formatter.ts
+++ b/src/serve/audit_sinks/cef_formatter.ts
@@ -89,8 +89,8 @@ export function formatCefLine(
   ].join("|");
 
   const extensions: string[] = [
-    `src=${escapeExtension(`${event.principalKind}:${event.principalId}`)}`,
-    `dst=${escapeExtension(`${event.resourceKind}:${event.resourceName}`)}`,
+    `suser=${escapeExtension(`${event.principalKind}:${event.principalId}`)}`,
+    `dhost=${escapeExtension(`${event.resourceKind}:${event.resourceName}`)}`,
     `outcome=${escapeExtension(event.outcome)}`,
     `rt=${escapeExtension(event.timestamp)}`,
     `cs3=${escapeExtension(event.instanceId)}`,
@@ -108,7 +108,7 @@ export function formatCefLine(
   }
 
   if (event.sourceIp) {
-    extensions.push(`spt=${escapeExtension(event.sourceIp)}`);
+    extensions.push(`src=${escapeExtension(event.sourceIp)}`);
   }
 
   return `${header}|${extensions.join(" ")}`;

--- a/src/serve/audit_sinks/cef_formatter.ts
+++ b/src/serve/audit_sinks/cef_formatter.ts
@@ -1,0 +1,115 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import type {
+  AuditCategory,
+  AuditEvent,
+} from "../../domain/serve_audit/audit_event.ts";
+
+const DEVICE_VENDOR = "SwampClub";
+const DEVICE_PRODUCT = "SwampServe";
+const CEF_VERSION = "0";
+const DEVICE_VERSION = "1.0";
+
+const SEVERITY_MAP: Record<AuditCategory, number> = {
+  secrets: 10,
+  admin: 7,
+  auth: 6,
+  access: 6,
+  execution: 5,
+  data: 3,
+  system: 3,
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  "vault.read-secret": "Vault secret read",
+  "vault.put-secret": "Vault secret write",
+  "vault.delete-secret": "Vault secret delete",
+  "auth.login": "User login",
+  "auth.logout": "User logout",
+  "access.grant.create": "Access grant created",
+  "access.grant.delete": "Access grant deleted",
+  "instance.start": "Instance started",
+  "instance.stop": "Instance stopped",
+  "instance.join": "Instance joined cluster",
+  "instance.leave": "Instance left cluster",
+  "health.transition": "Health state changed",
+};
+
+function escapeHeader(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+}
+
+function escapeExtension(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/=/g, "\\=")
+    .replace(/\n/g, "\\n");
+}
+
+function actionLabel(action: string): string {
+  return ACTION_LABELS[action] ?? action.replace(/\./g, " ");
+}
+
+export interface CefFormatOptions {
+  readonly namespace?: string;
+}
+
+export function formatCefLine(
+  event: AuditEvent,
+  options?: CefFormatOptions,
+): string {
+  const severity = SEVERITY_MAP[event.category] ?? 5;
+  const name = actionLabel(event.action);
+
+  const header = [
+    `CEF:${CEF_VERSION}`,
+    escapeHeader(DEVICE_VENDOR),
+    escapeHeader(DEVICE_PRODUCT),
+    escapeHeader(DEVICE_VERSION),
+    escapeHeader(event.action),
+    escapeHeader(name),
+    String(severity),
+  ].join("|");
+
+  const extensions: string[] = [
+    `src=${escapeExtension(`${event.principalKind}:${event.principalId}`)}`,
+    `dst=${escapeExtension(`${event.resourceKind}:${event.resourceName}`)}`,
+    `outcome=${escapeExtension(event.outcome)}`,
+    `rt=${escapeExtension(event.timestamp)}`,
+    `cs3=${escapeExtension(event.instanceId)}`,
+    `cs3Label=instanceId`,
+  ];
+
+  if (options?.namespace) {
+    extensions.push(`cs1=${escapeExtension(options.namespace)}`);
+    extensions.push("cs1Label=namespace");
+  }
+
+  if (event.decision?.grantId) {
+    extensions.push(`cs2=${escapeExtension(event.decision.grantId)}`);
+    extensions.push("cs2Label=grantId");
+  }
+
+  if (event.sourceIp) {
+    extensions.push(`spt=${escapeExtension(event.sourceIp)}`);
+  }
+
+  return `${header}|${extensions.join(" ")}`;
+}

--- a/src/serve/audit_sinks/cef_formatter_test.ts
+++ b/src/serve/audit_sinks/cef_formatter_test.ts
@@ -1,0 +1,141 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertStringIncludes } from "@std/assert";
+import { formatCefLine } from "./cef_formatter.ts";
+import { createAuditEvent } from "../../domain/serve_audit/audit_event.ts";
+
+function makeEvent(
+  overrides?: Partial<Parameters<typeof createAuditEvent>[0]>,
+) {
+  return createAuditEvent({
+    instanceId: "inst-abc",
+    category: "secrets",
+    stage: "response",
+    outcome: "success",
+    action: "vault.read-secret",
+    resourceKind: "vault",
+    resourceName: "api-keys",
+    principalKind: "user",
+    principalId: "paul",
+    initiatedBy: "paul",
+    sourceIp: "10.0.0.1",
+    requestId: "req-1",
+    ...overrides,
+  });
+}
+
+Deno.test("formatCefLine: produces valid CEF header", () => {
+  const line = formatCefLine(makeEvent());
+  assert(line.startsWith("CEF:0|SwampClub|SwampServe|1.0|"));
+});
+
+Deno.test("formatCefLine: includes action as signature ID", () => {
+  const line = formatCefLine(makeEvent());
+  assertStringIncludes(line, "|vault.read-secret|");
+});
+
+Deno.test("formatCefLine: maps secrets category to severity 10", () => {
+  const line = formatCefLine(makeEvent({ category: "secrets" }));
+  const parts = line.split("|");
+  const severity = parts[6];
+  assert(severity === "10", `Expected severity 10, got ${severity}`);
+});
+
+Deno.test("formatCefLine: maps auth category to severity 6", () => {
+  const line = formatCefLine(makeEvent({ category: "auth" }));
+  const parts = line.split("|");
+  const severity = parts[6];
+  assert(severity === "6", `Expected severity 6, got ${severity}`);
+});
+
+Deno.test("formatCefLine: maps system category to severity 3", () => {
+  const line = formatCefLine(
+    makeEvent({ category: "system", action: "instance.start" }),
+  );
+  const parts = line.split("|");
+  const severity = parts[6];
+  assert(severity === "3", `Expected severity 3, got ${severity}`);
+});
+
+Deno.test("formatCefLine: includes principal in src extension", () => {
+  const line = formatCefLine(makeEvent());
+  assertStringIncludes(line, "src=user:paul");
+});
+
+Deno.test("formatCefLine: includes resource in dst extension", () => {
+  const line = formatCefLine(makeEvent());
+  assertStringIncludes(line, "dst=vault:api-keys");
+});
+
+Deno.test("formatCefLine: includes instanceId as cs3", () => {
+  const line = formatCefLine(makeEvent());
+  assertStringIncludes(line, "cs3=inst-abc");
+  assertStringIncludes(line, "cs3Label=instanceId");
+});
+
+Deno.test("formatCefLine: includes grantId as cs2 when present", () => {
+  const event = makeEvent({
+    decision: {
+      action: "vault.read-secret",
+      resourceKind: "vault",
+      resourceName: "api-keys",
+      effect: "allow",
+      grantId: "g-123",
+      principalGroups: [],
+    },
+  });
+  const line = formatCefLine(event);
+  assertStringIncludes(line, "cs2=g-123");
+  assertStringIncludes(line, "cs2Label=grantId");
+});
+
+Deno.test("formatCefLine: escapes pipes in header values", () => {
+  const event = makeEvent({ action: "test|action" });
+  const line = formatCefLine(event);
+  assertStringIncludes(line, "test\\|action");
+});
+
+Deno.test("formatCefLine: escapes equals in extension values", () => {
+  const event = makeEvent({ resourceName: "key=value" });
+  const line = formatCefLine(event);
+  assertStringIncludes(line, "key\\=value");
+});
+
+Deno.test("formatCefLine: uses action label for known actions", () => {
+  const line = formatCefLine(makeEvent());
+  assertStringIncludes(line, "|Vault secret read|");
+});
+
+Deno.test("formatCefLine: falls back to formatted action for unknown", () => {
+  const event = makeEvent({ action: "custom.thing" });
+  const line = formatCefLine(event);
+  assertStringIncludes(line, "|custom thing|");
+});
+
+Deno.test("formatCefLine: includes namespace as cs1 when provided", () => {
+  const line = formatCefLine(makeEvent(), { namespace: "prod-us-east" });
+  assertStringIncludes(line, "cs1=prod-us-east");
+  assertStringIncludes(line, "cs1Label=namespace");
+});
+
+Deno.test("formatCefLine: omits cs1 when namespace not provided", () => {
+  const line = formatCefLine(makeEvent());
+  assert(!line.includes("cs1="), "Should not include cs1 without namespace");
+});

--- a/src/serve/audit_sinks/cef_formatter_test.ts
+++ b/src/serve/audit_sinks/cef_formatter_test.ts
@@ -74,14 +74,14 @@ Deno.test("formatCefLine: maps system category to severity 3", () => {
   assert(severity === "3", `Expected severity 3, got ${severity}`);
 });
 
-Deno.test("formatCefLine: includes principal in src extension", () => {
+Deno.test("formatCefLine: includes principal in suser extension", () => {
   const line = formatCefLine(makeEvent());
-  assertStringIncludes(line, "src=user:paul");
+  assertStringIncludes(line, "suser=user:paul");
 });
 
-Deno.test("formatCefLine: includes resource in dst extension", () => {
+Deno.test("formatCefLine: includes resource in dhost extension", () => {
   const line = formatCefLine(makeEvent());
-  assertStringIncludes(line, "dst=vault:api-keys");
+  assertStringIncludes(line, "dhost=vault:api-keys");
 });
 
 Deno.test("formatCefLine: includes instanceId as cs3", () => {

--- a/src/serve/audit_sinks/syslog_sink.ts
+++ b/src/serve/audit_sinks/syslog_sink.ts
@@ -143,11 +143,11 @@ export class SyslogSink implements AuditSink {
     }
   }
 
-  async flush(): Promise<void> {
-    // syslog messages are sent immediately, no batching
+  flush(): Promise<void> {
+    return Promise.resolve();
   }
 
-  async close(): Promise<void> {
+  close(): Promise<void> {
     this.#closed = true;
     if (this.#tcpConn) {
       try {
@@ -165,6 +165,7 @@ export class SyslogSink implements AuditSink {
       }
       this.#udpSocket = null;
     }
+    return Promise.resolve();
   }
 
   async #send(message: string): Promise<void> {
@@ -253,6 +254,11 @@ export class SyslogSink implements AuditSink {
           });
         }
         this.#reconnectAttempts = 0;
+        if (this.#closed) {
+          this.#tcpConn.close();
+          this.#tcpConn = null;
+          return null;
+        }
         return this.#tcpConn;
       } catch (error: unknown) {
         this.#reconnectAttempts++;

--- a/src/serve/audit_sinks/syslog_sink.ts
+++ b/src/serve/audit_sinks/syslog_sink.ts
@@ -223,6 +223,7 @@ export class SyslogSink implements AuditSink {
         error: error instanceof Error ? error.message : String(error),
       });
       this.#tcpConn = null;
+      this.#connectionFailed = true;
       try {
         conn.close();
       } catch {

--- a/src/serve/audit_sinks/syslog_sink.ts
+++ b/src/serve/audit_sinks/syslog_sink.ts
@@ -1,0 +1,282 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import dgram from "node:dgram";
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import type {
+  AuditCategory,
+  AuditEvent,
+  AuditOutcome,
+} from "../../domain/serve_audit/audit_event.ts";
+import type { AuditSink } from "../../domain/serve_audit/audit_sink.ts";
+import {
+  matchesSinkFilter,
+  type SinkFilterConfig,
+} from "../../domain/serve_audit/sink_filter.ts";
+
+const logger = getSwampLogger(["serve", "audit", "syslog-sink"]);
+
+export type SyslogTransport = "tcp" | "tcp+tls" | "udp";
+
+export interface SyslogSinkOptions {
+  readonly host: string;
+  readonly port: number;
+  readonly transport?: SyslogTransport;
+  readonly hostname?: string;
+  readonly filter?: SinkFilterConfig;
+  readonly caCert?: string;
+  readonly signal?: AbortSignal;
+}
+
+const FACILITY_MAP: Record<AuditCategory, number> = {
+  auth: 4,
+  access: 4,
+  secrets: 4,
+  admin: 10,
+  execution: 1,
+  data: 1,
+  system: 3,
+};
+
+const SEVERITY_MAP: Record<AuditOutcome, number> = {
+  denied: 4,
+  failure: 3,
+  success: 6,
+};
+
+const encoder = new TextEncoder();
+
+function escapeSD(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\]/g, "\\]");
+}
+
+function formatRfc5424(
+  event: AuditEvent,
+  hostname: string,
+): string {
+  const facility = FACILITY_MAP[event.category] ?? 1;
+  const severity = SEVERITY_MAP[event.outcome] ?? 6;
+  const priority = facility * 8 + severity;
+
+  const sd = [
+    `action="${escapeSD(event.action)}"`,
+    `category="${escapeSD(event.category)}"`,
+    `outcome="${escapeSD(event.outcome)}"`,
+    `principal="${escapeSD(`${event.principalKind}:${event.principalId}`)}"`,
+    `resource="${escapeSD(`${event.resourceKind}:${event.resourceName}`)}"`,
+  ];
+
+  if (event.decision?.grantId) {
+    sd.push(`grantId="${escapeSD(event.decision.grantId)}"`);
+  }
+
+  return `<${priority}>1 ${event.timestamp} ${hostname} swamp-serve ${event.instanceId} audit - [swamp ${
+    sd.join(" ")
+  }]`;
+}
+
+export { formatRfc5424 };
+
+export class SyslogSink implements AuditSink {
+  readonly name: string;
+  readonly durable = false;
+
+  readonly #host: string;
+  readonly #port: number;
+  readonly #transport: SyslogTransport;
+  readonly #hostname: string;
+  readonly #filter: SinkFilterConfig;
+  readonly #caCert: string | undefined;
+
+  #tcpConn: Deno.TcpConn | Deno.TlsConn | null = null;
+  #udpSocket: ReturnType<typeof dgram.createSocket> | null = null;
+  #reconnectAttempts = 0;
+  #closed = false;
+  #connectionFailed = false;
+
+  constructor(options: SyslogSinkOptions) {
+    this.#host = options.host;
+    this.#port = options.port;
+    this.#transport = options.transport ?? "tcp";
+    this.#hostname = options.hostname ?? "swamp-serve";
+    this.#filter = options.filter ?? {};
+    this.#caCert = options.caCert;
+    this.name = `syslog:${options.host}:${options.port}`;
+
+    if (options.signal) {
+      options.signal.addEventListener("abort", () => {
+        this.close().catch((error: unknown) => {
+          logger.warn("Shutdown close failed: {error}", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      }, { once: true });
+    }
+  }
+
+  async write(events: readonly AuditEvent[]): Promise<void> {
+    this.#connectionFailed = false;
+    for (const event of events) {
+      if (this.#connectionFailed) break;
+      if (!matchesSinkFilter(event, this.#filter)) continue;
+      const message = formatRfc5424(event, this.#hostname);
+      await this.#send(message);
+    }
+  }
+
+  async flush(): Promise<void> {
+    // syslog messages are sent immediately, no batching
+  }
+
+  async close(): Promise<void> {
+    this.#closed = true;
+    if (this.#tcpConn) {
+      try {
+        this.#tcpConn.close();
+      } catch {
+        // already closed
+      }
+      this.#tcpConn = null;
+    }
+    if (this.#udpSocket) {
+      try {
+        this.#udpSocket.close();
+      } catch {
+        // already closed
+      }
+      this.#udpSocket = null;
+    }
+  }
+
+  async #send(message: string): Promise<void> {
+    if (this.#closed) return;
+
+    if (this.#transport === "udp") {
+      await this.#sendUdp(message);
+      return;
+    }
+
+    await this.#sendTcp(message);
+  }
+
+  #getUdpSocket(): ReturnType<typeof dgram.createSocket> {
+    if (!this.#udpSocket) {
+      this.#udpSocket = dgram.createSocket("udp4");
+    }
+    return this.#udpSocket;
+  }
+
+  async #sendUdp(message: string): Promise<void> {
+    try {
+      const socket = this.#getUdpSocket();
+      const data = encoder.encode(message);
+      await new Promise<void>((resolve, reject) => {
+        socket.send(data, this.#port, this.#host, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    } catch (error: unknown) {
+      logger.warn("Syslog {target} UDP send failed: {error}", {
+        target: `${this.#host}:${this.#port}`,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  async #sendTcp(message: string): Promise<void> {
+    const conn = await this.#getConnection();
+    if (!conn) return;
+
+    const msgBytes = encoder.encode(message);
+    const header = encoder.encode(`${msgBytes.byteLength} `);
+    const framed = new Uint8Array(header.byteLength + msgBytes.byteLength);
+    framed.set(header, 0);
+    framed.set(msgBytes, header.byteLength);
+
+    try {
+      await conn.write(framed);
+      this.#reconnectAttempts = 0;
+    } catch (error: unknown) {
+      logger.warn("Syslog {target} TCP send failed, reconnecting: {error}", {
+        target: `${this.#host}:${this.#port}`,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.#tcpConn = null;
+      try {
+        conn.close();
+      } catch {
+        // already closed
+      }
+    }
+  }
+
+  async #getConnection(): Promise<Deno.TcpConn | Deno.TlsConn | null> {
+    if (this.#tcpConn) return this.#tcpConn;
+    if (this.#closed) return null;
+
+    const maxAttempts = 3;
+    while (this.#reconnectAttempts < maxAttempts && !this.#closed) {
+      try {
+        if (this.#transport === "tcp+tls") {
+          const options: Deno.ConnectTlsOptions = {
+            hostname: this.#host,
+            port: this.#port,
+          };
+          if (this.#caCert) {
+            options.caCerts = [this.#caCert];
+          }
+          this.#tcpConn = await Deno.connectTls(options);
+        } else {
+          this.#tcpConn = await Deno.connect({
+            hostname: this.#host,
+            port: this.#port,
+          });
+        }
+        this.#reconnectAttempts = 0;
+        return this.#tcpConn;
+      } catch (error: unknown) {
+        this.#reconnectAttempts++;
+        logger.warn(
+          "Syslog {target} connection attempt {attempt}/{max} failed: {error}",
+          {
+            target: `${this.#host}:${this.#port}`,
+            attempt: this.#reconnectAttempts,
+            max: maxAttempts,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        if (this.#reconnectAttempts < maxAttempts) {
+          const delay = 1000 * Math.pow(2, this.#reconnectAttempts - 1);
+          await new Promise((r) => setTimeout(r, delay));
+        }
+      }
+    }
+
+    this.#connectionFailed = true;
+    logger.warn(
+      "Syslog {target} connection failed after {max} attempts, dropping events",
+      { target: `${this.#host}:${this.#port}`, max: maxAttempts },
+    );
+    return null;
+  }
+}

--- a/src/serve/audit_sinks/syslog_sink.ts
+++ b/src/serve/audit_sinks/syslog_sink.ts
@@ -135,6 +135,7 @@ export class SyslogSink implements AuditSink {
 
   async write(events: readonly AuditEvent[]): Promise<void> {
     this.#connectionFailed = false;
+    this.#reconnectAttempts = 0;
     for (const event of events) {
       if (this.#connectionFailed) break;
       if (!matchesSinkFilter(event, this.#filter)) continue;

--- a/src/serve/audit_sinks/syslog_sink_test.ts
+++ b/src/serve/audit_sinks/syslog_sink_test.ts
@@ -1,0 +1,125 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assert, assertStringIncludes } from "@std/assert";
+import { formatRfc5424 } from "./syslog_sink.ts";
+import { createAuditEvent } from "../../domain/serve_audit/audit_event.ts";
+
+function makeEvent(
+  overrides?: Partial<Parameters<typeof createAuditEvent>[0]>,
+) {
+  return createAuditEvent({
+    instanceId: "inst-abc",
+    category: "secrets",
+    stage: "response",
+    outcome: "success",
+    action: "vault.read-secret",
+    resourceKind: "vault",
+    resourceName: "api-keys",
+    principalKind: "user",
+    principalId: "paul",
+    initiatedBy: "paul",
+    sourceIp: "127.0.0.1",
+    requestId: "req-1",
+    ...overrides,
+  });
+}
+
+Deno.test("formatRfc5424: produces valid priority for secrets/success", () => {
+  const msg = formatRfc5424(makeEvent(), "test-host");
+  assert(msg.startsWith("<38>1 "), `Expected <38>1, got: ${msg.slice(0, 20)}`);
+});
+
+Deno.test("formatRfc5424: maps auth/denied to facility 4 severity 4", () => {
+  const event = makeEvent({
+    category: "auth",
+    action: "auth.login",
+    outcome: "denied",
+  });
+  const msg = formatRfc5424(event, "test-host");
+  assert(msg.startsWith("<36>1 "), `Expected <36>1, got: ${msg.slice(0, 20)}`);
+});
+
+Deno.test("formatRfc5424: maps system/failure to facility 3 severity 3", () => {
+  const event = makeEvent({
+    category: "system",
+    action: "instance.start",
+    outcome: "failure",
+  });
+  const msg = formatRfc5424(event, "test-host");
+  assert(msg.startsWith("<27>1 "), `Expected <27>1, got: ${msg.slice(0, 20)}`);
+});
+
+Deno.test("formatRfc5424: includes hostname and app-name", () => {
+  const msg = formatRfc5424(makeEvent(), "my-host");
+  assertStringIncludes(msg, "my-host swamp-serve");
+});
+
+Deno.test("formatRfc5424: includes instanceId as procid", () => {
+  const msg = formatRfc5424(makeEvent(), "test-host");
+  assertStringIncludes(msg, "swamp-serve inst-abc audit");
+});
+
+Deno.test("formatRfc5424: includes structured data with action", () => {
+  const msg = formatRfc5424(makeEvent(), "test-host");
+  assertStringIncludes(msg, '[swamp action="vault.read-secret"');
+});
+
+Deno.test("formatRfc5424: includes principal in structured data", () => {
+  const msg = formatRfc5424(makeEvent(), "test-host");
+  assertStringIncludes(msg, 'principal="user:paul"');
+});
+
+Deno.test("formatRfc5424: includes resource in structured data", () => {
+  const msg = formatRfc5424(makeEvent(), "test-host");
+  assertStringIncludes(msg, 'resource="vault:api-keys"');
+});
+
+Deno.test("formatRfc5424: includes grantId when present", () => {
+  const event = makeEvent({
+    decision: {
+      action: "vault.read-secret",
+      resourceKind: "vault",
+      resourceName: "api-keys",
+      effect: "allow",
+      grantId: "g-123",
+      principalGroups: [],
+    },
+  });
+  const msg = formatRfc5424(event, "test-host");
+  assertStringIncludes(msg, 'grantId="g-123"');
+});
+
+Deno.test("formatRfc5424: escapes quotes in structured data", () => {
+  const event = makeEvent({ resourceName: 'key"with"quotes' });
+  const msg = formatRfc5424(event, "test-host");
+  assertStringIncludes(msg, 'key\\"with\\"quotes');
+});
+
+Deno.test("formatRfc5424: escapes backslash in structured data", () => {
+  const event = makeEvent({ resourceName: "path\\to\\key" });
+  const msg = formatRfc5424(event, "test-host");
+  assertStringIncludes(msg, "path\\\\to\\\\key");
+});
+
+Deno.test("formatRfc5424: escapes close bracket in structured data", () => {
+  const event = makeEvent({ resourceName: "key]bracket" });
+  const msg = formatRfc5424(event, "test-host");
+  assertStringIncludes(msg, "key\\]bracket");
+});

--- a/src/serve/audit_sinks/webhook_sink.ts
+++ b/src/serve/audit_sinks/webhook_sink.ts
@@ -1,0 +1,235 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getSwampLogger } from "../../infrastructure/logging/logger.ts";
+import type { AuditEvent } from "../../domain/serve_audit/audit_event.ts";
+import type { AuditSink } from "../../domain/serve_audit/audit_sink.ts";
+import {
+  matchesSinkFilter,
+  type SinkFilterConfig,
+} from "../../domain/serve_audit/sink_filter.ts";
+import { type CefFormatOptions, formatCefLine } from "./cef_formatter.ts";
+
+const logger = getSwampLogger(["serve", "audit", "webhook-sink"]);
+
+export type WebhookFormat = "json" | "cef";
+
+export interface WebhookAuthConfig {
+  readonly type: "bearer" | "basic" | "header";
+  readonly value: string;
+  readonly headerName?: string;
+}
+
+export interface WebhookSinkOptions {
+  readonly url: string;
+  readonly format?: WebhookFormat;
+  readonly auth?: WebhookAuthConfig;
+  readonly filter?: SinkFilterConfig;
+  readonly batchSize?: number;
+  readonly batchIntervalMs?: number;
+  readonly maxAttempts?: number;
+  readonly backoffMs?: number;
+  readonly maxPending?: number;
+  readonly signal?: AbortSignal;
+  readonly namespace?: string;
+}
+
+const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_BATCH_INTERVAL_MS = 5_000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BACKOFF_MS = 1_000;
+const DEFAULT_MAX_PENDING = 10;
+
+export class WebhookSink implements AuditSink {
+  readonly name: string;
+  readonly durable = false;
+
+  readonly #url: string;
+  readonly #format: WebhookFormat;
+  readonly #authHeaders: Record<string, string>;
+  readonly #filter: SinkFilterConfig;
+  readonly #batchSize: number;
+  readonly #maxAttempts: number;
+  readonly #backoffMs: number;
+  readonly #maxPending: number;
+  readonly #cefOptions: CefFormatOptions;
+
+  #batch: AuditEvent[] = [];
+  #pendingCount = 0;
+  #timer: ReturnType<typeof setInterval> | null = null;
+  #closed = false;
+
+  constructor(options: WebhookSinkOptions) {
+    this.#url = options.url;
+    this.#format = options.format ?? "json";
+    this.#filter = options.filter ?? {};
+    this.#batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+    this.#maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    this.#backoffMs = options.backoffMs ?? DEFAULT_BACKOFF_MS;
+    this.#maxPending = options.maxPending ?? DEFAULT_MAX_PENDING;
+    this.name = `webhook:${new URL(options.url).hostname}`;
+    this.#cefOptions = { namespace: options.namespace };
+
+    this.#authHeaders = {};
+    if (options.auth) {
+      switch (options.auth.type) {
+        case "bearer":
+          this.#authHeaders["Authorization"] = `Bearer ${options.auth.value}`;
+          break;
+        case "basic":
+          this.#authHeaders["Authorization"] = `Basic ${options.auth.value}`;
+          break;
+        case "header":
+          this.#authHeaders[options.auth.headerName ?? "X-Auth-Token"] =
+            options.auth.value;
+          break;
+      }
+    }
+
+    const intervalMs = options.batchIntervalMs ?? DEFAULT_BATCH_INTERVAL_MS;
+    this.#timer = setInterval(() => {
+      this.flush().catch((error: unknown) => {
+        logger.warn("Periodic flush failed: {error}", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }, intervalMs);
+    Deno.unrefTimer(this.#timer);
+
+    if (options.signal) {
+      options.signal.addEventListener("abort", () => {
+        this.close().catch((error: unknown) => {
+          logger.warn("Shutdown flush failed: {error}", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      }, { once: true });
+    }
+  }
+
+  async write(events: readonly AuditEvent[]): Promise<void> {
+    for (const event of events) {
+      if (!matchesSinkFilter(event, this.#filter)) continue;
+      this.#batch.push(event);
+      if (this.#batch.length >= this.#batchSize) {
+        await this.#sendBatch();
+      }
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.#batch.length > 0) {
+      await this.#sendBatch();
+    }
+  }
+
+  async close(): Promise<void> {
+    this.#closed = true;
+    if (this.#timer !== null) {
+      clearInterval(this.#timer);
+      this.#timer = null;
+    }
+    await this.flush();
+  }
+
+  async #sendBatch(): Promise<void> {
+    if (this.#closed && this.#batch.length === 0) return;
+
+    const batch = this.#batch;
+    this.#batch = [];
+
+    if (this.#pendingCount >= this.#maxPending) {
+      logger.warn(
+        "Webhook sink {url} backpressure: dropping {count} event(s), {pending} batches pending",
+        { url: this.#url, count: batch.length, pending: this.#pendingCount },
+      );
+      return;
+    }
+
+    this.#pendingCount++;
+    try {
+      await this.#deliverWithRetry(batch);
+    } finally {
+      this.#pendingCount--;
+    }
+  }
+
+  async #deliverWithRetry(events: readonly AuditEvent[]): Promise<void> {
+    const body = this.#formatBody(events);
+    const contentType = this.#format === "cef"
+      ? "text/plain; charset=utf-8"
+      : "application/json";
+
+    for (let attempt = 0; attempt < this.#maxAttempts; attempt++) {
+      try {
+        const resp = await fetch(this.#url, {
+          method: "POST",
+          headers: {
+            "Content-Type": contentType,
+            ...this.#authHeaders,
+          },
+          body,
+          signal: AbortSignal.timeout(30_000),
+        });
+
+        if (resp.ok) return;
+
+        const respBody = await resp.text().catch(() => "");
+        logger.warn(
+          "Webhook {url} delivery failed (attempt {attempt}/{max}): HTTP {status} {body}",
+          {
+            url: this.#url,
+            attempt: attempt + 1,
+            max: this.#maxAttempts,
+            status: resp.status,
+            body: respBody.slice(0, 200),
+          },
+        );
+      } catch (error: unknown) {
+        logger.warn(
+          "Webhook {url} delivery error (attempt {attempt}/{max}): {error}",
+          {
+            url: this.#url,
+            attempt: attempt + 1,
+            max: this.#maxAttempts,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+
+      if (attempt < this.#maxAttempts - 1) {
+        const delay = this.#backoffMs * Math.pow(2, attempt);
+        await new Promise((r) => setTimeout(r, delay));
+      }
+    }
+
+    logger.warn(
+      "Webhook {url} delivery failed after {max} attempts, dropping {count} event(s)",
+      { url: this.#url, max: this.#maxAttempts, count: events.length },
+    );
+  }
+
+  #formatBody(events: readonly AuditEvent[]): string {
+    if (this.#format === "cef") {
+      return events.map((e) => formatCefLine(e, this.#cefOptions)).join("\n") +
+        "\n";
+    }
+    return JSON.stringify(events);
+  }
+}

--- a/src/serve/audit_sinks/webhook_sink_test.ts
+++ b/src/serve/audit_sinks/webhook_sink_test.ts
@@ -1,0 +1,40 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { WebhookSink } from "./webhook_sink.ts";
+
+Deno.test("WebhookSink: name includes hostname from url", () => {
+  const sink = new WebhookSink({
+    url: "http://siem.example.com/api/ingest",
+    batchIntervalMs: 60_000,
+  });
+  assertEquals(sink.name, "webhook:siem.example.com");
+  assertEquals(sink.durable, false);
+  sink.close();
+});
+
+Deno.test("WebhookSink: defaults to json format", () => {
+  const sink = new WebhookSink({
+    url: "http://localhost:9999/ingest",
+    batchIntervalMs: 60_000,
+  });
+  assertEquals(sink.durable, false);
+  sink.close();
+});

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -29,6 +29,7 @@ import type { Principal } from "../domain/access/principal.ts";
 import { audited, type AuditedOptions } from "./audited.ts";
 import { AuditQueryService } from "../domain/serve_audit/audit_query_service.ts";
 import type { AuditSubscriptionFilter } from "./audit_sinks/websocket_sink.ts";
+import { formatCefLine } from "./audit_sinks/cef_formatter.ts";
 import {
   GIT_SHA as SERVER_GIT_SHA,
   VERSION as SERVER_VERSION,
@@ -491,6 +492,21 @@ const AuditSubscribeRequestSchema = z.object({
 const AuditUnsubscribeRequestSchema = z.object({
   type: z.literal("audit.unsubscribe"),
   id: z.string().min(1).max(256),
+});
+
+const AuditExportRequestSchema = z.object({
+  type: z.literal("audit.export"),
+  id: z.string().min(1).max(256),
+  payload: z.object({
+    from: z.string(),
+    to: z.string(),
+    format: z.enum(["json", "cef", "csv"]).optional(),
+    principal: z.string().optional(),
+    category: z.string().optional(),
+    action: z.string().optional(),
+    outcome: z.string().optional(),
+    resource: z.string().optional(),
+  }),
 });
 
 const SummariseRequestSchema = z.object({
@@ -1230,6 +1246,7 @@ const ServerRequestSchema = z.discriminatedUnion("type", [
   AuditVerifyRequestSchema,
   AuditSubscribeRequestSchema,
   AuditUnsubscribeRequestSchema,
+  AuditExportRequestSchema,
   SummariseRequestSchema,
   ReportGetRequestSchema,
   ReportSearchRequestSchema,
@@ -1972,6 +1989,120 @@ export function handleMessage(
             id: request.id,
             payload: verifyResult,
           });
+        })(),
+        auditOpts("admin", "access", "audit"),
+      );
+      break;
+    case "audit.export":
+      if (
+        !authorizeOrReject(
+          socket,
+          request.id,
+          principal,
+          "admin",
+          { kind: "access", name: "audit", fields: {} },
+          ctx,
+        ).allowed
+      ) {
+        task = Promise.resolve();
+        activeRequests.delete(request.id);
+        break;
+      }
+      task = audited(
+        (async () => {
+          const format = request.payload.format ?? "json";
+          if (!ctx.auditStores || ctx.auditStores.length === 0) {
+            send(socket, {
+              type: "audit.export",
+              id: request.id,
+              payload: format === "json"
+                ? { events: [], format, count: 0 }
+                : { data: "", format, count: 0 },
+            });
+            return;
+          }
+          const exportService = new AuditQueryService(ctx.auditStores[0]);
+          const result = await exportService.query({
+            since: request.payload.from,
+            until: request.payload.to,
+            principal: request.payload.principal,
+            category: request.payload.category,
+            action: request.payload.action,
+            outcome: request.payload.outcome,
+            resource: request.payload.resource,
+          });
+          const events = result.events;
+          const truncated = result.total !== undefined &&
+            result.total > events.length;
+
+          if (format === "json") {
+            send(socket, {
+              type: "audit.export",
+              id: request.id,
+              payload: {
+                events: events as unknown as Record<string, unknown>[],
+                format,
+                count: events.length,
+                truncated,
+              },
+            });
+          } else if (format === "cef") {
+            const cefOpts = ctx.auditNamespace
+              ? { namespace: ctx.auditNamespace }
+              : undefined;
+            const lines = events.map((e) => formatCefLine(e, cefOpts)).join(
+              "\n",
+            );
+            send(socket, {
+              type: "audit.export",
+              id: request.id,
+              payload: {
+                data: lines,
+                format,
+                count: events.length,
+                truncated,
+              },
+            });
+          } else {
+            const csvHeader =
+              "id,timestamp,instanceId,category,action,stage,outcome,principalKind,principalId,initiatedBy,resourceKind,resourceName,decision.effect,decision.grantId,detail";
+            const csvRows = events.map((e) => {
+              const fields = [
+                e.id,
+                e.timestamp,
+                e.instanceId,
+                e.category,
+                e.action,
+                e.stage,
+                e.outcome,
+                e.principalKind,
+                e.principalId,
+                e.initiatedBy,
+                e.resourceKind,
+                e.resourceName,
+                e.decision?.effect ?? "",
+                e.decision?.grantId ?? "",
+                e.detail ?? "",
+              ];
+              return fields.map((f) => {
+                const s = String(f);
+                if (s.includes(",") || s.includes('"') || s.includes("\n")) {
+                  return `"${s.replace(/"/g, '""')}"`;
+                }
+                return s;
+              }).join(",");
+            });
+            send(socket, {
+              type: "audit.export",
+              id: request.id,
+              payload: {
+                data: [csvHeader, ...csvRows].join("\n"),
+                format,
+                count: events.length,
+                truncated,
+              },
+            });
+          }
         })(),
         auditOpts("admin", "access", "audit"),
       );

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -2087,7 +2087,10 @@ export function handleMessage(
                 e.detail ?? "",
               ];
               return fields.map((f) => {
-                const s = String(f);
+                let s = String(f);
+                if (/^[=+\-@\t\r]/.test(s)) {
+                  s = `\t${s}`;
+                }
                 if (s.includes(",") || s.includes('"') || s.includes("\n")) {
                   return `"${s.replace(/"/g, '""')}"`;
                 }

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -2065,7 +2065,7 @@ export function handleMessage(
             });
           } else {
             const csvHeader =
-              "id,timestamp,instanceId,category,action,stage,outcome,principalKind,principalId,initiatedBy,resourceKind,resourceName,decision.effect,decision.grantId,detail";
+              "id,timestamp,instanceId,category,action,stage,outcome,principalKind,principalId,initiatedBy,sourceIp,requestId,resourceKind,resourceName,decision.effect,decision.grantId,detail";
             const csvRows = events.map((e) => {
               const fields = [
                 e.id,
@@ -2078,6 +2078,8 @@ export function handleMessage(
                 e.principalKind,
                 e.principalId,
                 e.initiatedBy,
+                e.sourceIp,
+                e.requestId,
                 e.resourceKind,
                 e.resourceName,
                 e.decision?.effect ?? "",

--- a/src/serve/connection.ts
+++ b/src/serve/connection.ts
@@ -2030,6 +2030,8 @@ export function handleMessage(
             action: request.payload.action,
             outcome: request.payload.outcome,
             resource: request.payload.resource,
+            limit: 50_000,
+            export: true,
           });
           const events = result.events;
           const truncated = result.total !== undefined &&

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -184,6 +184,7 @@ export interface ConnectionContext {
   auditWal?: AuditWal;
   /** WebSocket audit sink — broadcasts events to subscribed connections. */
   auditWebSocketSink?: import("../audit_sinks/websocket_sink.ts").WebSocketSink;
+  auditNamespace?: string;
 }
 
 // SECURITY: Authorization must operate on canonical (normalized) model types,

--- a/src/serve/health_collector.ts
+++ b/src/serve/health_collector.ts
@@ -89,6 +89,8 @@ export interface WorkerProvider {
   workers(): WorkerSnapshot[];
 }
 
+export type HealthStatus = "healthy" | "degraded" | "unhealthy";
+
 export interface HealthCollectorDeps {
   readonly instanceId: string;
   readonly deploymentMode: string;
@@ -102,11 +104,27 @@ export interface HealthCollectorDeps {
   readonly scheduleEnabled: boolean;
   readonly webhookProvider: WebhookProvider | null;
   readonly remoteOnly: boolean;
+  readonly onHealthTransition?: (
+    previous: HealthStatus,
+    current: HealthStatus,
+  ) => void;
+}
+
+export function classifyHealthStatus(
+  ready: boolean,
+  components: readonly { healthy: boolean }[],
+): HealthStatus {
+  if (!ready) return "unhealthy";
+  if (components.length === 0) return "healthy";
+  const allHealthy = components.every((c) => c.healthy);
+  if (allHealthy) return "healthy";
+  return "degraded";
 }
 
 export class HealthCollector {
   readonly #deps: HealthCollectorDeps;
   #inflight: Promise<HealthSnapshot> | null = null;
+  #previousStatus: HealthStatus | null = null;
 
   constructor(deps: HealthCollectorDeps) {
     this.#deps = deps;
@@ -161,12 +179,24 @@ export class HealthCollector {
 
     const components = await this.#deps.componentChecker.checkAll(signal);
 
+    const ready = this.#deps.isReady();
+    const currentStatus = classifyHealthStatus(ready, components);
+
+    if (
+      this.#previousStatus !== null &&
+      currentStatus !== this.#previousStatus &&
+      this.#deps.onHealthTransition
+    ) {
+      this.#deps.onHealthTransition(this.#previousStatus, currentStatus);
+    }
+    this.#previousStatus = currentStatus;
+
     return {
       instanceId: this.#deps.instanceId,
       deploymentMode: this.#deps.deploymentMode,
       remoteOnly: this.#deps.remoteOnly,
       uptimeMs: now - this.#deps.startedAt,
-      ready: this.#deps.isReady(),
+      ready,
       activeRuns,
       metrics,
       workers,

--- a/src/serve/health_collector_test.ts
+++ b/src/serve/health_collector_test.ts
@@ -19,8 +19,10 @@
 
 import { assertEquals, assertGreater } from "@std/assert";
 import {
+  classifyHealthStatus,
   HealthCollector,
   type HealthCollectorDeps,
+  type HealthStatus,
 } from "./health_collector.ts";
 import { RunMetricsTracker } from "./run_metrics_tracker.ts";
 import { ComponentHealthChecker } from "./component_health_checker.ts";
@@ -178,4 +180,68 @@ Deno.test("HealthCollector: reports not ready", async () => {
   const snapshot = await collector.collect();
 
   assertEquals(snapshot.ready, false);
+});
+
+Deno.test("classifyHealthStatus: healthy when ready and all components healthy", () => {
+  assertEquals(classifyHealthStatus(true, [{ healthy: true }]), "healthy");
+});
+
+Deno.test("classifyHealthStatus: healthy when ready and no components", () => {
+  assertEquals(classifyHealthStatus(true, []), "healthy");
+});
+
+Deno.test("classifyHealthStatus: degraded when ready but some unhealthy", () => {
+  assertEquals(
+    classifyHealthStatus(true, [{ healthy: true }, { healthy: false }]),
+    "degraded",
+  );
+});
+
+Deno.test("classifyHealthStatus: unhealthy when not ready", () => {
+  assertEquals(classifyHealthStatus(false, [{ healthy: true }]), "unhealthy");
+});
+
+Deno.test("HealthCollector: emits health transition on state change", async () => {
+  const transitions: { previous: HealthStatus; current: HealthStatus }[] = [];
+  let ready = true;
+
+  const deps = makeDeps({
+    isReady: () => ready,
+    onHealthTransition: (previous, current) => {
+      transitions.push({ previous, current });
+    },
+  });
+  const collector = new HealthCollector(deps);
+
+  await collector.collect();
+  assertEquals(transitions.length, 0);
+
+  ready = false;
+  await collector.collect();
+  assertEquals(transitions.length, 1);
+  assertEquals(transitions[0].previous, "healthy");
+  assertEquals(transitions[0].current, "unhealthy");
+
+  ready = true;
+  await collector.collect();
+  assertEquals(transitions.length, 2);
+  assertEquals(transitions[1].previous, "unhealthy");
+  assertEquals(transitions[1].current, "healthy");
+});
+
+Deno.test("HealthCollector: no transition when status unchanged", async () => {
+  const transitions: { previous: HealthStatus; current: HealthStatus }[] = [];
+
+  const deps = makeDeps({
+    isReady: () => true,
+    onHealthTransition: (previous, current) => {
+      transitions.push({ previous, current });
+    },
+  });
+  const collector = new HealthCollector(deps);
+
+  await collector.collect();
+  await collector.collect();
+  await collector.collect();
+  assertEquals(transitions.length, 0);
 });

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -173,6 +173,25 @@ export interface AuditVerifyPayload {
   until?: string;
 }
 
+export interface AuditExportPayload {
+  from: string;
+  to: string;
+  format?: "json" | "cef" | "csv";
+  principal?: string;
+  category?: string;
+  action?: string;
+  outcome?: string;
+  resource?: string;
+}
+
+export interface AuditExportResponse {
+  events?: readonly Record<string, unknown>[];
+  data?: string;
+  format: string;
+  count: number;
+  truncated?: boolean;
+}
+
 export interface AuditSubscribePayload {
   categories?: string[];
   principals?: string[];
@@ -768,6 +787,7 @@ export type ServerRequest =
   | { type: "audit.verify"; id: string; payload: AuditVerifyPayload }
   | { type: "audit.subscribe"; id: string; payload?: AuditSubscribePayload }
   | { type: "audit.unsubscribe"; id: string }
+  | { type: "audit.export"; id: string; payload: AuditExportPayload }
   | { type: "summarise"; id: string; payload?: SummarisePayload }
   | { type: "report.get"; id: string; payload: ReportGetPayload }
   | { type: "report.search"; id: string; payload?: ReportSearchPayload }
@@ -1573,6 +1593,7 @@ export type ServerMessage =
   | { type: "audit.subscribe"; id: string; payload: AuditSubscribeResponse }
   | { type: "audit.unsubscribe"; id: string }
   | { type: "audit.event"; id: string; payload: AuditEventPayload }
+  | { type: "audit.export"; id: string; payload: AuditExportResponse }
   | { type: "summarise"; id: string; payload: SummariseResponse }
   | { type: "report.get"; id: string; payload: ReportGetResponse }
   | { type: "report.search"; id: string; payload: ReportSearchResponse }

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -1552,7 +1552,7 @@ export function parseAuditConfig(
     policyRules: audit.policy?.rules ?? [],
     hmacVault: audit.hmac?.vault ?? "_audit",
     hmacKey: audit.hmac?.key ?? "hmac-key",
-    hmacEnabled: audit.hmac?.enabled ?? true,
+    hmacEnabled: audit.hmac?.enabled ?? false,
     sinks,
   };
 }

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -139,6 +139,12 @@ export interface ServeConfigFile {
       directory?: string;
       "max-size"?: string;
     };
+    hmac?: {
+      vault?: string;
+      key?: string;
+      enabled?: boolean;
+    };
+    sinks?: Array<Record<string, unknown>>;
   };
 }
 
@@ -164,7 +170,17 @@ export interface AuditConfig {
     readonly action?: string;
     readonly tier?: string;
     readonly level: string;
+    readonly hmac?: boolean;
   }[];
+  readonly hmacVault: string;
+  readonly hmacKey: string;
+  readonly hmacEnabled: boolean;
+  readonly sinks: readonly AuditSinkConfigEntry[];
+}
+
+export interface AuditSinkConfigEntry {
+  readonly type: "webhook" | "syslog";
+  readonly config: Record<string, unknown>;
 }
 
 // ── Known Keys ────────────────────────────────────────────────────────
@@ -1166,11 +1182,13 @@ export async function writeServeConfigFile(
 
 const KNOWN_AUDIT_KEYS = new Set([
   "stores",
+  "sinks",
   "batch-size",
   "flush-interval",
   "fail-open",
   "policy",
   "wal",
+  "hmac",
 ]);
 
 function validateAuditConfig(audit: unknown, path: string): void {
@@ -1323,6 +1341,11 @@ function validateAuditConfig(audit: unknown, path: string): void {
             `Invalid audit.policy.rules[${i}].tier in ${path}: expected one of management, data`,
           );
         }
+        if (rule.hmac !== undefined && typeof rule.hmac !== "boolean") {
+          throw new UserError(
+            `Invalid audit.policy.rules[${i}].hmac in ${path}: expected boolean`,
+          );
+        }
       }
     }
   }
@@ -1394,6 +1417,99 @@ function validateAuditConfig(audit: unknown, path: string): void {
       );
     }
   }
+
+  if (obj.hmac !== undefined) {
+    if (
+      typeof obj.hmac !== "object" || obj.hmac === null ||
+      Array.isArray(obj.hmac)
+    ) {
+      throw new UserError(
+        `Invalid audit.hmac in ${path}: expected mapping`,
+      );
+    }
+    const hmac = obj.hmac as Record<string, unknown>;
+    const knownHmacKeys = new Set(["vault", "key", "enabled"]);
+    warnUnknownKeys(hmac, knownHmacKeys, path, "audit.hmac.");
+    if (hmac.vault !== undefined && typeof hmac.vault !== "string") {
+      throw new UserError(
+        `Invalid audit.hmac.vault in ${path}: expected string`,
+      );
+    }
+    if (hmac.key !== undefined && typeof hmac.key !== "string") {
+      throw new UserError(
+        `Invalid audit.hmac.key in ${path}: expected string`,
+      );
+    }
+    if (hmac.enabled !== undefined && typeof hmac.enabled !== "boolean") {
+      throw new UserError(
+        `Invalid audit.hmac.enabled in ${path}: expected boolean`,
+      );
+    }
+  }
+
+  if (obj.sinks !== undefined) {
+    if (!Array.isArray(obj.sinks)) {
+      throw new UserError(
+        `Invalid audit.sinks in ${path}: expected array`,
+      );
+    }
+    const validSinkTypes = new Set(["webhook", "syslog"]);
+    const knownWebhookKeys = new Set([
+      "type",
+      "url",
+      "format",
+      "auth",
+      "batch",
+      "retry",
+      "filter",
+      "max-pending",
+    ]);
+    const knownSyslogKeys = new Set([
+      "type",
+      "host",
+      "port",
+      "transport",
+      "filter",
+      "ca-cert",
+      "hostname",
+    ]);
+    for (let i = 0; i < obj.sinks.length; i++) {
+      const sink = obj.sinks[i];
+      if (typeof sink !== "object" || sink === null || Array.isArray(sink)) {
+        throw new UserError(
+          `Invalid audit.sinks[${i}] in ${path}: expected object`,
+        );
+      }
+      const s = sink as Record<string, unknown>;
+      if (typeof s.type !== "string" || !validSinkTypes.has(s.type)) {
+        throw new UserError(
+          `Invalid audit.sinks[${i}].type in ${path}: expected one of webhook, syslog`,
+        );
+      }
+      if (s.type === "webhook") {
+        warnUnknownKeys(s, knownWebhookKeys, path, `audit.sinks[${i}].`);
+      } else if (s.type === "syslog") {
+        warnUnknownKeys(s, knownSyslogKeys, path, `audit.sinks[${i}].`);
+      }
+      if (s.type === "webhook" && typeof s.url !== "string") {
+        throw new UserError(
+          `Invalid audit.sinks[${i}].url in ${path}: webhook sink requires a url`,
+        );
+      }
+      if (s.type === "syslog") {
+        if (typeof s.host !== "string") {
+          throw new UserError(
+            `Invalid audit.sinks[${i}].host in ${path}: syslog sink requires a host`,
+          );
+        }
+        if (typeof s.port !== "number" || !Number.isInteger(s.port)) {
+          throw new UserError(
+            `Invalid audit.sinks[${i}].port in ${path}: syslog sink requires an integer port`,
+          );
+        }
+      }
+    }
+  }
 }
 
 export function parseAuditConfig(
@@ -1415,6 +1531,16 @@ export function parseAuditConfig(
     if (parsed !== null) walMaxBytes = parsed;
   }
 
+  const sinks: AuditSinkConfigEntry[] = [];
+  if (audit.sinks) {
+    for (const raw of audit.sinks) {
+      const type = raw.type as string;
+      if (type === "webhook" || type === "syslog") {
+        sinks.push({ type, config: raw });
+      }
+    }
+  }
+
   return {
     stores: audit.stores,
     batchSize: audit["batch-size"] ?? 100,
@@ -1424,6 +1550,10 @@ export function parseAuditConfig(
     walMaxBytes,
     policyDefaultLevel: audit.policy?.["default-level"] ?? "metadata",
     policyRules: audit.policy?.rules ?? [],
+    hmacVault: audit.hmac?.vault ?? "_audit",
+    hmacKey: audit.hmac?.key ?? "hmac-key",
+    hmacEnabled: audit.hmac?.enabled ?? true,
+    sinks,
   };
 }
 

--- a/src/serve/serve_config.ts
+++ b/src/serve/serve_config.ts
@@ -1491,10 +1491,19 @@ function validateAuditConfig(audit: unknown, path: string): void {
       } else if (s.type === "syslog") {
         warnUnknownKeys(s, knownSyslogKeys, path, `audit.sinks[${i}].`);
       }
-      if (s.type === "webhook" && typeof s.url !== "string") {
-        throw new UserError(
-          `Invalid audit.sinks[${i}].url in ${path}: webhook sink requires a url`,
-        );
+      if (s.type === "webhook") {
+        if (typeof s.url !== "string") {
+          throw new UserError(
+            `Invalid audit.sinks[${i}].url in ${path}: webhook sink requires a url`,
+          );
+        }
+        try {
+          new URL(s.url);
+        } catch {
+          throw new UserError(
+            `Invalid audit.sinks[${i}].url in ${path}: "${s.url}" is not a valid URL`,
+          );
+        }
       }
       if (s.type === "syslog") {
         if (typeof s.host !== "string") {


### PR DESCRIPTION
## Summary

Phase 4 of the serve audit log. Builds on Phases 1-3 to push audit events to
external SIEM tools, add bulk compliance exports, and hash sensitive fields.

- **Webhook sink** (JSON + CEF) — batched delivery with retry, bearer/basic/header
  auth via @vault=/@env=/@file=, per-sink filtering, backpressure, 30s fetch timeout
- **Syslog sink** (RFC 5424) — TCP persistent with reconnect, TCP+TLS, UDP via
  node:dgram, facility/severity mapping, octet-counting framing
- **CEF formatter** — shared between webhook sink and audit.export, correct
  severity mapping, field mapping (suser, dhost, cs1=namespace, cs2=grantId,
  cs3=instanceId), header/extension escaping
- **HMAC-SHA256** of sensitive fields (resourceName, detail, methodName,
  decision.resourceName) — vault-backed key with auto-generation, per-rule opt-out,
  applied in emitter drain before chain hashing, opt-in via audit.hmac.enabled
- **Bulk export** via audit.export protocol — JSON/CEF/CSV formats with 50K event
  limit, CSV formula injection protection, --since/--until/--format/--output/
  --resource CLI flags matching audit log conventions
- **System events** — health.transition from HealthCollector state tracking,
  instance.join/leave from peer-set delta detection in reconciliation loop
- **Config** — audit.sinks and audit.hmac parsing with validation, unknown-key
  warnings, URL validation, sinks created at startup (no hot-reload, deferred to
  Phase 5)

## Test plan

- [x] 11,496 tests pass (full project suite), 0 failures
- [x] 12 HMAC tests (field hashing, round-trip, opt-out, key generation)
- [x] 11 sink filter tests (category, tier, outcome, combined, defaults)
- [x] 15 CEF formatter tests (severity, field mapping, escaping, namespace)
- [x] 12 syslog tests (RFC 5424 format, facility/severity, escaping)
- [x] 2 webhook unit tests + 5 integration tests (JSON, CEF, auth, batching, filter)
- [x] 3 integration tests (HMAC-through-emitter, webhook e2e, syslog TCP/UDP)
- [x] 5 shouldHmac policy tests (default, opt-out, first-match-wins)
- [x] 6 health transition tests (classify, transition callback, no-op)
- [x] Verification: build 9/9, code review pass, UX pass, adversarial pass

Closes #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQoBfHkLwd7Maq1ZsMpdzZ