### PR TITLE
fix(serve): add runtime data poller for cross-instance query visibility

### DIFF
--- a/design/enablers/datastores.md
+++ b/design/enablers/datastores.md
@@ -449,6 +449,32 @@ immediately (same directory). On S3 datastores, reads see whatever was last
 synced to the local cache by a write command; users can run
 `swamp datastore sync --pull` to refresh manually.
 
+### Serve Runtime Data Refresh
+
+In a multi-instance `swamp serve` deployment sharing a remote datastore, an idle
+server does not automatically see runtime output written by a peer. Write
+commands sync on execution, but `data.query` reads the local cache without
+triggering a remote pull.
+
+Three background pollers address this for serve:
+
+- **ConfigPoller** (`subdirs: ["config"]`) — refreshes managed configuration.
+- **AccessDataPoller** (`subdirs: ["data/swamp/grant", ...]`) — refreshes
+  access-control grants and groups, then reloads the policy snapshot.
+- **RuntimeDataPoller** (`subdirs: ["data"]`) — refreshes the `data/` subtree
+  (runtime model output), then invalidates the query catalog so the next
+  `data.query` rebuilds from the updated local files.
+
+All three run at 30-second intervals by default and start when a
+`DatastoreSyncService` is available. Each poller is independent — a
+configuration-only pull does not satisfy the runtime refresh, and vice versa.
+
+The RuntimeDataPoller provides **eventual visibility**, not immediate
+consistency. An idle peer discovers a peer's committed output within one
+polling interval after the data reaches the remote datastore. The query
+catalog is invalidated only after a successful pull that reports changes,
+preserving fast cached reads on quiet cycles.
+
 ### SyncContext and SyncCapabilities
 
 Extensions can advertise capabilities by implementing the optional

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -237,6 +237,7 @@ import {
 } from "../../serve/boot_reconciliation.ts";
 import { AccessDataPoller } from "../../serve/access_data_poller.ts";
 import { ConfigPoller } from "../../serve/config_poller.ts";
+import { RuntimeDataPoller } from "../../serve/runtime_data_poller.ts";
 
 import {
   DEFAULT_HEARTBEAT_INTERVAL_MS,
@@ -1510,6 +1511,7 @@ export const serveCommand = new Command()
 
     let configPoller: ConfigPoller | null = null;
     let accessDataPoller: AccessDataPoller | null = null;
+    let runtimeDataPoller: RuntimeDataPoller | null = null;
     let repoMarker = null;
     try {
       const markerRepo = new RepoMarkerRepository();
@@ -2539,6 +2541,13 @@ export const serveCommand = new Command()
         namespace: serveNamespace,
       });
       accessDataPoller.start();
+
+      runtimeDataPoller = new RuntimeDataPoller({
+        syncService,
+        catalogInvalidate: () => repoContext.catalogStore.invalidate(),
+        namespace: serveNamespace,
+      });
+      runtimeDataPoller.start();
     }
 
     const cancelRegistry = new RunCancelRegistry();
