### PR TITLE
fix(serve): improve token auth diagnostics — vault-aware sweep and structured rejection reasons (swamp-club#2113)

### DIFF
--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1926,6 +1926,17 @@ export const serveCommand = new Command()
       repoContext,
       tokenSecretsProvider,
       knownUndecryptable: new Set(healthResult.undecryptable),
+      probeVaultSecret: async (vaultName, secretKey) => {
+        try {
+          const vs = await VaultService.fromRepository(resolvedRepoDir, {
+            defaultVaultName: repoMarker?.defaultVault,
+          });
+          await vs.get(vaultName, secretKey, "serve:token-consistency-probe");
+          return true;
+        } catch {
+          return false;
+        }
+      },
     });
 
     const clubApiKey = Deno.env.get("SWAMP_API_KEY") ?? null;
@@ -3843,10 +3854,18 @@ export const serveCommand = new Command()
             );
             if (!result.ok) {
               logger.warn(
-                "WebSocket auth rejected for {key} from {ip}: {error}",
-                { key: rlKey, ip: remoteAddr, error: result.error },
+                "WebSocket auth rejected for {key} from {ip} ({reason}): {error}",
+                {
+                  key: rlKey,
+                  ip: remoteAddr,
+                  reason: result.reason,
+                  error: result.error,
+                },
               );
-              return new Response("Unauthorized", { status: 401 });
+              return new Response(
+                `Unauthorized: ${result.reason}`,
+                { status: 401 },
+              );
             }
             clearRateLimit(rlKey);
             const principal = parsePrincipal(result.principalId);
@@ -3938,7 +3957,10 @@ export const serveCommand = new Command()
                 repoContext,
               );
               if (!authResult.ok) {
-                return new Response("Unauthorized", { status: 401 });
+                return new Response(
+                  `Unauthorized: ${authResult.reason}`,
+                  { status: 401 },
+                );
               }
               clearRateLimit(cancelRlKey);
 

--- a/src/serve/admin_auth.ts
+++ b/src/serve/admin_auth.ts
@@ -106,7 +106,10 @@ export async function authenticateAdmin(
   if (!authResult.ok) {
     return {
       ok: false,
-      response: new Response("Unauthorized", { status: 401 }),
+      response: new Response(
+        `Unauthorized: ${authResult.reason}`,
+        { status: 401 },
+      ),
     };
   }
 

--- a/src/serve/boot_reconciliation.ts
+++ b/src/serve/boot_reconciliation.ts
@@ -663,6 +663,10 @@ export interface TokenConsistencyDeps {
     list(): Promise<string[]>;
   };
   knownUndecryptable?: Set<string>;
+  probeVaultSecret?: (
+    vaultName: string,
+    secretKey: string,
+  ) => Promise<boolean>;
 }
 
 export interface TokenInconsistency {
@@ -752,15 +756,34 @@ async function sweepTokenConsistencyInner(
     }
   }
 
