### PR TITLE
fix(serve): use pre-warmed repos in all serve handlers (swamp-club#2085)

### DIFF
--- a/integration/serve_deps_rules_test.ts
+++ b/integration/serve_deps_rules_test.ts
@@ -1,0 +1,72 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals } from "@std/assert";
+import { walk } from "@std/fs/walk";
+import { join, relative, SEPARATOR } from "@std/path";
+
+const ROOT = join(import.meta.dirname!, "..");
+const SERVE_HANDLERS_DIR = join(ROOT, "src", "serve", "handlers");
+
+function normalise(p: string): string {
+  return SEPARATOR === "\\" ? p.replaceAll("\\", "/") : p;
+}
+
+Deno.test("serve handlers must not construct fresh definition or workflow repos", async () => {
+  const violations: string[] = [];
+
+  for await (
+    const entry of walk(SERVE_HANDLERS_DIR, {
+      exts: [".ts"],
+      skip: [/_test\.ts$/],
+    })
+  ) {
+    const content = await Deno.readTextFile(entry.path);
+    const rel = normalise(relative(ROOT, entry.path));
+
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (
+        line.includes("new YamlDefinitionRepository(") ||
+        line.includes("new YamlWorkflowRepository(")
+      ) {
+        // Auto-definition repos scoped to autoDefinitionsDir are
+        // write-only repos for direct-type-execution and file grants —
+        // they don't do general definition lookups, so the path
+        // divergence doesn't apply.
+        if (line.includes("autoDefRepo")) continue;
+        violations.push(`${rel}:${i + 1}: ${line.trim()}`);
+      }
+    }
+  }
+
+  assertEquals(
+    violations,
+    [],
+    "Serve handlers must use ctx.repoContext repos (pre-warmed at boot) " +
+      "instead of constructing fresh YamlDefinitionRepository or " +
+      "YamlWorkflowRepository instances. Fresh repos miss the " +
+      "datastore-resolved paths under managedConfig + namespace. " +
+      "Pass the pre-warmed repo via the injectedDefinitionRepo / " +
+      "injectedWorkflowRepo parameter on the libswamp create*Deps " +
+      "function instead.\n\nViolations:\n" +
+      violations.join("\n"),
+  );
+});