@@ -4514,6 +4523,9 @@ export const serveCommand = new Command()
       }
       if (accessDataPoller) {
         await accessDataPoller.stop();
+      }
+      if (runtimeDataPoller) {
+        await runtimeDataPoller.stop();
       }
       if (configPoller) {
         await configPoller.stop();

--- a/src/serve/runtime_data_poller.ts
+++ b/src/serve/runtime_data_poller.ts
@@ -1,0 +1,97 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { getLogger } from "@logtape/logtape";
+import type { DatastoreSyncService } from "../domain/datastore/datastore_sync_service.ts";
+
+const logger = getLogger(["swamp", "serve", "runtime-data-poller"]);
+
+const DEFAULT_RUNTIME_DATA_POLL_INTERVAL_MS = 30_000;
+
+export interface RuntimeDataPollerOptions {
+  syncService: DatastoreSyncService;
+  catalogInvalidate: () => void;
+  pollIntervalMs?: number;
+  namespace?: string;
+}
+
+export class RuntimeDataPoller {
+  readonly #syncService: DatastoreSyncService;
+  readonly #catalogInvalidate: () => void;
+  readonly #pollIntervalMs: number;
+  readonly #namespace?: string;
+  #timer: ReturnType<typeof setInterval> | null = null;
+  #pendingPull: Promise<void> = Promise.resolve();
+  #pulling = false;
+
+  constructor(options: RuntimeDataPollerOptions) {
+    this.#syncService = options.syncService;
+    this.#catalogInvalidate = options.catalogInvalidate;
+    this.#pollIntervalMs = options.pollIntervalMs ??
+      DEFAULT_RUNTIME_DATA_POLL_INTERVAL_MS;
+    this.#namespace = options.namespace;
+  }
+
+  start(): void {
+    if (this.#timer) return;
+    this.#timer = setInterval(() => {
+      this.#poll();
+    }, this.#pollIntervalMs);
+    Deno.unrefTimer(this.#timer);
+    const intervalSec = this.#pollIntervalMs / 1000;
+    logger.info`Runtime data poller started (interval: ${intervalSec}s)`;
+  }
+
+  async stop(): Promise<void> {
+    if (this.#timer) {
+      clearInterval(this.#timer);
+      this.#timer = null;
+    }
+    await this.#pendingPull;
+  }
+
+  #poll(): void {
+    if (this.#pulling) return;
+
+    this.#pendingPull = this.#pendingPull.then(() => this.#pullAndInvalidate());
+  }
+
+  async #pullAndInvalidate(): Promise<void> {
+    this.#pulling = true;
+    try {
+      const result = await this.#syncService.pullChanged({
+        subdirs: ["data"],
+        namespace: this.#namespace,
+      });
+      const count = typeof result === "number" ? result : 0;
+      if (count > 0) {
+        logger
+          .info`Runtime data poller: ${count} file(s) updated, invalidating catalog`;
+        this.#catalogInvalidate();
+      }
+    } catch (error) {
+      logger
+        .warn`Runtime data poller pull failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+    } finally {
+      this.#pulling = false;
+    }
+  }
+}

--- a/src/serve/runtime_data_poller_test.ts
+++ b/src/serve/runtime_data_poller_test.ts
@@ -1,0 +1,333 @@
+// Swamp, an Automation Framework
+// Copyright (C) 2026 Elder Swamp Club, Inc.
+//
+// This file is part of Swamp.
+//
+// Swamp is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License version 3
+// as published by the Free Software Foundation, with the Swamp
+// Extension and Definition Exception (found in the "COPYING-EXCEPTION"
+// file).
+//
+// Swamp is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with Swamp.  If not, see <https://www.gnu.org/licenses/>.
+
+import { assertEquals, assertGreater } from "@std/assert";
+import { RuntimeDataPoller } from "./runtime_data_poller.ts";
+import type {
+  DatastoreSyncOptions,
+  DatastoreSyncService,
+} from "../domain/datastore/datastore_sync_service.ts";
+import { waitFor } from "@swamp-club/swamp-testing";
+
+interface MockSyncService extends DatastoreSyncService {
+  pullCalls: DatastoreSyncOptions[];
+  pullResult: number | void;
+  pullDelay: number;
+  pullError: Error | null;
+}
+
+function createMockSyncService(
+  overrides: Partial<
+    Pick<MockSyncService, "pullResult" | "pullDelay" | "pullError">
+  > = {},
+): MockSyncService {
+  const mock: MockSyncService = {
+    pullCalls: [],
+    pullResult: overrides.pullResult ?? 0,
+    pullDelay: overrides.pullDelay ?? 0,
+    pullError: overrides.pullError ?? null,
+    async pullChanged(options?: DatastoreSyncOptions): Promise<number | void> {
+      mock.pullCalls.push(options ?? {});
+      if (mock.pullDelay > 0) {
+        await new Promise<void>((r) => setTimeout(r, mock.pullDelay));
+      }
+      if (mock.pullError) {
+        throw mock.pullError;
+      }
+      return mock.pullResult;
+    },
+    pushChanged(): Promise<number | void> {
+      return Promise.resolve(0);
+    },
+    async markDirty(): Promise<void> {},
+  };
+  return mock;
+}
+
+function createCallbackTrackers() {
+  const state = { catalogInvalidateCalls: 0 };
+  return {
+    state,
+    catalogInvalidate: () => {
+      state.catalogInvalidateCalls++;
+    },
+  };
+}
+
+Deno.test("RuntimeDataPoller: start and stop lifecycle completes cleanly", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 50,
+  });
+
+  poller.start();
+  await new Promise<void>((r) => setTimeout(r, 10));
+  await poller.stop();
+});
+
+Deno.test("RuntimeDataPoller: pullChanged is called with subdirs data", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  const call = sync.pullCalls[0];
+  assertEquals(call.subdirs, ["data"]);
+});
+
+Deno.test("RuntimeDataPoller: namespace is passed through to pullChanged", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+    namespace: "test-namespace",
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  assertEquals(sync.pullCalls[0].namespace, "test-namespace");
+});
+
+Deno.test("RuntimeDataPoller: invalidates catalog when pullChanged returns count > 0", async () => {
+  const sync = createMockSyncService({ pullResult: 3 });
+  const { state, catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(
+    () => state.catalogInvalidateCalls >= 1,
+    "catalog invalidation",
+  );
+  await poller.stop();
+
+  assertGreater(state.catalogInvalidateCalls, 0);
+});
+
+Deno.test("RuntimeDataPoller: does not invalidate catalog when pullChanged returns 0", async () => {
+  const sync = createMockSyncService({ pullResult: 0 });
+  const { state, catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 2, "at least two pulls");
+  await poller.stop();
+
+  assertEquals(state.catalogInvalidateCalls, 0);
+});
+
+Deno.test("RuntimeDataPoller: does not invalidate catalog when pullChanged returns void", async () => {
+  const sync = createMockSyncService({ pullResult: undefined });
+  const { state, catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 2, "at least two pulls");
+  await poller.stop();
+
+  assertEquals(state.catalogInvalidateCalls, 0);
+});
+
+Deno.test("RuntimeDataPoller: survives pullChanged throwing an error", async () => {
+  const sync = createMockSyncService({
+    pullError: new Error("network timeout"),
+  });
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 2, "at least two pulls");
+  await poller.stop();
+
+  assertGreater(sync.pullCalls.length, 1);
+});
+
+Deno.test("RuntimeDataPoller: serializes pulls — skips tick while pulling", async () => {
+  const sync = createMockSyncService({ pullDelay: 100 });
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 20,
+  });
+
+  poller.start();
+  await new Promise<void>((r) => setTimeout(r, 200));
+  await poller.stop();
+
+  assertEquals(sync.pullCalls.length <= 3, true);
+});
+
+Deno.test("RuntimeDataPoller: double start does not create duplicate timers", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  poller.start();
+
+  await waitFor(() => sync.pullCalls.length >= 2, "at least two pulls");
+  const countAfterDoubleStart = sync.pullCalls.length;
+  await poller.stop();
+
+  assertEquals(countAfterDoubleStart <= 5, true);
+});
+
+Deno.test("RuntimeDataPoller: stop awaits pending pull before returning", async () => {
+  let pullCompleted = false;
+  const sync = createMockSyncService({ pullDelay: 80 });
+  const originalPull = sync.pullChanged.bind(sync);
+  sync.pullChanged = async (options?: DatastoreSyncOptions) => {
+    const result = await originalPull(options);
+    pullCompleted = true;
+    return result;
+  };
+
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 20,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  assertEquals(pullCompleted, true);
+});
+
+Deno.test("RuntimeDataPoller: respects custom pollIntervalMs", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 80,
+  });
+
+  poller.start();
+  await new Promise<void>((r) => setTimeout(r, 50));
+  assertEquals(sync.pullCalls.length, 0);
+
+  await new Promise<void>((r) => setTimeout(r, 70));
+  assertEquals(sync.pullCalls.length, 1);
+
+  await poller.stop();
+});
+
+Deno.test("RuntimeDataPoller: stop on never-started poller is a no-op", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+  });
+
+  await poller.stop();
+  assertEquals(sync.pullCalls.length, 0);
+});
+
+Deno.test("RuntimeDataPoller: can be restarted after stop", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  const countAfterFirstRun = sync.pullCalls.length;
+
+  poller.start();
+  await waitFor(
+    () => sync.pullCalls.length > countAfterFirstRun,
+    "pulls resume after restart",
+  );
+  await poller.stop();
+
+  assertGreater(sync.pullCalls.length, countAfterFirstRun);
+});
+
+Deno.test("RuntimeDataPoller: without namespace, pullChanged options omit namespace", async () => {
+  const sync = createMockSyncService();
+  const { catalogInvalidate } = createCallbackTrackers();
+
+  const poller = new RuntimeDataPoller({
+    syncService: sync,
+    catalogInvalidate,
+    pollIntervalMs: 30,
+  });
+
+  poller.start();
+  await waitFor(() => sync.pullCalls.length >= 1, "at least one pull");
+  await poller.stop();
+
+  assertEquals(sync.pullCalls[0].namespace, undefined);
+});


### PR DESCRIPTION
## Summary

- Adds `RuntimeDataPoller` that periodically pulls the `data/` subtree from the remote datastore and invalidates the local query catalog, giving idle peer servers eventual visibility of runtime output written by other servers
- Wires the poller into the serve command alongside the existing `ConfigPoller` and `AccessDataPoller`
- Updates `design/enablers/datastores.md` to document the runtime data refresh behavior

Fixes swamp-club#2111

## Test plan

- [x] 14 unit tests covering lifecycle, subdirs, namespace, catalog invalidation, error resilience, pull serialization, idempotent start, restart
- [x] Full test suite passes (no regressions)
- [x] Type check, lint, fmt all pass
- [x] Binary compiles and smoke check passes
- [x] Code review, adversarial review, UX review all pass

Co-authored-by: jamesakeech <jamesakeech@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)