### PR TITLE
fix(security): strip SWAMP_* env vars from shell model child processes

### DIFF
--- a/design/enablers/remote-execution.md
+++ b/design/enablers/remote-execution.md
@@ -666,6 +666,33 @@ running on the orchestrator host would. Scoping the snapshot (allowlists per
 token or per label) is a later refinement; v1 chooses single-host fidelity over
 introducing a new partial-environment failure mode.
 
+### Method-to-child env scrubbing (third boundary)
+
+The two layers above protect the orchestrator→worker and worker→dispatch-runner
+boundaries. A third layer protects the **method→child** boundary: when the shell
+model (`command/shell`) or extension code spawns an external subprocess, the
+child must not inherit swamp's own auth tokens (`SWAMP_SERVER_TOKEN`,
+`SWAMP_API_KEY`, etc.) from the host process. An external tool (an LLM CLI, a
+cloud SDK, kubectl) holding these tokens in its `/proc/<pid>/environ` is a
+credential-leakage vector.
+
+The shell model builds the child's environment via `createSafeMethodEnv`
+(`src/domain/remote/environment_snapshot.ts`), which copies the host env and
+strips every `SWAMP_*` variable (case-insensitive prefix match). Process-identity
+vars (`HOME`, `PATH`, `SHELL`, …) are preserved because the child runs on the
+same host. The resulting env is passed with `clearEnv: true` so Deno does not
+re-inherit the parent's `SWAMP_*` vars behind the filter. A per-variable
+allowlist on `createSafeMethodEnv` lets a method opt specific vars back in when
+a child genuinely needs one.
+
+The three boundaries form a defense-in-depth chain:
+
+| Boundary                | Mechanism                             | What is stripped                                |
+| ----------------------- | ------------------------------------- | ----------------------------------------------- |
+| orchestrator → worker   | `captureEnvironmentSnapshot` denylist | `HOME`, `PATH`, `SWAMP_*`, `DENO_*`, `XDG_*`, … |
+| worker → dispatch runner| `stripWorkerCredentials`              | `SWAMP_WORKER_TOKEN`, `SWAMP_SERVER_TOKEN`, `SWAMP_ORCHESTRATOR_URL` |
+| method → child process  | `createSafeMethodEnv` + `clearEnv`    | all `SWAMP_*` variables                         |
+
 Workers accept up to `capacity` concurrent dispatches (configured via
 `--concurrency N` on `worker connect`, default 1). When all slots are full, an
 overlapping dispatch is rejected with `worker_busy` and re-queued by the

--- a/src/domain/models/command/shell/shell_model.ts
+++ b/src/domain/models/command/shell/shell_model.ts
@@ -26,6 +26,7 @@ import {
   type ModelDefinition,
 } from "../../model.ts";
 import { executeProcess } from "../../../../infrastructure/process/process_executor.ts";
+import { createSafeMethodEnv } from "../../../remote/environment_snapshot.ts";
 import { selectShellStrategy } from "./shell_strategy.ts";
 
 const shellStrategy = selectShellStrategy();
@@ -127,11 +128,16 @@ async function executeCommand(
     }
 
     const invocation = shellStrategy.buildInvocation(shellCommand);
