### PR TITLE
fix(testing): add .warning() method to mock Logger (swamp-club#2098)

### DIFF
--- a/packages/testing/report_test_context.ts
+++ b/packages/testing/report_test_context.ts
@@ -149,6 +149,9 @@ export function createReportTestContext(
     warn(message: string, ...args: unknown[]) {
       captureLog("warning", message, args);
     },
+    warning(message: string, ...args: unknown[]) {
+      captureLog("warning", message, args);
+    },
     error(message: string, ...args: unknown[]) {
       captureLog("error", message, args);
     },

--- a/packages/testing/test_context.ts
+++ b/packages/testing/test_context.ts
@@ -285,6 +285,9 @@ export function createModelTestContext(
     warn(message: string, ...args: unknown[]) {
       captureLog("warning", message, args);
     },
+    warning(message: string, ...args: unknown[]) {
+      captureLog("warning", message, args);
+    },
     error(message: string, ...args: unknown[]) {
       captureLog("error", message, args);
     },

--- a/packages/testing/test_context_test.ts
+++ b/packages/testing/test_context_test.ts
@@ -226,6 +226,20 @@ Deno.test("createModelTestContext: logger captures log entries", () => {
   assertEquals(getLogsByLevel("warning").length, 1);
 });
 
+Deno.test("createModelTestContext: logger.warning() captures with warning level", () => {
+  const { context, getLogs, getLogsByLevel } = createModelTestContext();
+
+  context.logger.warning("warning msg");
+
+  assertEquals(getLogs().length, 1);
+  assertEquals(getLogs()[0], {
+    level: "warning",
+    message: "warning msg",
+    args: [],
+  });
+  assertEquals(getLogsByLevel("warning").length, 1);
+});
+
 Deno.test("createModelTestContext: logger captures extra args", () => {
   const { context, getLogs } = createModelTestContext();
 

--- a/packages/testing/types.ts
+++ b/packages/testing/types.ts
@@ -129,6 +129,7 @@ export interface Logger {
   debug(message: string, ...args: unknown[]): void;
   info(message: string, ...args: unknown[]): void;
   warn(message: string, ...args: unknown[]): void;
+  warning(message: string, ...args: unknown[]): void;
   error(message: string, ...args: unknown[]): void;
   fatal(message: string, ...args: unknown[]): void;
 }


### PR DESCRIPTION
## Summary

- Add `.warning()` method to the `Logger` interface in `packages/testing/types.ts` so the mock structurally matches the real LogTape `Logger` used at runtime
- Add `.warning()` method to the mock logger objects in `test_context.ts` and `report_test_context.ts`
- Add test coverage verifying `context.logger.warning()` captures entries with the `"warning"` level

Fixes swamp-club#2098

## Context

`createModelTestContext()` from `@swamp-club/swamp-testing` returned a `context.logger` with `.warn()` but not `.warning()`. The real runtime (LogTape) exposes both as aliases. Extension authors calling `ctx.logger.warning()` — matching the documented API — got `TS2345` type errors in tests and `TypeError` at runtime against the mock.

## Test plan

- [x] New test: `logger.warning() captures with warning level`
- [x] Existing tests pass (30/30 in `test_context_test.ts`)
- [x] Type-check passes (`deno check` on all affected files)
- [x] Full verification workflow passed (build, reviews, skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019snVD5BRAPAcbPnWfEQQPa