### PR TITLE
fix(serve): reload workflows from pulled extensions during hot reload

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -23,7 +23,10 @@ import {
   type GlobalOptions,
   resolveRepoDir,
 } from "../context.ts";
-import { requireInitializedRepoUnlocked } from "../repo_context.ts";
+import {
+  getSourceWorkflowDirs,
+  requireInitializedRepoUnlocked,
+} from "../repo_context.ts";
 import { UserError } from "../../domain/errors.ts";
 import { parseTimeout } from "../duration_parser.ts";
 import { buildServeAuthConfig } from "../../domain/access/serve_auth_config.ts";
@@ -94,6 +97,7 @@ import {
 } from "../../presentation/output/serve_daemon_output.ts";
 import { groupCommandAction } from "../group_action.ts";
 import {
+  enumeratePulledExtensionDirs,
   normalizeFireTime,
   ScheduledExecutionService,
   type TriggerOverride,
@@ -4323,13 +4327,34 @@ export const serveCommand = new Command()
           return;
         }
         logger.info("SIGHUP received, reloading pulled extensions...");
-        const reloadOptions = scheduledExecution
-          ? {
-            triggerOverrideUpdater: (
-              overrides: ReadonlyMap<string, TriggerOverride>,
-            ) => scheduledExecution!.updateTriggerOverrides(overrides),
-          }
-          : undefined;
+        const extWorkflowRepo = repoContext.extensionWorkflowRepo;
+        const reloadOptions: import("../../serve/extension_reload.ts").ServeReloadOptions =
+          {
+            triggerOverrideUpdater: scheduledExecution
+              ? (overrides: ReadonlyMap<string, TriggerOverride>) =>
+                scheduledExecution!.updateTriggerOverrides(overrides)
+              : undefined,
+            workflowReloader: extWorkflowRepo
+              ? async () => {
+                const sourceWfDirs = await getSourceWorkflowDirs(
+                  resolvedRepoDir,
+                );
+                const pulledWfDirs = await enumeratePulledExtensionDirs(
+                  extensionLockfilePath,
+                  resolvedRepoDir,
+                  "workflows",
+                );
+                extWorkflowRepo.updateAdditionalDirs([
+                  ...sourceWfDirs,
+                  ...pulledWfDirs,
+                ]);
+                if (scheduledExecution) {
+                  await scheduledExecution.rescanWorkflows();
+                }
+                return pulledWfDirs.length;
+              }
+              : undefined,
+          };
         performServeReload(
           resolvedRepoDir,
           extensionLockfilePath,
@@ -4338,6 +4363,12 @@ export const serveCommand = new Command()
           .then((result) => {
             if (result.success) {
               logger.info`Hot-reloaded ${result.reloadedCount} type(s)`;
+              if (result.workflowsReloaded && result.workflowsReloaded > 0) {
+                logger.info(
+                  "Refreshed {count} extension workflow dir(s)",
+                  { count: result.workflowsReloaded },
+                );
+              }
               if (
                 result.triggerOverridesChanged &&
                 result.triggerOverridesChanged > 0

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -3295,6 +3295,29 @@ export const serveCommand = new Command()
       connectionCtx.scheduledExecution = scheduledExecution;
     }
 
+    // Wire workflow reloader for hot-reload: re-enumerates pulled extension
+    // workflow dirs and rescans schedules. Built here (cli layer) so the
+    // serve handlers never import from src/cli/.
+    const extWorkflowRepo = repoContext.extensionWorkflowRepo;
+    if (extWorkflowRepo) {
+      connectionCtx.workflowReloader = async () => {
+        const sourceWfDirs = await getSourceWorkflowDirs(resolvedRepoDir);
+        const pulledWfDirs = await enumeratePulledExtensionDirs(
+          extensionLockfilePath,
+          resolvedRepoDir,
+          "workflows",
+        );
+        extWorkflowRepo.updateAdditionalDirs([
+          ...sourceWfDirs,
+          ...pulledWfDirs,
+        ]);
+        if (connectionCtx.scheduledExecution) {
+          await connectionCtx.scheduledExecution.rescanWorkflows();
+        }
+        return pulledWfDirs.length;
+      };
+    }
+
     // Parse group refresh interval and construct service
     let collectiveRefreshService:
       | import("../../serve/collective_refresh_service.ts").CollectiveRefreshService
@@ -4327,33 +4350,13 @@ export const serveCommand = new Command()
           return;
         }
         logger.info("SIGHUP received, reloading pulled extensions...");
-        const extWorkflowRepo = repoContext.extensionWorkflowRepo;
-        const reloadOptions: import("../../serve/extension_reload.ts").ServeReloadOptions =
-          {
+        const reloadOptions:
+          import("../../serve/extension_reload.ts").ServeReloadOptions = {
             triggerOverrideUpdater: scheduledExecution
               ? (overrides: ReadonlyMap<string, TriggerOverride>) =>
                 scheduledExecution!.updateTriggerOverrides(overrides)
               : undefined,
-            workflowReloader: extWorkflowRepo
-              ? async () => {
-                const sourceWfDirs = await getSourceWorkflowDirs(
-                  resolvedRepoDir,
-                );
-                const pulledWfDirs = await enumeratePulledExtensionDirs(
-                  extensionLockfilePath,
-                  resolvedRepoDir,
-                  "workflows",
-                );
-                extWorkflowRepo.updateAdditionalDirs([
-                  ...sourceWfDirs,
-                  ...pulledWfDirs,
-                ]);
-                if (scheduledExecution) {
-                  await scheduledExecution.rescanWorkflows();
-                }
-                return pulledWfDirs.length;
-              }
-              : undefined,
+            workflowReloader: connectionCtx.workflowReloader,
           };
         performServeReload(
           resolvedRepoDir,

--- a/src/cli/repo_context.ts
+++ b/src/cli/repo_context.ts
@@ -127,7 +127,9 @@ import { resolveGitMainWorktreeRoot } from "../infrastructure/persistence/git_wo
  * Returns an empty array if no sources are configured or file doesn't exist.
  */
 const sourceWorkflowDirCache = new Map<string, string[]>();
-async function getSourceWorkflowDirs(repoDir: string): Promise<string[]> {
+export async function getSourceWorkflowDirs(
+  repoDir: string,
+): Promise<string[]> {
   const cached = sourceWorkflowDirCache.get(repoDir);
   if (cached) return cached;
   const sourcesConfig = await readSwampSources(repoDir);

--- a/src/infrastructure/persistence/extension_workflow_repository.ts
+++ b/src/infrastructure/persistence/extension_workflow_repository.ts
@@ -46,13 +46,19 @@ const MANIFEST_FILENAMES = new Set(["manifest.yaml", "manifest.yml"]);
  * definition; `manifest.yaml` and `manifest.yml` are skipped.
  */
 export class ExtensionWorkflowRepository implements WorkflowRepository {
-  private readonly workflowsDirs: string[];
+  private readonly baseDir: string;
+  private workflowsDirs: string[];
 
   constructor(
     workflowsDir: string,
     additionalDirs?: string[],
   ) {
+    this.baseDir = workflowsDir;
     this.workflowsDirs = [workflowsDir, ...(additionalDirs ?? [])];
+  }
+
+  updateAdditionalDirs(additionalDirs: string[]): void {
+    this.workflowsDirs = [this.baseDir, ...additionalDirs];
   }
 
   async findById(id: WorkflowId): Promise<Workflow | null> {

--- a/src/infrastructure/persistence/extension_workflow_repository_test.ts
+++ b/src/infrastructure/persistence/extension_workflow_repository_test.ts
@@ -284,6 +284,93 @@ Deno.test("ExtensionWorkflowRepository findPath skips manifest.yaml", async () =
   });
 });
 
+Deno.test("ExtensionWorkflowRepository updateAdditionalDirs: discovers workflows from newly added dirs", async () => {
+  await withTempDir(async (baseDir) => {
+    await withTempDir(async (additionalDir) => {
+      // Base dir has one workflow
+      const baseWorkflow = createWorkflowYaml("base-workflow");
+      await Deno.writeTextFile(
+        join(baseDir, "base.yaml"),
+        stringifyYaml(baseWorkflow),
+      );
+
+      const repo = new ExtensionWorkflowRepository(baseDir);
+      let workflows = await repo.findAll();
+      assertEquals(workflows.length, 1);
+      assertEquals(workflows[0].name, "base-workflow");
+
+      // Additional dir has another workflow
+      const additionalWorkflow = createWorkflowYaml("additional-workflow");
+      await Deno.writeTextFile(
+        join(additionalDir, "additional.yaml"),
+        stringifyYaml(additionalWorkflow),
+      );
+
+      // Update dirs to include the additional directory
+      repo.updateAdditionalDirs([additionalDir]);
+      workflows = await repo.findAll();
+      assertEquals(workflows.length, 2);
+
+      const names = workflows.map((w) => w.name).sort();
+      assertEquals(names, ["additional-workflow", "base-workflow"]);
+    });
+  });
+});
+
+Deno.test("ExtensionWorkflowRepository updateAdditionalDirs: preserves base dir", async () => {
+  await withTempDir(async (baseDir) => {
+    const baseWorkflow = createWorkflowYaml("base-workflow");
+    await Deno.writeTextFile(
+      join(baseDir, "base.yaml"),
+      stringifyYaml(baseWorkflow),
+    );
+
+    const repo = new ExtensionWorkflowRepository(baseDir, ["/nonexistent"]);
+
+    // Replace additional dirs with empty list
+    repo.updateAdditionalDirs([]);
+    const workflows = await repo.findAll();
+
+    // Base dir workflow is still found
+    assertEquals(workflows.length, 1);
+    assertEquals(workflows[0].name, "base-workflow");
+  });
+});
+
+Deno.test("ExtensionWorkflowRepository updateAdditionalDirs: replaces previous additional dirs", async () => {
+  await withTempDir(async (baseDir) => {
+    await withTempDir(async (dirA) => {
+      await withTempDir(async (dirB) => {
+        const workflowA = createWorkflowYaml("workflow-a");
+        await Deno.writeTextFile(
+          join(dirA, "a.yaml"),
+          stringifyYaml(workflowA),
+        );
+        const workflowB = createWorkflowYaml("workflow-b");
+        await Deno.writeTextFile(
+          join(dirB, "b.yaml"),
+          stringifyYaml(workflowB),
+        );
+
+        const repo = new ExtensionWorkflowRepository(baseDir, [dirA]);
+        let workflows = await repo.findAll();
+        assertEquals(
+          workflows.map((w) => w.name),
+          ["workflow-a"],
+        );
+
+        // Replace dirA with dirB
+        repo.updateAdditionalDirs([dirB]);
+        workflows = await repo.findAll();
+        assertEquals(
+          workflows.map((w) => w.name),
+          ["workflow-b"],
+        );
+      });
+    });
+  });
+});
+
 Deno.test("ExtensionWorkflowRepository delete throws UserError", async () => {
   await withTempDir(async (dir) => {
     const repo = new ExtensionWorkflowRepository(dir);

--- a/src/infrastructure/persistence/repository_factory.ts
+++ b/src/infrastructure/persistence/repository_factory.ts
@@ -394,6 +394,7 @@ export interface RepositoryContext {
   unifiedDataRepo: FileSystemUnifiedDataRepository;
   outputRepo: YamlOutputRepository;
   workflowRepo: WorkflowRepository;
+  extensionWorkflowRepo: ExtensionWorkflowRepository | null;
   workflowRunRepo: YamlWorkflowRunRepository;
   vaultConfigRepo: YamlVaultConfigRepository;
   catalogStore: CatalogStore;
@@ -529,6 +530,7 @@ export function createRepositoryContext(
     unifiedDataRepo,
     outputRepo,
     workflowRepo,
+    extensionWorkflowRepo,
     workflowRunRepo,
     vaultConfigRepo,
     catalogStore,

--- a/src/libswamp/workflows/scheduled_execution.ts
+++ b/src/libswamp/workflows/scheduled_execution.ts
@@ -238,6 +238,14 @@ export class ScheduledExecutionService {
   }
 
   /**
+   * Re-scans all workflows and registers any new schedules.
+   * Called during hot reload after extension workflow directories are updated.
+   */
+  async rescanWorkflows(): Promise<void> {
+    await this.watcher.scanExisting();
+  }
+
+  /**
    * Returns all registered schedules and their next fire times.
    */
   listSchedules(): Array<ScheduleEntry & { workflowName: string }> {

--- a/src/libswamp/workflows/scheduled_execution_test.ts
+++ b/src/libswamp/workflows/scheduled_execution_test.ts
@@ -758,6 +758,37 @@ Deno.test("updateTriggerOverrides: override for unknown workflow is skipped", as
   await service.stop();
 });
 
+Deno.test("ScheduledExecutionService: rescanWorkflows registers new workflows added after start", async () => {
+  const wf1 = createTestWorkflow("existing-wf", "0 * * * *");
+  const workflows = [wf1];
+
+  const mockRepo = createMockWorkflowRepo(workflows);
+  const service = new ScheduledExecutionService({
+    workflowRepo: mockRepo,
+    repoDir: "/tmp/nonexistent-test-repo",
+    executeWorkflow: () => Promise.resolve(),
+  });
+
+  await service.start();
+
+  let schedules = service.listSchedules();
+  assertEquals(schedules.length, 1);
+  assertEquals(schedules[0].workflowName, "existing-wf");
+
+  // Simulate a new workflow being added to the repo (e.g., via extension pull + reload)
+  const wf2 = createTestWorkflow("new-wf", "30 * * * *");
+  workflows.push(wf2);
+
+  await service.rescanWorkflows();
+
+  schedules = service.listSchedules();
+  assertEquals(schedules.length, 2);
+  const names = schedules.map((s) => s.workflowName).sort();
+  assertEquals(names, ["existing-wf", "new-wf"]);
+
+  await service.stop();
+});
+
 Deno.test("normalizeFireTime: truncates milliseconds and replaces colons for Windows compat", () => {
   assertEquals(
     normalizeFireTime(new Date("2026-08-01T12:30:45.123Z")),

--- a/src/serve/extension_reload.ts
+++ b/src/serve/extension_reload.ts
@@ -251,6 +251,7 @@ export interface ServeReloadOptions {
   triggerOverrideUpdater?: (
     overrides: ReadonlyMap<string, TriggerOverride>,
   ) => Promise<number>;
+  workflowReloader?: () => Promise<number>;
 }
 
 export async function performServeReload(
@@ -271,6 +272,7 @@ export async function performServeReload(
   const errors: string[] = [];
   let reloadedCount = 0;
   let triggerOverridesChanged = 0;
+  let workflowsReloaded = 0;
 
   try {
     reloadedCount = await reloadPulledExtensions(
@@ -286,6 +288,17 @@ export async function performServeReload(
         "Failed to refresh trust list: " +
           (err instanceof Error ? err.message : String(err)),
       );
+    }
+
+    if (options?.workflowReloader) {
+      try {
+        workflowsReloaded = await options.workflowReloader();
+      } catch (err) {
+        errors.push(
+          "Failed to reload workflows: " +
+            (err instanceof Error ? err.message : String(err)),
+        );
+      }
     }
 
     if (options?.triggerOverrideUpdater) {
@@ -305,7 +318,13 @@ export async function performServeReload(
       }
     }
 
-    return { success: true, reloadedCount, triggerOverridesChanged, errors };
+    return {
+      success: true,
+      reloadedCount,
+      triggerOverridesChanged,
+      workflowsReloaded,
+      errors,
+    };
   } catch (err) {
     return {
       success: false,

--- a/src/serve/extension_reload_test.ts
+++ b/src/serve/extension_reload_test.ts
@@ -160,9 +160,9 @@ Deno.test("performServeReload: calls workflowReloader and includes count in resp
       tmpDir,
       join(tmpDir, "nonexistent_lockfile.json"),
       {
-        workflowReloader: async () => {
+        workflowReloader: () => {
           reloaderCalled = true;
-          return 4;
+          return Promise.resolve(4);
         },
       },
     );

--- a/src/serve/extension_reload_test.ts
+++ b/src/serve/extension_reload_test.ts
@@ -150,6 +150,53 @@ Deno.test("performServeReload: passes empty map when serve.yaml has no triggers"
   }
 });
 
+Deno.test("performServeReload: calls workflowReloader and includes count in response", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(join(tmpDir, ".swamp"), { recursive: true });
+
+    let reloaderCalled = false;
+    const result = await performServeReload(
+      tmpDir,
+      join(tmpDir, "nonexistent_lockfile.json"),
+      {
+        workflowReloader: async () => {
+          reloaderCalled = true;
+          return 4;
+        },
+      },
+    );
+
+    assertEquals(result.success, true);
+    assertEquals(reloaderCalled, true);
+    assertEquals(result.workflowsReloaded, 4);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+Deno.test("performServeReload: workflowReloader error is soft failure", async () => {
+  const tmpDir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(join(tmpDir, ".swamp"), { recursive: true });
+
+    const result = await performServeReload(
+      tmpDir,
+      join(tmpDir, "nonexistent_lockfile.json"),
+      {
+        workflowReloader: () =>
+          Promise.reject(new Error("workflow scan failed")),
+      },
+    );
+
+    assertEquals(result.success, true);
+    assertStringIncludes(result.errors[0], "Failed to reload workflows");
+    assertStringIncludes(result.errors[0], "workflow scan failed");
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
 Deno.test("performServeReload: trigger override updater error is soft failure", async () => {
   const tmpDir = await Deno.makeTempDir();
   try {

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -71,7 +71,6 @@ import {
   extensionRm,
   extensionSearch,
   type ExtensionSearchDeps,
-  enumeratePulledExtensionDirs,
   extensionUpdate,
   LockfileRepository,
   parseExtensionRef,
@@ -158,7 +157,6 @@ import {
   resolveLockfilePath,
   type ServeReloadOptions,
 } from "../extension_reload.ts";
-import { getSourceWorkflowDirs } from "../../cli/repo_context.ts";
 import { isReservedVaultName } from "./vault_handlers.ts";
 
 /**
@@ -1850,30 +1848,12 @@ export async function handleServeReload(
       ctx.repoDir,
       ctx.datastoreResolver,
     );
-    const extWorkflowRepo = ctx.repoContext.extensionWorkflowRepo;
     const reloadOptions: ServeReloadOptions = {
       triggerOverrideUpdater: ctx.scheduledExecution
         ? (overrides: ReadonlyMap<string, TriggerOverride>) =>
           ctx.scheduledExecution!.updateTriggerOverrides(overrides)
         : undefined,
-      workflowReloader: extWorkflowRepo
-        ? async () => {
-          const sourceWfDirs = await getSourceWorkflowDirs(ctx.repoDir);
-          const pulledWfDirs = await enumeratePulledExtensionDirs(
-            lockfilePath,
-            ctx.repoDir,
-            "workflows",
-          );
-          extWorkflowRepo.updateAdditionalDirs([
-            ...sourceWfDirs,
-            ...pulledWfDirs,
-          ]);
-          if (ctx.scheduledExecution) {
-            await ctx.scheduledExecution.rescanWorkflows();
-          }
-          return pulledWfDirs.length;
-        }
-        : undefined,
+      workflowReloader: ctx.workflowReloader,
     };
     const result = await performServeReload(
       ctx.repoDir,

--- a/src/serve/handlers/admin_handlers.ts
+++ b/src/serve/handlers/admin_handlers.ts
@@ -71,6 +71,7 @@ import {
   extensionRm,
   extensionSearch,
   type ExtensionSearchDeps,
+  enumeratePulledExtensionDirs,
   extensionUpdate,
   LockfileRepository,
   parseExtensionRef,
@@ -155,7 +156,9 @@ import {
 import {
   performServeReload,
   resolveLockfilePath,
+  type ServeReloadOptions,
 } from "../extension_reload.ts";
+import { getSourceWorkflowDirs } from "../../cli/repo_context.ts";
 import { isReservedVaultName } from "./vault_handlers.ts";
 
 /**
@@ -1847,13 +1850,31 @@ export async function handleServeReload(
       ctx.repoDir,
       ctx.datastoreResolver,
     );
-    const reloadOptions = ctx.scheduledExecution
-      ? {
-        triggerOverrideUpdater: (
-          overrides: ReadonlyMap<string, TriggerOverride>,
-        ) => ctx.scheduledExecution!.updateTriggerOverrides(overrides),
-      }
-      : undefined;
+    const extWorkflowRepo = ctx.repoContext.extensionWorkflowRepo;
+    const reloadOptions: ServeReloadOptions = {
+      triggerOverrideUpdater: ctx.scheduledExecution
+        ? (overrides: ReadonlyMap<string, TriggerOverride>) =>
+          ctx.scheduledExecution!.updateTriggerOverrides(overrides)
+        : undefined,
+      workflowReloader: extWorkflowRepo
+        ? async () => {
+          const sourceWfDirs = await getSourceWorkflowDirs(ctx.repoDir);
+          const pulledWfDirs = await enumeratePulledExtensionDirs(
+            lockfilePath,
+            ctx.repoDir,
+            "workflows",
+          );
+          extWorkflowRepo.updateAdditionalDirs([
+            ...sourceWfDirs,
+            ...pulledWfDirs,
+          ]);
+          if (ctx.scheduledExecution) {
+            await ctx.scheduledExecution.rescanWorkflows();
+          }
+          return pulledWfDirs.length;
+        }
+        : undefined,
+    };
     const result = await performServeReload(
       ctx.repoDir,
       lockfilePath,
@@ -1863,6 +1884,12 @@ export async function handleServeReload(
     if (result.success) {
       logger
         .info`Extension reload completed: ${result.reloadedCount} type(s) reloaded (requested by ${who})`;
+      if (result.workflowsReloaded && result.workflowsReloaded > 0) {
+        logger.info(
+          "Refreshed {count} extension workflow dir(s) (requested by {who})",
+          { count: result.workflowsReloaded, who },
+        );
+      }
       if (
         result.triggerOverridesChanged &&
         result.triggerOverridesChanged > 0

--- a/src/serve/handlers/shared.ts
+++ b/src/serve/handlers/shared.ts
@@ -164,6 +164,8 @@ export interface ConnectionContext {
   hotReload?: boolean;
   /** Scheduled execution service — used by serve.reload to update trigger overrides. */
   scheduledExecution?: ScheduledExecutionService;
+  /** Reloads extension workflow directories and rescans schedules during hot reload. */
+  workflowReloader?: () => Promise<number>;
   /** Inverted resolvedAdmins map: OAuth sub → username. Populated at startup in OAuth mode. */
   resolvedUserNames?: Record<string, string>;
   /** Resolved serve options — used by serve.config endpoint. */

--- a/src/serve/protocol.ts
+++ b/src/serve/protocol.ts
@@ -1036,6 +1036,7 @@ export interface ServeReloadResponse {
   success: boolean;
   reloadedCount: number;
   triggerOverridesChanged?: number;
+  workflowsReloaded?: number;
   errors: string[];
 }
 


### PR DESCRIPTION
## Summary

- `serve reload` updated existing model/vault/datastore/report types but silently skipped workflows — new workflow definitions from extensions pulled after server start were only discovered on a full restart
- Added a `workflowReloader` callback to `performServeReload()` that re-enumerates pulled extension workflow directories, updates the `ExtensionWorkflowRepository`'s directory list, and rescans for new workflow schedules via `ScheduledExecutionService`
- Both SIGHUP and WebSocket reload paths now discover new extension workflows without requiring a server restart

## Changes

- `ExtensionWorkflowRepository`: added `updateAdditionalDirs()` to allow runtime directory list updates (stores base dir separately)
- `RepositoryContext`: exposed `extensionWorkflowRepo` for callers that need directory management
- `ScheduledExecutionService`: added `rescanWorkflows()` delegating to `watcher.scanExisting()`
- `ServeReloadOptions`/`performServeReload()`: added `workflowReloader` callback (follows existing `triggerOverrideUpdater` pattern)
- `ServeReloadResponse`: added `workflowsReloaded` count
- `ConnectionContext`: carries the pre-built `workflowReloader` callback so serve handlers respect the DDD layer boundary (serve → cli)
- `getSourceWorkflowDirs`: exported from `repo_context.ts` (cached, idempotent)

## Test plan

- [x] Unit tests for `ExtensionWorkflowRepository.updateAdditionalDirs()` — discovers workflows from new dirs, preserves base dir, replaces previous additional dirs
- [x] Unit test for `ScheduledExecutionService.rescanWorkflows()` — registers new scheduled workflows added after start
- [x] Unit tests for `performServeReload()` — `workflowReloader` callback invoked and count included in response; error is soft failure
- [x] Architecture fitness test passes (no new serve→cli layer violations)
- [x] Full verification workflow: lint, fmt, type-check, tests (11503 passed), compile, code review, adversarial review, UX review

Closes swamp-club#2092

🤖 Generated with [Claude Code](https://claude.com/claude-code)