### PR TITLE
fix(audit): syslog circuit breaker and UDP message size limit

### DIFF
--- a/src/serve/audit_sinks/syslog_sink.ts
+++ b/src/serve/audit_sinks/syslog_sink.ts
@@ -112,6 +112,7 @@ export class SyslogSink implements AuditSink {
   #reconnectAttempts = 0;
   #closed = false;
   #connectionFailed = false;
+  #circuitBreakerUntil = 0;
 
   constructor(options: SyslogSinkOptions) {
     this.#host = options.host;
@@ -134,6 +135,7 @@ export class SyslogSink implements AuditSink {
   }
 
   async write(events: readonly AuditEvent[]): Promise<void> {
+    if (Date.now() < this.#circuitBreakerUntil) return;
     this.#connectionFailed = false;
     this.#reconnectAttempts = 0;
     for (const event of events) {
@@ -190,7 +192,10 @@ export class SyslogSink implements AuditSink {
   async #sendUdp(message: string): Promise<void> {
     try {
       const socket = this.#getUdpSocket();
-      const data = encoder.encode(message);
+      let data = encoder.encode(message);
+      if (data.byteLength > 2048) {
+        data = data.subarray(0, 2048);
+      }
       await new Promise<void>((resolve, reject) => {
         socket.send(data, this.#port, this.#host, (err) => {
           if (err) reject(err);
@@ -281,8 +286,9 @@ export class SyslogSink implements AuditSink {
     }
 
     this.#connectionFailed = true;
+    this.#circuitBreakerUntil = Date.now() + 60_000;
     logger.warn(
-      "Syslog {target} connection failed after {max} attempts, dropping events",
+      "Syslog {target} connection failed after {max} attempts, circuit breaker open for 60s",
       { target: `${this.#host}:${this.#port}`, max: maxAttempts },
     );
     return null;


### PR DESCRIPTION
## Summary

Follow-up to #2074 (audit Phase 4) addressing review feedback:

- **Syslog circuit breaker** — after 3 failed connection attempts, the sink
  skips reconnection for 60s instead of retrying every drain cycle. Prevents
  connection storms when the syslog server is down.
- **UDP message truncation** — truncate UDP syslog messages to 2048 bytes to
  stay within typical MTU limits per RFC 5424 transport recommendations.

## Test plan

- [x] Existing syslog tests pass (14 tests — format, TCP, UDP, filter)
- [x] Full Phase 4 test suite passes (74 tests)
- [x] `deno lint` and `deno fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQoBfHkLwd7Maq1ZsMpdzZ