### PR TITLE
fix(tokens): allow re-minting after revoke or expire

### DIFF
--- a/src/domain/models/access/server_token_model.ts
+++ b/src/domain/models/access/server_token_model.ts
@@ -104,9 +104,9 @@ async function mint(
   const existing = await context.readResource!(TOKEN_DATA_NAME);
   if (existing !== null) {
     const parsed = ServerTokenSchema.parse(existing);
-    if (parsed.state !== "revoked") {
+    if (parsed.state !== "revoked" && parsed.state !== "expired") {
       throw new Error(
-        `Server token '${context.definition.name}' already exists — revoke it first`,
+        `Server token '${context.definition.name}' already exists — revoke it or wait for expiry before re-minting`,
       );
     }
   }

--- a/src/domain/models/access/server_token_model_test.ts
+++ b/src/domain/models/access/server_token_model_test.ts
@@ -93,14 +93,17 @@ Deno.test("serverTokenModel: mint after revoke succeeds with fresh credentials",
   assertNotEquals(newPlaintext, oldPlaintext);
 });
 
-Deno.test("serverTokenModel: mint after expire still fails", async () => {
-  const { context } = await mintToken();
+Deno.test("serverTokenModel: mint after expire succeeds with fresh credentials", async () => {
+  const { context, store, vault, plaintext: oldPlaintext } = await mintToken();
   await serverTokenModel.methods.expire.execute({}, context);
-  await assertRejects(
-    () => serverTokenModel.methods.mint.execute(mintArgs, context),
-    Error,
-    "already exists",
-  );
+  assertEquals(store.get("token-main")!.state, "expired");
+  await serverTokenModel.methods.mint.execute(mintArgs, context);
+  const token = store.get("token-main")!;
+  assertEquals(token.state, "active");
+  const newPlaintext = vault.get(
+    `local/${serverTokenSecretKey("user-token-1")}`,
+  )!;
+  assertNotEquals(newPlaintext, oldPlaintext);
 });
 
 Deno.test("serverTokenModel: mint uses default 30-day expiry when durationMs not provided", async () => {

--- a/src/domain/models/worker/enrollment_token_model.ts
+++ b/src/domain/models/worker/enrollment_token_model.ts
@@ -145,9 +145,12 @@ async function mint(
   }
   const existing = await context.readResource!(TOKEN_DATA_NAME);
   if (existing !== null) {
-    throw new Error(
-      `Enrollment token '${context.definition.name}' already exists — revoke it and mint a new name, or pick another name`,
-    );
+    const parsed = EnrollmentTokenSchema.parse(existing);
+    if (parsed.state !== "revoked" && parsed.state !== "expired") {
+      throw new Error(
+        `Enrollment token '${context.definition.name}' already exists — revoke it or wait for expiry before re-minting`,
+      );
+    }
   }
 
   const name = context.definition.name;

--- a/src/domain/models/worker/enrollment_token_model_test.ts
+++ b/src/domain/models/worker/enrollment_token_model_test.ts
@@ -74,13 +74,39 @@ Deno.test("enrollmentTokenModel: mint writes the secret to the vault, never to d
   assertEquals(JSON.stringify(token).includes(plaintext), false);
 });
 
-Deno.test("enrollmentTokenModel: mint twice with the same name fails", async () => {
+Deno.test("enrollmentTokenModel: mint twice with the same name fails when active", async () => {
   const { context } = await mintToken();
   await assertRejects(
     () => enrollmentTokenModel.methods.mint.execute(mintArgs, context),
     Error,
     "already exists",
   );
+});
+
+Deno.test("enrollmentTokenModel: mint after revoke succeeds with fresh credentials", async () => {
+  const { context, store, vault, plaintext: oldPlaintext } = await mintToken();
+  await enrollmentTokenModel.methods.revoke.execute({}, context);
+  assertEquals(store.get("token-main")!.state, "revoked");
+  await enrollmentTokenModel.methods.mint.execute(mintArgs, context);
+  const token = store.get("token-main")!;
+  assertEquals(token.state, "unused");
+  const newPlaintext = vault.get(
+    `local/${tokenSecretKey("ci-runner-3")}`,
+  )!;
+  assertNotEquals(newPlaintext, oldPlaintext);
+});
+
+Deno.test("enrollmentTokenModel: mint after expire succeeds with fresh credentials", async () => {
+  const { context, store, vault, plaintext: oldPlaintext } = await mintToken();
+  await enrollmentTokenModel.methods.expire.execute({}, context);
+  assertEquals(store.get("token-main")!.state, "expired");
+  await enrollmentTokenModel.methods.mint.execute(mintArgs, context);
+  const token = store.get("token-main")!;
+  assertEquals(token.state, "unused");
+  const newPlaintext = vault.get(
+    `local/${tokenSecretKey("ci-runner-3")}`,
+  )!;
+  assertNotEquals(newPlaintext, oldPlaintext);
 });
 
 Deno.test("enrollmentTokenModel: redeem transitions unused → enrolled and binds the machine", async () => {


### PR DESCRIPTION
## Summary

- Enrollment token `mint` unconditionally rejected names with existing data, permanently reserving them after revocation or expiry. Now parses the existing record and only rejects active tokens (`unused`/`enrolled`).
- Server token `mint` allowed re-mint after revoke (since #2026) but not after expire. Extended the guard to treat both `revoked` and `expired` as terminal states.
- Both token types overwrite the old record with fresh credentials via `vault.put` + `writeResource`.

Closes swamp-club#2078

## Test plan

- [x] Enrollment token: re-mint after revoke succeeds with fresh credentials
- [x] Enrollment token: re-mint after expire succeeds with fresh credentials
- [x] Enrollment token: mint while active (unused/enrolled) still rejected
- [x] Server token: re-mint after expire now succeeds (previously failed)
- [x] Server token: re-mint after revoke still works (existing behavior)
- [x] Server token: mint while active still rejected
- [x] All 20 enrollment token tests pass
- [x] All 39 server token tests pass
- [x] Full verification workflow green (lint, fmt, type-check, tests, compile, code review, adversarial review, UX review)

Co-authored-by: Blake Irvin <blakeirvin@me.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)