### PR TITLE
fix(ci): restore PR approval in validate-attestation for auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,6 +474,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     # Mandatory merge gate. Validates that local verification ran on this commit
     # and that config integrity checksums match.
     if: github.event.pull_request.draft == false
@@ -690,6 +691,22 @@ jobs:
             echo "### ✅ Validation Passed" >> "$GITHUB_STEP_SUMMARY"
             echo "All checks passed — commit, gate, freshness, and config integrity verified." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Approve PR
+        if: steps.find.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          steps_completed=$(jq -r '.gate.stepsCompleted // 0' attestation.json)
+          steps_total=$(jq -r '.gate.stepsTotal // 0' attestation.json)
+
+          gh pr review "${{ github.event.pull_request.number }}" --approve --body "$(cat <<EOF
+          ## Attestation Approved
+
+          Verified commit \`${head_sha:0:8}\` — attestation gate passed (${steps_completed}/${steps_total} steps).
+          EOF
+          )"
 
   auto-merge:
     name: Auto-merge PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,7 +693,7 @@ jobs:
           fi
 
       - name: Approve PR
-        if: steps.find.outputs.found == 'true'
+        if: success() && steps.find.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

- Add `gh pr review --approve` step to the `validate-attestation` CI job, restoring the PR approval that auto-merge requires to satisfy branch protection's "1 approving review" rule
- The `claude-review` job removed in #2425 was the sole source of this approval — no other job provides an unconditional approval
- `validate-attestation` is the right home because it always runs (no conditional file-change filter) and already verifies all checks passed

## What changed

- Added `pull-requests: write` permission to `validate-attestation` job
- Added "Approve PR" step after successful validation that calls `gh pr review --approve` with a structured body containing the validated commit SHA and gate summary

## How it was before

1. `claude-review` job ran on every non-draft PR
2. On pass, it called `gh pr review --approve`
3. This satisfied branch protection's "1 approving review" requirement
4. `auto-merge` could then `gh pr merge --squash`

## What broke (PR #2425)

1. `claude-review` removed as redundant (reviews now run locally)
2. No other job provides the PR approval
3. `auto-merge` fails with "the base branch policy prohibits the merge"

Closes swamp-club#2100

🤖 Generated with [Claude Code](https://claude.com/claude-code)