+    const safeBaseEnv = createSafeMethodEnv(Deno.env.toObject());
+    const processEnv = Object.keys(shellEnv).length > 0
+      ? { ...safeBaseEnv, ...shellEnv }
+      : safeBaseEnv;
     const result = await executeProcess({
       command: invocation.command,
       args: invocation.args,
       cwd: args.workingDir,
-      env: Object.keys(shellEnv).length > 0 ? shellEnv : undefined,
+      env: processEnv,
+      clearEnv: true,
       timeoutMs: args.timeout,
       signal: context.signal,
       logger: context.logger,

--- a/src/domain/models/command/shell/shell_model_test.ts
+++ b/src/domain/models/command/shell/shell_model_test.ts
@@ -533,6 +533,62 @@ posixOnlyTest("shellModel.methods.execute respects env variables", async () => {
   assertStringIncludes(logContent, "test_value");
 });
 
+posixOnlyTest(
+  "shellModel.methods.execute strips SWAMP_* vars from child env",
+  async () => {
+    const original = Deno.env.get("SWAMP_SERVER_TOKEN");
+    Deno.env.set("SWAMP_SERVER_TOKEN", "test.leaked-secret");
+    try {
+      const args: ShellInputAttributes = {
+        run: "echo SWAMP_SERVER_TOKEN=$SWAMP_SERVER_TOKEN",
+      };
+
+      const { context, getResults } = createTestContext();
+      await shellModel.methods.execute.execute(args, context);
+
+      const logContent = getOutputLogContent(getResults());
+      assertStringIncludes(logContent, "SWAMP_SERVER_TOKEN=");
+      assertEquals(logContent.includes("leaked-secret"), false);
+    } finally {
+      if (original !== undefined) {
+        Deno.env.set("SWAMP_SERVER_TOKEN", original);
+      } else {
+        Deno.env.delete("SWAMP_SERVER_TOKEN");
+      }
+    }
+  },
+);
+
+posixOnlyTest(
+  "shellModel.methods.execute preserves PATH in child env",
+  async () => {
+    const args: ShellInputAttributes = { run: "echo PATH=$PATH" };
+
+    const { context, getResults } = createTestContext();
+    await shellModel.methods.execute.execute(args, context);
+
+    const logContent = getOutputLogContent(getResults());
+    assertStringIncludes(logContent, "PATH=/");
+  },
+);
+
+posixOnlyTest(
+  "shellModel.methods.execute merges user env on top of safe base",
+  async () => {
+    const args: ShellInputAttributes = {
+      run: "echo MY_VAR=$MY_VAR && echo PATH=$PATH",
+      env: { MY_VAR: "user-value" },
+    };
+
+    const { context, getResults } = createTestContext();
+    await shellModel.methods.execute.execute(args, context);
+
+    const logContent = getOutputLogContent(getResults());
+    assertStringIncludes(logContent, "MY_VAR=user-value");
+    assertStringIncludes(logContent, "PATH=/");
+  },
+);
+
 posixOnlyTest("shellModel.methods.execute handles pipes", async () => {
   const args: ShellInputAttributes = { run: "echo 'hello world' | tr 'h' 'H'" };
 

--- a/src/domain/remote/environment_snapshot.ts
+++ b/src/domain/remote/environment_snapshot.ts
@@ -107,6 +107,43 @@ export function stripWorkerCredentials(
   return cleaned;
 }
 
+const SWAMP_PREFIX = "SWAMP_";
+
+/**
+ * True when an environment variable is a SWAMP_* runtime variable.
+ * Used by {@link createSafeMethodEnv} to strip swamp auth and config
+ * vars from the environment inherited by method-spawned child processes.
+ */
+export function isSwampEnvVar(name: string): boolean {
+  return name.toUpperCase().startsWith(SWAMP_PREFIX);
+}
+
+/**
+ * Build a safe environment for child processes spawned by method code
+ * (the shell model, or extension code using Deno.Command directly).
+ *
+ * Strips all SWAMP_* variables — auth tokens, server URLs, worker
+ * credentials, and config overrides — so external tools never inherit
+ * swamp's own credentials. Process-identity vars (HOME, PATH, SHELL, …)
+ * are preserved because the child runs on the same host.
+ *
+ * Pass `allow` to opt specific SWAMP_* names back in when a child
+ * genuinely needs one (exact, case-sensitive match).
+ */
+export function createSafeMethodEnv(
+  env: Record<string, string>,
+  allow?: readonly string[],
+): Record<string, string> {
+  const allowSet = allow ? new Set(allow) : undefined;
+  const safe: Record<string, string> = {};
+  for (const [name, value] of Object.entries(env)) {
+    if (!isSwampEnvVar(name) || allowSet?.has(name)) {
+      safe[name] = value;
+    }
+  }
+  return safe;
+}
+
 /**
  * Overlay a shipped snapshot onto a worker's base environment. The snapshot
  * wins for every variable it carries; denylisted names are dropped even if a

--- a/src/domain/remote/environment_snapshot_test.ts
+++ b/src/domain/remote/environment_snapshot_test.ts
@@ -20,7 +20,9 @@
 import { assertEquals } from "@std/assert";
 import {
   captureEnvironmentSnapshot,
+  createSafeMethodEnv,
   isDeniedEnvVar,
+  isSwampEnvVar,
   overlayEnvironment,
   stripWorkerCredentials,
 } from "./environment_snapshot.ts";
@@ -116,6 +118,86 @@ Deno.test("stripWorkerCredentials: removes worker control-plane credentials", ()
     DEPLOY_ENV: "prod",
     AWS_ACCESS_KEY_ID: "AKIA123",
   });
+});
+
+Deno.test("isSwampEnvVar: matches SWAMP_ prefix case-insensitively", () => {
+  assertEquals(isSwampEnvVar("SWAMP_SERVER_TOKEN"), true);
+  assertEquals(isSwampEnvVar("SWAMP_API_KEY"), true);
+  assertEquals(isSwampEnvVar("SWAMP_HOME"), true);
+  assertEquals(isSwampEnvVar("swamp_log_level"), true);
+  assertEquals(isSwampEnvVar("Swamp_Foo"), true);
+});
+
+Deno.test("isSwampEnvVar: rejects non-SWAMP variables", () => {
+  assertEquals(isSwampEnvVar("HOME"), false);
+  assertEquals(isSwampEnvVar("PATH"), false);
+  assertEquals(isSwampEnvVar("AWS_ACCESS_KEY_ID"), false);
+  assertEquals(isSwampEnvVar("DENO_DIR"), false);
+});
+
+Deno.test("createSafeMethodEnv: strips all SWAMP_* variables", () => {
+  const env = {
+    HOME: "/home/user",
+    PATH: "/usr/bin",
+    SHELL: "/bin/bash",
+    SWAMP_SERVER_TOKEN: "srv.secret",
+    SWAMP_API_KEY: "api-key-123",
+    SWAMP_SERVER_URL: "wss://orch:9090",
+    SWAMP_SERVE_URL: "wss://demo.swamp-club.ai",
+    SWAMP_SERVE_EXTRA_HEADERS: "Tunnel-Token: abc",
+    SWAMP_HOME: "/custom/swamp",
+    SWAMP_LOG_LEVEL: "debug",
+    AWS_ACCESS_KEY_ID: "AKIA123",
+    DEPLOY_ENV: "prod",
+  };
+  assertEquals(createSafeMethodEnv(env), {
+    HOME: "/home/user",
+    PATH: "/usr/bin",
+    SHELL: "/bin/bash",
+    AWS_ACCESS_KEY_ID: "AKIA123",
+    DEPLOY_ENV: "prod",
+  });
+});
+
+Deno.test("createSafeMethodEnv: case-insensitive matching", () => {
+  const env = {
+    swamp_server_token: "secret",
+    Swamp_Api_Key: "key",
+    PATH: "/usr/bin",
+  };
+  assertEquals(createSafeMethodEnv(env), {
+    PATH: "/usr/bin",
+  });
+});
+
+Deno.test("createSafeMethodEnv: allowlist opts specific vars back in", () => {
+  const env = {
+    SWAMP_SERVER_TOKEN: "secret",
+    SWAMP_HOME: "/custom",
+    SWAMP_LOG_LEVEL: "debug",
+    PATH: "/usr/bin",
+  };
+  assertEquals(createSafeMethodEnv(env, ["SWAMP_HOME", "SWAMP_LOG_LEVEL"]), {
+    SWAMP_HOME: "/custom",
+    SWAMP_LOG_LEVEL: "debug",
+    PATH: "/usr/bin",
+  });
+});
+
+Deno.test("createSafeMethodEnv: allowlist is case-sensitive", () => {
+  const env = {
+    SWAMP_HOME: "/custom",
+    swamp_home: "/other",
+    PATH: "/usr/bin",
+  };
+  assertEquals(createSafeMethodEnv(env, ["SWAMP_HOME"]), {
+    SWAMP_HOME: "/custom",
+    PATH: "/usr/bin",
+  });
+});
+
+Deno.test("createSafeMethodEnv: empty env returns empty", () => {
+  assertEquals(createSafeMethodEnv({}), {});
 });
 
 Deno.test("stripWorkerCredentials: preserves SWAMP_SERVE_EXTRA_HEADERS and worker config vars", () => {

--- a/src/infrastructure/process/process_executor.ts
+++ b/src/infrastructure/process/process_executor.ts
@@ -33,6 +33,10 @@ export interface ProcessExecutorOptions {
   cwd?: string;
   /** Environment variables. */
   env?: Record<string, string>;
+  /** When true, the child starts with an empty environment and gets only
+   *  the variables from `env`. Without this, `env` augments the inherited
+   *  parent environment (Deno default). */
+  clearEnv?: boolean;
   /** Timeout in milliseconds. */
   timeoutMs?: number;
   /** Logger for streaming stdout (info) and stderr (warning). */
@@ -159,6 +163,10 @@ export async function executeProcess(
 
   if (options.env) {
     commandOptions.env = options.env;
+  }
+
+  if (options.clearEnv) {
+    commandOptions.clearEnv = true;
   }
 
   const command = new Deno.Command(options.command, commandOptions);


### PR DESCRIPTION
## Summary

- Add `createSafeMethodEnv()` to `environment_snapshot.ts` — strips all `SWAMP_*` variables from the process env before spawning method children, with per-variable allowlist for opt-in
- Shell model now builds a safe env (`createSafeMethodEnv` + `clearEnv: true`) so external tools never inherit swamp auth tokens
- Add `clearEnv` option to `ProcessExecutorOptions` to prevent Deno's default env augmentation from re-leaking stripped vars
- Document the third env scrubbing boundary in `design/enablers/remote-execution.md`

## Context

Methods running on the loopback executor inherited the full parent environment when spawning child processes, leaking auth tokens like `SWAMP_SERVER_TOKEN` to external tools (LLM CLIs, kubectl, etc.). The remote execution layer already had env scrubbing at two boundaries (orchestrator→worker snapshot denylist, worker→dispatch runner credential stripping) but the method→child boundary was unprotected.

Key discovery during implementation: Deno's `env` option on `Deno.Command` *augments* the parent env rather than replacing it, so `clearEnv: true` is required to actually prevent leakage.

## Test plan

- [x] Unit tests for `createSafeMethodEnv`: stripping, case-insensitive matching, allowlist opt-in, empty env edge case
- [x] Shell model tests: SWAMP_SERVER_TOKEN not in child env, PATH preserved, user env merged correctly
- [x] All existing shell model tests pass (38 passed, 19 ignored/Windows)
- [x] Build verification: lint, fmt, type-check, tests, compile all pass
- [x] Code review: pass (0 findings)
- [x] Adversarial review: pass (0 findings)

Fixes swamp-club#2032

Follow-ups:
- swamp-club#2114 — extend `--server-token-file` to all `--server` subcommands
- swamp-club/swamp-uat#375 — adversarial UAT test for subprocess env leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)