+  const dataAttrsByName = new Map(
+    dataItems
+      .filter((item) => item.modelName && item.data.name === "token-main")
+      .map((item) => [
+        item.modelName,
+        item.attrs as { vaultName?: string; secretKey?: string },
+      ]),
+  );
   for (const tokenName of definitionNames) {
-    if (!secretTokenNames.has(tokenName)) {
-      inconsistencies.push({
-        mode: "missing-secret",
-        tokenName,
-        detail:
-          "Definition and data exist but no secret found in _token-secrets — token will fail authentication",
-      });
+    if (secretTokenNames.has(tokenName)) continue;
+    const attrs = dataAttrsByName.get(tokenName);
+    if (attrs?.vaultName && attrs?.secretKey && deps.probeVaultSecret) {
+      try {
+        const found = await deps.probeVaultSecret(
+          attrs.vaultName,
+          attrs.secretKey,
+        );
+        if (found) continue;
+      } catch {
+        // Vault probe failed — fall through to report missing-secret
+      }
     }
+    inconsistencies.push({
+      mode: "missing-secret",
+      tokenName,
+      detail:
+        "Definition and data exist but no secret found — token will fail authentication",
+    });
   }
 
   const knownUndecryptable = deps.knownUndecryptable ?? new Set();

--- a/src/serve/boot_reconciliation_test.ts
+++ b/src/serve/boot_reconciliation_test.ts
@@ -1436,6 +1436,11 @@ function createMockConsistencyDeps(opts: {
   dataTokenNames?: string[];
   definitionNames?: string[];
   undecryptableKeys?: Set<string>;
+  tokenVaultNames?: Record<string, string>;
+  probeVaultSecret?: (
+    vaultName: string,
+    secretKey: string,
+  ) => Promise<boolean>;
 }): TokenConsistencyDeps {
   const provider = createMockTokenSecretsProvider({
     keys: (opts.secretKeys ?? []).map((n) => `server-token-${n}`),
@@ -1445,6 +1450,7 @@ function createMockConsistencyDeps(opts: {
   });
 
   const definitionSet = new Set(opts.definitionNames ?? []);
+  const vaultNames = opts.tokenVaultNames ?? {};
 
   const dataItems = (opts.dataTokenNames ?? []).map((name) => ({
     data: Data.create({
@@ -1462,6 +1468,17 @@ function createMockConsistencyDeps(opts: {
     modelId: `def-${name}`,
   }));
 
+  const tokenAttrs = Object.fromEntries(
+    (opts.dataTokenNames ?? []).map((name) => [
+      name,
+      {
+        state: "active",
+        vaultName: vaultNames[name] ?? "_token-secrets",
+        secretKey: `server-token-${name}`,
+      },
+    ]),
+  );
+
   return {
     repoContext: {
       definitionRepo: {
@@ -1474,13 +1491,17 @@ function createMockConsistencyDeps(opts: {
       },
       unifiedDataRepo: {
         findAllForType: () => Promise.resolve(dataItems),
-        getContent: (_mt: ModelType, _id: string, _name: string) =>
-          Promise.resolve(
-            encoder.encode(JSON.stringify({ state: "active" })),
-          ),
+        getContent: (_mt: ModelType, _id: string, name: string) => {
+          const modelName =
+            dataItems.find((d) => d.modelId === _id && d.data.name === name)
+              ?.data.tags["modelName"] ?? "";
+          const attrs = tokenAttrs[modelName] ?? { state: "active" };
+          return Promise.resolve(encoder.encode(JSON.stringify(attrs)));
+        },
       },
     } as unknown as RepositoryContext,
     tokenSecretsProvider: provider,
+    probeVaultSecret: opts.probeVaultSecret,
   };
 }
 
@@ -1554,6 +1575,56 @@ Deno.test("sweepTokenConsistency: orders by severity", async () => {
   assertEquals(modes[0], "undecryptable-secret");
   assertEquals(modes[1], "missing-secret");
   assertEquals(modes[2], "orphaned-secret");
+});
+
+Deno.test("sweepTokenConsistency: vault-backed token passes when probe finds secret", async () => {
+  const deps = createMockConsistencyDeps({
+    secretKeys: [],
+    dataTokenNames: ["vault-token"],
+    definitionNames: ["vault-token"],
+    tokenVaultNames: { "vault-token": "my-vault" },
+    probeVaultSecret: (_vaultName, _secretKey) => Promise.resolve(true),
+  });
+  const result = await sweepTokenConsistency(deps);
+  assertEquals(result.inconsistencies.length, 0);
+});
+
+Deno.test("sweepTokenConsistency: vault-backed token fails when probe returns false", async () => {
+  const deps = createMockConsistencyDeps({
+    secretKeys: [],
+    dataTokenNames: ["vault-token"],
+    definitionNames: ["vault-token"],
+    tokenVaultNames: { "vault-token": "my-vault" },
+    probeVaultSecret: (_vaultName, _secretKey) => Promise.resolve(false),
+  });
+  const result = await sweepTokenConsistency(deps);
+  assertEquals(result.inconsistencies.length, 1);
+  assertEquals(result.inconsistencies[0].mode, "missing-secret");
+});
+
+Deno.test("sweepTokenConsistency: vault-backed token fails when probe throws", async () => {
+  const deps = createMockConsistencyDeps({
+    secretKeys: [],
+    dataTokenNames: ["vault-token"],
+    definitionNames: ["vault-token"],
+    tokenVaultNames: { "vault-token": "my-vault" },
+    probeVaultSecret: () => Promise.reject(new Error("vault unreachable")),
+  });
+  const result = await sweepTokenConsistency(deps);
+  assertEquals(result.inconsistencies.length, 1);
+  assertEquals(result.inconsistencies[0].mode, "missing-secret");
+});
+
+Deno.test("sweepTokenConsistency: missing-secret reported when no probe provided", async () => {
+  const deps = createMockConsistencyDeps({
+    secretKeys: [],
+    dataTokenNames: ["vault-token"],
+    definitionNames: ["vault-token"],
+    tokenVaultNames: { "vault-token": "my-vault" },
+  });
+  const result = await sweepTokenConsistency(deps);
+  assertEquals(result.inconsistencies.length, 1);
+  assertEquals(result.inconsistencies[0].mode, "missing-secret");
 });
 
 // ── Root control-plane isolation regression test ────────────────────

--- a/src/serve/token_auth.ts
+++ b/src/serve/token_auth.ts
@@ -87,6 +87,15 @@ export function extractWebSocketToken(
   return null;
 }
 
+export type TokenAuthRejectionReason =
+  | "expired"
+  | "revoked"
+  | "secret-mismatch"
+  | "no-definition"
+  | "invalid-format"
+  | "vault-error"
+  | "unknown";
+
 export type ServerTokenAuthResult =
   | {
     ok: true;
@@ -94,7 +103,22 @@ export type ServerTokenAuthResult =
     collectives: readonly string[];
     groups: readonly string[];
   }
-  | { ok: false; error: string };
+  | { ok: false; error: string; reason: TokenAuthRejectionReason };
+
+export function classifyRedeemError(message: string): TokenAuthRejectionReason {
+  if (message.includes("has expired")) return "expired";
+  if (message.includes("has been revoked")) return "revoked";
+  if (message.includes("does not match")) return "secret-mismatch";
+  if (message.includes("does not exist")) return "no-definition";
+  if (message.includes("Invalid token format")) return "invalid-format";
+  if (
+    message.includes("not found") || message.includes("Vault") ||
+    message.includes("vault")
+  ) {
+    return "vault-error";
+  }
+  return "unknown";
+}
 
 /**
  * Validates a presented `<name>.<secret>` server token by running the
@@ -109,7 +133,11 @@ export async function authenticateServerToken(
   repoContext: RepositoryContext,
 ): Promise<ServerTokenAuthResult> {
   if (presented.length > MAX_TOKEN_LENGTH) {
-    return { ok: false, error: "Token exceeds maximum length" };
+    return {
+      ok: false,
+      error: "Token exceeds maximum length",
+      reason: "invalid-format",
+    };
   }
 
   const split = splitServerToken(presented);
@@ -117,6 +145,7 @@ export async function authenticateServerToken(
     return {
       ok: false,
       error: "Invalid token format: expected <name>.<secret>",
+      reason: "invalid-format",
     };
   }
 
@@ -136,11 +165,16 @@ export async function authenticateServerToken(
     })
   ) {
     if (event.kind === "error") {
-      logger.debug("Token authentication failed for {name}: {error}", {
-        name: split.name,
-        error: event.error.message,
-      });
-      return { ok: false, error: "Authentication failed" };
+      const reason = classifyRedeemError(event.error.message);
+      logger.warn(
+        "Token authentication failed for {name} ({reason}): {error}",
+        {
+          name: split.name,
+          reason,
+          error: event.error.message,
+        },
+      );
+      return { ok: false, error: "Authentication failed", reason };
     }
     if (event.kind === "completed") {
       const tokenRecord = event.run.dataArtifacts.find(
@@ -162,6 +196,7 @@ export async function authenticateServerToken(
     return {
       ok: false,
       error: "Token validation completed but principal could not be resolved",
+      reason: "unknown",
     };
   }
 

--- a/src/serve/token_auth_test.ts
+++ b/src/serve/token_auth_test.ts
@@ -20,6 +20,7 @@
 import { assertEquals } from "@std/assert";
 import {
   authenticateServerToken,
+  classifyRedeemError,
   extractWebSocketToken,
   splitServerToken,
 } from "./token_auth.ts";
@@ -177,6 +178,63 @@ Deno.test("extractWebSocketToken: ignores empty query param", () => {
   assertEquals(extractWebSocketToken(req), null);
 });
 
+// ── classifyRedeemError ────────────────────────────────────────────────
+
+Deno.test("classifyRedeemError: classifies expired token", () => {
+  assertEquals(
+    classifyRedeemError("Server token 'bot' has expired"),
+    "expired",
+  );
+});
+
+Deno.test("classifyRedeemError: classifies revoked token", () => {
+  assertEquals(
+    classifyRedeemError("Server token 'bot' has been revoked"),
+    "revoked",
+  );
+});
+
+Deno.test("classifyRedeemError: classifies secret mismatch", () => {
+  assertEquals(
+    classifyRedeemError("Server token 'bot' does not match"),
+    "secret-mismatch",
+  );
+});
+
+Deno.test("classifyRedeemError: classifies no definition", () => {
+  assertEquals(
+    classifyRedeemError("Server token 'bot' does not exist — mint it first"),
+    "no-definition",
+  );
+});
+
+Deno.test("classifyRedeemError: classifies invalid format", () => {
+  assertEquals(
+    classifyRedeemError("Invalid token format: expected <name>.<secret>"),
+    "invalid-format",
+  );
+});
+
+Deno.test("classifyRedeemError: classifies vault error", () => {
+  assertEquals(
+    classifyRedeemError(
+      "Secret 'server-token-bot' not found in _token-secrets",
+    ),
+    "vault-error",
+  );
+  assertEquals(
+    classifyRedeemError("Vault 'my-vault' not found"),
+    "vault-error",
+  );
+});
+
+Deno.test("classifyRedeemError: returns unknown for unrecognized errors", () => {
+  assertEquals(
+    classifyRedeemError("Something completely unexpected"),
+    "unknown",
+  );
+});
+
 // ── authenticateServerToken ─────────────────────────────────────────────
 
 Deno.test("authenticateServerToken: rejects token exceeding MAX_TOKEN_LENGTH", async () => {
@@ -189,5 +247,6 @@ Deno.test("authenticateServerToken: rejects token exceeding MAX_TOKEN_LENGTH", a
   assertEquals(result.ok, false);
   if (!result.ok) {
     assertEquals(result.error, "Token exceeds maximum length");
+    assertEquals(result.reason, "invalid-format");
   }
 });


### PR DESCRIPTION
## Summary

- The boot-time token consistency sweep only checked `_token-secrets` for
  missing secrets, falsely reporting vault-backed tokens as dead. Now it probes
  the token's actual `vaultName` before declaring `missing-secret`.
- Token auth rejection logged a generic "Authentication failed" with no reason
  class. Now classifies errors (`expired`, `revoked`, `secret-mismatch`,
  `vault-error`, `no-definition`) and surfaces the reason in both the daemon
  log and the 401 response body.

Fixes swamp-club#2113

## Test plan

- [x] 4 new sweep tests: vault probe pass/fail/throw/absent
- [x] 7 new `classifyRedeemError` tests: one per reason class + unknown
- [x] Updated existing `authenticateServerToken` test to verify `reason` field
- [x] All 11,517 existing tests pass
- [x] All reviews (code, adversarial, UX) pass with no blocking findings

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BErtkvYnXYs7SjMpLas59H

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BErtkvYnXYs7SjMpLas59H