--- a/src/cli/context_test.ts
+++ b/src/cli/context_test.ts
@@ -106,8 +106,14 @@ Deno.test("getOutputModeFromArgs returns json when --json is present", () => {
 // ============================================================================
 
 Deno.test("getRepoDirFromArgs returns cwd when no --repo-dir flag", () => {
-  assertEquals(getRepoDirFromArgs([]), Deno.cwd());
-  assertEquals(getRepoDirFromArgs(["model", "create"]), Deno.cwd());
+  const saved = Deno.env.get("SWAMP_REPO_DIR");
+  Deno.env.delete("SWAMP_REPO_DIR");
+  try {
+    assertEquals(getRepoDirFromArgs([]), Deno.cwd());
+    assertEquals(getRepoDirFromArgs(["model", "create"]), Deno.cwd());
+  } finally {
+    if (saved !== undefined) Deno.env.set("SWAMP_REPO_DIR", saved);
+  }
 });
 
 Deno.test("getRepoDirFromArgs parses --repo-dir with space separator", () => {
@@ -138,7 +144,16 @@ Deno.test("getRepoDirFromArgs resolves relative paths to absolute", () => {
 });
 
 Deno.test("getRepoDirFromArgs returns cwd when --repo-dir is last arg with no value", () => {
-  assertEquals(getRepoDirFromArgs(["model", "run", "--repo-dir"]), Deno.cwd());
+  const saved = Deno.env.get("SWAMP_REPO_DIR");
+  Deno.env.delete("SWAMP_REPO_DIR");
+  try {
+    assertEquals(
+      getRepoDirFromArgs(["model", "run", "--repo-dir"]),
+      Deno.cwd(),
+    );
+  } finally {
+    if (saved !== undefined) Deno.env.set("SWAMP_REPO_DIR", saved);
+  }
 });
 
 Deno.test("getRepoDirFromArgs finds flag among other args", () => {

--- a/src/infrastructure/tracing/otel_init.ts
+++ b/src/infrastructure/tracing/otel_init.ts
@@ -151,8 +151,9 @@ export async function shutdownTracing(): Promise<void> {
     }
     providerRef = undefined;
 
-    // Disable global context manager and propagator
+    // Disable global context manager, propagator, and tracer provider
     const contextApi = await import("@opentelemetry/api");
+    contextApi.trace.disable();
     contextApi.context.disable();
     contextApi.propagation.disable();
   }

--- a/src/libswamp/models/create.ts
+++ b/src/libswamp/models/create.ts
@@ -90,13 +90,15 @@ export interface ModelCreateDeps {
 export async function createModelCreateDeps(
   repoDir: string,
   definitionsDir?: string,
+  injectedDefinitionRepo?: YamlDefinitionRepository,
 ): Promise<ModelCreateDeps> {
   await modelRegistry.ensureLoaded();
-  const definitionRepo = new YamlDefinitionRepository(
-    repoDir,
-    undefined,
-    definitionsDir,
-  );
+  const definitionRepo = injectedDefinitionRepo ??
+    new YamlDefinitionRepository(
+      repoDir,
+      undefined,
+      definitionsDir,
+    );
   return {
     resolveModelType: (typeArg) => {
       const modelType = ModelType.create(typeArg);

--- a/src/libswamp/models/delete.ts
+++ b/src/libswamp/models/delete.ts
@@ -118,16 +118,18 @@ export function createModelDeleteDeps(
   datastoreResolver?: DatastorePathResolver,
   injectedDataRepo?: FileSystemUnifiedDataRepository,
   markDirty?: MarkDirtyHook,
+  injectedDefinitionRepo?: YamlDefinitionRepository,
 ): ModelDeleteDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const definitionRepo = new YamlDefinitionRepository(
-    repoDir,
-    undefined,
-    undefined,
-    undefined,
-    markDirty,
-  );
+  const definitionRepo = injectedDefinitionRepo ??
+    new YamlDefinitionRepository(
+      repoDir,
+      undefined,
+      undefined,
+      undefined,
+      markDirty,
+    );
   const evaluatedDefinitionRepo = new YamlEvaluatedDefinitionRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.definitionsEvaluated),

--- a/src/libswamp/models/edit.ts
+++ b/src/libswamp/models/edit.ts
@@ -80,8 +80,12 @@ export interface ModelEditDeps {
 }
 
 /** Wires real infrastructure into ModelEditDeps. */
-export function createModelEditDeps(repoDir: string): ModelEditDeps {
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
+export function createModelEditDeps(
+  repoDir: string,
+  injectedDefinitionRepo?: YamlDefinitionRepository,
+): ModelEditDeps {
+  const definitionRepo = injectedDefinitionRepo ??
+    new YamlDefinitionRepository(repoDir);
   const editorService = new EditorService();
   return {
     lookupDefinition: (idOrName) =>

--- a/src/libswamp/models/evaluate.ts
+++ b/src/libswamp/models/evaluate.ts
@@ -95,10 +95,12 @@ export function createModelEvaluateDeps(
   datastoreResolver?: DatastorePathResolver,
   injectedDataRepo?: FileSystemUnifiedDataRepository,
   injectedCatalogStore?: CatalogStore,
+  injectedDefinitionRepo?: YamlDefinitionRepository,
 ): ModelEvaluateDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const definitionRepo = injectedDefinitionRepo ??
+    new YamlDefinitionRepository(repoDir);
   // When a shared catalog store / data repo is injected (e.g. by serve
   // handlers passing the process-scoped RepositoryContext), reuse it and skip
   // createCatalogStore so we don't open a new file-based SQLite store — and

--- a/src/libswamp/models/get.ts
+++ b/src/libswamp/models/get.ts
@@ -75,9 +75,11 @@ export interface ModelGetDeps {
 /** Wires real infrastructure into ModelGetDeps. */
 export async function createModelGetDeps(
   repoDir: string,
+  injectedDefinitionRepo?: YamlDefinitionRepository,
 ): Promise<ModelGetDeps> {
   await modelRegistry.ensureLoaded();
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const definitionRepo = injectedDefinitionRepo ??
+    new YamlDefinitionRepository(repoDir);
   return {
     lookupDefinition: async (idOrName) => {
       const result = await findDefinitionByIdOrName(definitionRepo, idOrName);

--- a/src/libswamp/models/method_describe.ts
+++ b/src/libswamp/models/method_describe.ts
@@ -63,8 +63,10 @@ export interface ModelMethodDescribeDeps {
 /** Wires real infrastructure into ModelMethodDescribeDeps. */
 export function createModelMethodDescribeDeps(
   repoDir: string,
+  injectedDefinitionRepo?: YamlDefinitionRepository,
 ): ModelMethodDescribeDeps {
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const definitionRepo = injectedDefinitionRepo ??
+    new YamlDefinitionRepository(repoDir);
   return {
     lookupDefinition: (idOrName) =>
       findDefinitionByIdOrName(definitionRepo, idOrName),

--- a/src/libswamp/models/method_history_logs.ts
+++ b/src/libswamp/models/method_history_logs.ts
@@ -109,11 +109,13 @@ export interface ModelMethodHistoryLogsDeps {
 export async function createModelMethodHistoryLogsDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedDefinitionRepo?: YamlDefinitionRepository,
 ): Promise<ModelMethodHistoryLogsDeps> {
   await modelRegistry.ensureLoaded();
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const definitionRepo = injectedDefinitionRepo ??
+    new YamlDefinitionRepository(repoDir);
   const outputRepo = new YamlOutputRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.outputs),

--- a/src/libswamp/models/output_data.ts
+++ b/src/libswamp/models/output_data.ts
@@ -108,6 +108,7 @@ export function createModelOutputDataDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
   injectedDataRepo?: FileSystemUnifiedDataRepository,
+  injectedDefinitionRepo?: YamlDefinitionRepository,
 ): ModelOutputDataDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
@@ -115,7 +116,8 @@ export function createModelOutputDataDeps(
     repoDir,
     dsPath(SWAMP_SUBDIRS.outputs),
   );
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const definitionRepo = injectedDefinitionRepo ??
+    new YamlDefinitionRepository(repoDir);
   // Reuse an injected shared data repo (e.g. serve's process-scoped
   // RepositoryContext) so we don't open a new file-based catalog store — and
   // leak its 3 FDs — on every request.

--- a/src/libswamp/models/output_get.ts
+++ b/src/libswamp/models/output_get.ts
@@ -149,11 +149,13 @@ export interface ModelOutputGetDeps {
 export async function createModelOutputGetDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
+  injectedDefinitionRepo?: YamlDefinitionRepository,
 ): Promise<ModelOutputGetDeps> {
   await modelRegistry.ensureLoaded();
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const definitionRepo = injectedDefinitionRepo ??
+    new YamlDefinitionRepository(repoDir);
   const outputRepo = new YamlOutputRepository(
     repoDir,
     dsPath(SWAMP_SUBDIRS.outputs),

--- a/src/libswamp/models/validate.ts
+++ b/src/libswamp/models/validate.ts
@@ -127,10 +127,12 @@ export function createModelValidateDeps(
   datastoreResolver?: DatastorePathResolver,
   injectedDataRepo?: FileSystemUnifiedDataRepository,
   injectedCatalogStore?: CatalogStore,
+  injectedDefinitionRepo?: YamlDefinitionRepository,
 ): ModelValidateDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const definitionRepo = injectedDefinitionRepo ??
+    new YamlDefinitionRepository(repoDir);
   // When a shared catalog store / data repo is injected (e.g. by serve
   // handlers passing the process-scoped RepositoryContext), reuse it and skip
   // createCatalogStore so we don't open a new file-based SQLite store — and

--- a/src/libswamp/workflows/create.ts
+++ b/src/libswamp/workflows/create.ts
@@ -22,6 +22,7 @@ import { Job } from "../../domain/workflows/job.ts";
 import { Step } from "../../domain/workflows/step.ts";
 import { StepTask } from "../../domain/workflows/step_task.ts";
 import type { WorkflowId } from "../../domain/workflows/workflow_id.ts";
+import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import type { LibSwampContext } from "../context.ts";
 import type { SwampError } from "../errors.ts";
@@ -70,8 +71,9 @@ export interface WorkflowCreateDeps {
 /** Wires real infrastructure into WorkflowCreateDeps. */
 export function createWorkflowCreateDeps(
   repoDir: string,
+  injectedWorkflowRepo?: WorkflowRepository,
 ): WorkflowCreateDeps {
-  const repo = new YamlWorkflowRepository(repoDir);
+  const repo = injectedWorkflowRepo ?? new YamlWorkflowRepository(repoDir);
   return {
     findByName: (name) => repo.findByName(name),
     save: (workflow) => repo.save(workflow),

--- a/src/libswamp/workflows/delete.ts
+++ b/src/libswamp/workflows/delete.ts
@@ -22,6 +22,7 @@ import {
   createWorkflowId,
   type WorkflowId,
 } from "../../domain/workflows/workflow_id.ts";
+import type { WorkflowRepository } from "../../domain/workflows/repositories.ts";
 import { YamlWorkflowRepository } from "../../infrastructure/persistence/yaml_workflow_repository.ts";
 import { YamlWorkflowRunRepository } from "../../infrastructure/persistence/yaml_workflow_run_repository.ts";
 import { YamlEvaluatedWorkflowRepository } from "../../infrastructure/persistence/yaml_evaluated_workflow_repository.ts";
@@ -83,15 +84,17 @@ export function createWorkflowDeleteDeps(
   repoDir: string,
   datastoreResolver?: DatastorePathResolver,
   markDirty?: MarkDirtyHook,
+  injectedWorkflowRepo?: WorkflowRepository,
 ): WorkflowDeleteDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const workflowRepo = new YamlWorkflowRepository(
-    repoDir,
-    undefined,
-    undefined,
-    markDirty,
-  );
+  const workflowRepo = injectedWorkflowRepo ??
+    new YamlWorkflowRepository(
+      repoDir,
+      undefined,
+      undefined,
+      markDirty,
+    );
   const workflowRunRepo = new YamlWorkflowRunRepository(
     repoDir,
     undefined,

--- a/src/libswamp/workflows/evaluate.ts
+++ b/src/libswamp/workflows/evaluate.ts
@@ -119,10 +119,12 @@ export function createWorkflowEvaluateDeps(
   repoDir: string,
   workflowRepo: WorkflowRepository,
   datastoreResolver?: DatastorePathResolver,
+  injectedDefinitionRepo?: YamlDefinitionRepository,
 ): WorkflowEvaluateDeps {
   const dsPath = (subdir: string): string | undefined =>
     datastoreResolver?.resolvePath(subdir);
-  const definitionRepo = new YamlDefinitionRepository(repoDir);
+  const definitionRepo = injectedDefinitionRepo ??
+    new YamlDefinitionRepository(repoDir);
   const catalogStore = createCatalogStore(repoDir, datastoreResolver);
   const dataRepo = new FileSystemUnifiedDataRepository(
     repoDir,

--- a/src/serve/handlers/access_handlers.ts
+++ b/src/serve/handlers/access_handlers.ts
@@ -705,11 +705,10 @@ export async function handleAccessReload(
       }
     }
 
-    const autoDefDir = join(ctx.repoDir, ".swamp", "auto-definitions");
     const autoDefRepo = new YamlDefinitionRepository(
       ctx.repoDir,
       ctx.repoContext.eventBus,
-      autoDefDir,
+      ctx.repoContext.autoDefinitionsDir,
       false,
     );
     const fileGrantStore = createFileGrantStore(

--- a/src/serve/handlers/model_handlers.ts
+++ b/src/serve/handlers/model_handlers.ts
@@ -701,7 +701,10 @@ export async function handleModelMethodDescribe(
   try {
     await modelRegistry.ensureLoaded();
     const libCtx = createLibSwampContext();
-    const deps = createModelMethodDescribeDeps(ctx.repoDir);
+    const deps = createModelMethodDescribeDeps(
+      ctx.repoDir,
+      ctx.repoContext.definitionRepo,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -761,7 +764,10 @@ export async function handleModelGet(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = await createModelGetDeps(ctx.repoDir);
+    const deps = await createModelGetDeps(
+      ctx.repoDir,
+      ctx.repoContext.definitionRepo,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -835,6 +841,7 @@ export async function handleModelCreate(
     const deps = await createModelCreateDeps(
       ctx.repoDir,
       ctx.managedDefinitionsDir,
+      ctx.repoContext.definitionRepo,
     );
 
     let result: Record<string, unknown> | undefined;
@@ -920,6 +927,7 @@ export async function handleModelDelete(
       ctx.datastoreResolver,
       ctx.repoContext.unifiedDataRepo,
       ctx.repoContext.markDirty,
+      ctx.repoContext.definitionRepo,
     );
 
     const preview = await modelDeletePreview(
@@ -1017,7 +1025,11 @@ export async function handleModelOutputGet(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = await createModelOutputGetDeps(ctx.repoDir);
+    const deps = await createModelOutputGetDeps(
+      ctx.repoDir,
+      undefined,
+      ctx.repoContext.definitionRepo,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -1076,6 +1088,7 @@ export async function handleModelOutputData(
       ctx.repoDir,
       ctx.datastoreResolver,
       ctx.repoContext.unifiedDataRepo,
+      ctx.repoContext.definitionRepo,
     );
 
     let result: Record<string, unknown> | undefined;
@@ -1277,7 +1290,11 @@ export async function handleModelMethodHistoryGet(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = await createModelOutputGetDeps(ctx.repoDir);
+    const deps = await createModelOutputGetDeps(
+      ctx.repoDir,
+      undefined,
+      ctx.repoContext.definitionRepo,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -1337,7 +1354,11 @@ export async function handleModelMethodHistoryLogs(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = await createModelMethodHistoryLogsDeps(ctx.repoDir);
+    const deps = await createModelMethodHistoryLogsDeps(
+      ctx.repoDir,
+      undefined,
+      ctx.repoContext.definitionRepo,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -1499,6 +1520,7 @@ export async function handleModelValidate(
       ctx.datastoreResolver,
       ctx.repoContext.unifiedDataRepo,
       ctx.repoContext.catalogStore,
+      ctx.repoContext.definitionRepo,
     );
 
     let result: Record<string, unknown> | undefined;
@@ -1556,6 +1578,7 @@ export async function handleModelEvaluate(
       ctx.datastoreResolver,
       ctx.repoContext.unifiedDataRepo,
       ctx.repoContext.catalogStore,
+      ctx.repoContext.definitionRepo,
     );
 
     let result: Record<string, unknown> | undefined;
@@ -1608,7 +1631,10 @@ export async function handleModelEdit(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createModelEditDeps(ctx.repoDir);
+    const deps = createModelEditDeps(
+      ctx.repoDir,
+      ctx.repoContext.definitionRepo,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(

--- a/src/serve/handlers/workflow_handlers.ts
+++ b/src/serve/handlers/workflow_handlers.ts
@@ -1535,7 +1535,10 @@ export async function handleWorkflowCreate(
 
   try {
     const libCtx = createLibSwampContext();
-    const deps = createWorkflowCreateDeps(ctx.repoDir);
+    const deps = createWorkflowCreateDeps(
+      ctx.repoDir,
+      ctx.repoContext.workflowRepo,
+    );
 
     let result: Record<string, unknown> | undefined;
     await consumeStream(
@@ -1612,6 +1615,7 @@ export async function handleWorkflowDelete(
       ctx.repoDir,
       ctx.datastoreResolver,
       ctx.repoContext.markDirty,
+      ctx.repoContext.workflowRepo,
     );
 
     let result: Record<string, unknown> | undefined;
@@ -1831,6 +1835,7 @@ export async function handleWorkflowEvaluate(
       ctx.repoDir,
       ctx.repoContext.workflowRepo,
       ctx.datastoreResolver,
+      ctx.repoContext.definitionRepo,
     );
 
     let result: Record<string, unknown> | undefined;


### PR DESCRIPTION
## Summary

- All serve handlers for model and workflow operations were constructing fresh
  `YamlDefinitionRepository` / `YamlWorkflowRepository` instances per request.
  These fresh repos resolve their base directory via the module-level
  `managedConfigRegistry`, which can diverge from the boot-time
  datastore-resolved paths under `managedConfig` + namespace configurations.
- Added optional `injectedDefinitionRepo` / `injectedWorkflowRepo` parameters
  to each libswamp `create*Deps` function. Serve handlers now pass the
  pre-warmed `ctx.repoContext` repos, matching the pattern already established
  by `createModelMethodRunDeps` and `createWorkflowRunDeps`.
- Fixed a hardcoded `.swamp/auto-definitions/` path in `access_handlers.ts`
  that missed the datastore-resolved `autoDefinitionsDir` under namespace.
- Fixed `shutdownTracing` to call `trace.disable()` alongside context and
  propagation disable, preventing a parallel test flake where the global
  tracer provider leaked between test files.
- Fixed two `context_test.ts` tests that assumed `SWAMP_REPO_DIR` was unset,
  causing failures when the verification workflow set the env var.
- Added architecture fitness test preventing serve handlers from constructing
  fresh definition or workflow repos.

## Test plan

- [x] 11,498 unit/integration tests pass
- [x] Lint, fmt, type-check clean
- [x] Compile + binary smoke test pass
- [x] Code review: pass (0 findings)
- [x] Adversarial review: pass (0 findings)
- [x] UX review: pass (0 findings)
- [x] Architecture fitness test: pass
- [x] Attestation posted: `e501d425-bc83-411c-8c98-47ebd38ed6f7`

Closes swamp-club#2085

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>